### PR TITLE
Linux/Avalonia: шапка списка, справочник ключей запуска, меню трея

### DIFF
--- a/Configuration Management/LaunchParametersWindow.Avalonia.cs
+++ b/Configuration Management/LaunchParametersWindow.Avalonia.cs
@@ -30,7 +30,7 @@ namespace Configuration_Management
         {
             Title = LocalizationManager.T("LaunchParams.Title");
             Width = 800;
-            Height = 560;
+            Height = 640;
             MinWidth = 720;
             MinHeight = 480;
 
@@ -94,7 +94,8 @@ namespace Configuration_Management
             list.ItemTemplate = new FuncDataTemplate<ParamRef>((item, _) =>
             {
                 var panel = new Grid { Margin = new Thickness(2, 3) };
-                panel.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(220)));
+                // 220 под текст, как в колонке WPF, плюс зазор до описания.
+                panel.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(232)));
                 panel.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
 
                 var key = new TextBlock

--- a/Configuration Management/LaunchParametersWindow.Avalonia.cs
+++ b/Configuration Management/LaunchParametersWindow.Avalonia.cs
@@ -29,9 +29,9 @@ namespace Configuration_Management
         public LaunchParametersWindow(string currentParameters)
         {
             Title = LocalizationManager.T("LaunchParams.Title");
-            Width = 620;
+            Width = 800;
             Height = 560;
-            MinWidth = 540;
+            MinWidth = 720;
             MinHeight = 480;
 
             _txtCustom = new TextBox
@@ -94,14 +94,27 @@ namespace Configuration_Management
             list.ItemTemplate = new FuncDataTemplate<ParamRef>((item, _) =>
             {
                 var panel = new Grid { Margin = new Thickness(2, 3) };
-                panel.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(150)));
+                panel.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(220)));
                 panel.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
 
-                var key = new TextBlock { Text = item.Key, FontWeight = FontWeight.SemiBold, VerticalAlignment = VerticalAlignment.Center };
+                var key = new TextBlock
+                {
+                    Text = item.Key,
+                    FontWeight = FontWeight.SemiBold,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    TextTrimming = TextTrimming.CharacterEllipsis,
+                    Margin = new Thickness(0, 0, 12, 0)
+                };
                 Grid.SetColumn(key, 0);
                 panel.Children.Add(key);
 
-                var desc = new TextBlock { Text = item.Description, FontSize = 12, VerticalAlignment = VerticalAlignment.Center };
+                var desc = new TextBlock
+                {
+                    Text = item.Description,
+                    FontSize = 12,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    TextTrimming = TextTrimming.CharacterEllipsis
+                };
                 Grid.SetColumn(desc, 1);
                 panel.Children.Add(desc);
                 return panel;

--- a/Configuration Management/MainWindow.Avalonia.cs
+++ b/Configuration Management/MainWindow.Avalonia.cs
@@ -54,6 +54,7 @@ namespace Configuration_Management
         private ColumnDefinition? _headerOffsetColumn;
         private Control? _headerPinMark;
         private double _headerToolbarWidth;
+        private StackPanel? _groupToolbar;
         private Grid? _listContent;
         /// <summary>Шаг прокрутки колесом, как у штатного ScrollContentPresenter.</summary>
         private const double WheelScrollStep = 50;
@@ -2026,6 +2027,16 @@ namespace Configuration_Management
         private static double GroupToolbarWidth => ToolbarButtonWidth * 4 + 6 + UiMetrics.Scaled(6);
 
         /// <summary>
+        /// Расчётная ширина переключателя тегов: он сделан сегментной кнопкой
+        /// с горизонтальным отступом 12 и иконкой 15, то есть заметно шире
+        /// обычной кнопки панели.
+        /// </summary>
+        private const double TagsToggleWidth = 12 * 2 + 15;
+
+        /// <summary>Зазор между блоком кнопок и подписью «Название».</summary>
+        private const double HeaderToolbarGap = 2;
+
+        /// <summary>
         /// Номер колонки заголовка с именем базы: компенсатор отступа дерева,
         /// звезда, булавка, иконка.
         /// </summary>
@@ -2147,9 +2158,12 @@ namespace Configuration_Management
             _columnHeaderRow.ColumnDefinitions.Clear();
 
             var columns = ListColumns();
-            // Ширина блока кнопок: четыре кнопки групп при группировке плюс
-            // переключатель тегов, который показывается всегда.
-            _headerToolbarWidth = (_vm.ShowExpandCollapseButtons ? GroupToolbarWidth : 0) + ToolbarButtonWidth + 2;
+            // Ширина блока кнопок нужна, чтобы подпись «Название» встала правее
+            // него. Здесь она только расчётная: панель ещё не создана, а Bounds
+            // прежней панели относятся к прежнему составу кнопок. Измеренную
+            // ширину подставляет AlignHeaderToRows, когда панель разложена.
+            _headerToolbarWidth = (_vm.ShowExpandCollapseButtons ? GroupToolbarWidth : 0)
+                + TagsToggleWidth + HeaderToolbarGap;
             var favoriteWidth = _vm.ShowFavoritesButton ? FavoriteColumnWidth : 0;
             var pinWidth = _vm.ShowPinnedButton ? PinColumnWidth : 0;
 
@@ -2215,6 +2229,25 @@ namespace Configuration_Management
         }
 
         /// <summary>
+        /// Измеренная ширина блока кнопок; null, пока он не разложен.
+        /// Панель зажата в узкие колонки заголовка, поэтому её собственный
+        /// Bounds обрезан по ним, а кнопки рисуются дальше: ширину берём
+        /// по самому правому краю содержимого.
+        /// </summary>
+        private double? MeasuredToolbarWidth
+        {
+            get
+            {
+                if (_groupToolbar is null)
+                    return null;
+                var right = 0d;
+                foreach (var child in _groupToolbar.Children)
+                    right = Math.Max(right, child.Bounds.Right);
+                return right > 0 ? right : null;
+            }
+        }
+
+        /// <summary>
         /// Блок кнопок над списком: развернуть и свернуть все группы и две
         /// сортировки групп (только при группировке), а также переключатель
         /// тегов в строках, который нужен всегда.
@@ -2241,7 +2274,14 @@ namespace Configuration_Management
                     LocalizationManager.T("Main.SortGroupsDescending"), "SortGroupsDescendingCommand"));
             }
 
-            panel.Children.Add(BuildTagsInListToggle());
+            var tagsToggle = BuildTagsInListToggle();
+            panel.Children.Add(tagsToggle);
+            tagsToggle.GetObservable(Visual.BoundsProperty).Subscribe(new PropertyObserver<Rect>(_ => QueueHeaderAlign()));
+
+            _groupToolbar = panel;
+            // Ширина известна только после раскладки, а подпись выравнивается
+            // по ней: пересчитываем, когда блок получил размер.
+            panel.GetObservable(Visual.BoundsProperty).Subscribe(new PropertyObserver<Rect>(_ => QueueHeaderAlign()));
             return panel;
         }
 
@@ -2714,15 +2754,29 @@ namespace Configuration_Management
                 if (left is null || origin.Value.X < left.Value)
                     left = origin.Value.X;
             }
-            if (left is null)
-                return;
+            // Строк может не быть вовсе: список пуст, всё отобрано фильтром
+            // или группы свёрнуты. Выходить нельзя, иначе подпись «Название»
+            // остаётся под блоком кнопок и он её перекрывает.
 
             // Пустые колонки звезды, булавки и иконки заголовка кнопки перекрывают,
             // а на подпись «Название» налезать не должны, отсюда нижняя граница.
             var lead = _columnHeaderRow.ColumnDefinitions[1].ActualWidth
                 + _columnHeaderRow.ColumnDefinitions[2].ActualWidth
                 + _columnHeaderRow.ColumnDefinitions[3].ActualWidth;
-            var offset = Math.Max(Math.Max(0, _headerToolbarWidth - lead), left.Value);
+            // Измеренная ширина точнее расчётной, и она же нужна минимуму
+            // области списка: там расчёт по константам оставил бы пустоту
+            // или лишнюю прокрутку.
+            if (MeasuredToolbarWidth is { } measured)
+            {
+                var target = measured + HeaderToolbarGap;
+                if (Math.Abs(target - _headerToolbarWidth) > 0.5)
+                {
+                    _headerToolbarWidth = target;
+                    UpdateListMinWidth();
+                }
+            }
+
+            var offset = Math.Max(Math.Max(0, _headerToolbarWidth - lead), left ?? 0);
             if (Math.Abs(offset - _headerOffsetColumn.Width.Value) > 0.5)
                 _headerOffsetColumn.Width = new GridLength(offset);
 

--- a/Configuration Management/MainWindow.Avalonia.cs
+++ b/Configuration Management/MainWindow.Avalonia.cs
@@ -123,6 +123,7 @@ namespace Configuration_Management
 
         /// <summary>Ссылка на значок трея, чтобы обновлять меню при смене языка.</summary>
         private TrayIcon? _trayIcon;
+        private NativeMenu? _trayMenu;
 
         /// <summary>
         /// Можно ли вернуть спрятанное окно. Значок трея это первый путь, но
@@ -663,6 +664,11 @@ namespace Configuration_Management
                 {
                     if (e.PropertyName == nameof(MainViewModel.SearchText))
                         UpdateEmptyState();
+                    // Меню трея показывает выбранную базу и недавние: без этого
+                    // оно осталось бы таким, каким было собрано при запуске.
+                    if (e.PropertyName == nameof(MainViewModel.SelectedInfobase)
+                        || e.PropertyName == nameof(MainViewModel.RecentInfobases))
+                        RefreshTrayMenu();
                     // Заголовок строится до загрузки настроек, поэтому обновляется
                     // при уведомлении о колонках: иначе сохранённые ширина и состав
                     // применились бы к строкам, но не к уже собранному заголовку.
@@ -3240,6 +3246,27 @@ namespace Configuration_Management
         private NativeMenu BuildTrayMenu()
         {
             var menu = new NativeMenu();
+            // Состав меню зависит от данных: недавние базы и выбранная база
+            // меняются в работе. Штатный запрос обновления перед показом
+            // (NeedsUpdate) под KDE не приходит вовсе, проверено прогоном,
+            // поэтому меню ещё и пересобирается по изменению самих данных.
+            menu.NeedsUpdate += (_, _) => FillTrayMenu(menu);
+            FillTrayMenu(menu);
+            _trayMenu = menu;
+            return menu;
+        }
+
+        /// <summary>Пересобирает меню трея, если оно уже создано.</summary>
+        private void RefreshTrayMenu()
+        {
+            if (_trayMenu is not null)
+                FillTrayMenu(_trayMenu);
+        }
+
+        /// <summary>Наполняет меню трея заново по текущему состоянию списка баз.</summary>
+        private void FillTrayMenu(NativeMenu menu)
+        {
+            menu.Items.Clear();
 
             var showItem = new NativeMenuItem(LocalizationManager.T("Main.ShowWindow"));
             showItem.Click += (_, _) => ShowAndActivate();
@@ -3293,8 +3320,6 @@ namespace Configuration_Management
                 _vm?.ExitCommand.Execute(null);
             };
             menu.Add(exitItem);
-
-            return menu;
         }
 
         private void SetupTray()

--- a/Configuration Management/MainWindow.Avalonia.cs
+++ b/Configuration Management/MainWindow.Avalonia.cs
@@ -1,6 +1,7 @@
 #if LINUX
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
@@ -124,6 +125,13 @@ namespace Configuration_Management
         /// <summary>Ссылка на значок трея, чтобы обновлять меню при смене языка.</summary>
         private TrayIcon? _trayIcon;
         private NativeMenu? _trayMenu;
+        private string? _traySignature;
+        private bool _trayRefreshQueued;
+        private IDisposable? _toolbarWidthLink;
+        private NotifyCollectionChangedEventHandler? _groupNodesChanged;
+        private NotifyCollectionChangedEventHandler? _flatItemsChanged;
+        private EventHandler? _tagFiltersRebuilt;
+        private PropertyChangedEventHandler? _vmPropertyChanged;
 
         /// <summary>
         /// Можно ли вернуть спрятанное окно. Значок трея это первый путь, но
@@ -655,12 +663,17 @@ namespace Configuration_Management
             // Показываем/скрываем заглушку при любых изменениях списка и поиска.
             if (_vm is not null)
             {
+                // Содержимое окна пересобирается при смене языка и компактного
+                // режима, а вьюмодель живёт дальше: без снятия прежние
+                // обработчики накапливались бы и делали ту же работу заново.
+                DetachViewModelHandlers();
+
                 // Строки пересобираются вместе с деревом, поэтому заголовок
                 // выравнивается по ним заново: отступ уровня мог измениться.
-                _vm.GroupNodes.CollectionChanged += (_, _) => { UpdateEmptyState(); QueueHeaderAlign(); };
-                _vm.FlatItems.CollectionChanged += (_, _) => UpdateEmptyState();
-                _vm.TagFiltersRebuilt += (_, _) => RefreshTagFilterPanel();
-                _vm.PropertyChanged += (_, e) =>
+                _groupNodesChanged = (_, _) => { UpdateEmptyState(); QueueHeaderAlign(); };
+                _flatItemsChanged = (_, _) => UpdateEmptyState();
+                _tagFiltersRebuilt = (_, _) => RefreshTagFilterPanel();
+                _vmPropertyChanged = (_, e) =>
                 {
                     if (e.PropertyName == nameof(MainViewModel.SearchText))
                         UpdateEmptyState();
@@ -668,7 +681,7 @@ namespace Configuration_Management
                     // оно осталось бы таким, каким было собрано при запуске.
                     if (e.PropertyName == nameof(MainViewModel.SelectedInfobase)
                         || e.PropertyName == nameof(MainViewModel.RecentInfobases))
-                        RefreshTrayMenu();
+                        QueueTrayMenuRefresh();
                     // Заголовок строится до загрузки настроек, поэтому обновляется
                     // при уведомлении о колонках: иначе сохранённые ширина и состав
                     // применились бы к строкам, но не к уже собранному заголовку.
@@ -696,6 +709,11 @@ namespace Configuration_Management
                         RefreshTagFilterPanel();
                     }
                 };
+
+                _vm.GroupNodes.CollectionChanged += _groupNodesChanged;
+                _vm.FlatItems.CollectionChanged += _flatItemsChanged;
+                _vm.TagFiltersRebuilt += _tagFiltersRebuilt;
+                _vm.PropertyChanged += _vmPropertyChanged;
             }
             UpdateEmptyState();
             RefreshTagFilterPanel();
@@ -1887,7 +1905,8 @@ namespace Configuration_Management
                 Cursor = new Cursor(StandardCursorType.Hand);
                 MinHeight = 30;
                 Padding = new Thickness(12, 5);
-                BorderThickness = new Thickness(0);
+                BorderThickness = new Thickness(2);
+                BorderBrush = Brushes.Transparent;
 
                 // Кастомный шаблон: скруглённый Border + ContentPresenter (без Fluent-хрома).
                 Theme = new ControlTheme(typeof(ToggleButton))
@@ -1994,16 +2013,10 @@ namespace Configuration_Management
                 else
                     Background = _pressed ? _pressedBg : (_hovered ? _hoverBg : Brushes.Transparent);
 
-                if (_focused)
-                {
-                    BorderBrush = _accent;
-                    BorderThickness = new Thickness(2);
-                }
-                else
-                {
-                    BorderBrush = Brushes.Transparent;
-                    BorderThickness = new Thickness(0);
-                }
+                // Толщина постоянна, меняется только цвет: иначе фокус
+                // расширял бы кнопку на четыре пикселя, а по её правому краю
+                // выравнивается подпись «Название» в шапке списка.
+                BorderBrush = _focused ? _accent : Brushes.Transparent;
             }
         }
 
@@ -2034,10 +2047,10 @@ namespace Configuration_Management
 
         /// <summary>
         /// Расчётная ширина переключателя тегов: он сделан сегментной кнопкой
-        /// с горизонтальным отступом 12 и иконкой 15, то есть заметно шире
-        /// обычной кнопки панели.
+        /// с горизонтальным отступом 12, рамкой 2 и иконкой 15, то есть
+        /// заметно шире обычной кнопки панели.
         /// </summary>
-        private const double TagsToggleWidth = 12 * 2 + 15;
+        private const double TagsToggleWidth = 12 * 2 + 2 * 2 + 15;
 
         /// <summary>Зазор между блоком кнопок и подписью «Название».</summary>
         private const double HeaderToolbarGap = 2;
@@ -2282,12 +2295,15 @@ namespace Configuration_Management
 
             var tagsToggle = BuildTagsInListToggle();
             panel.Children.Add(tagsToggle);
-            tagsToggle.GetObservable(Visual.BoundsProperty).Subscribe(new PropertyObserver<Rect>(_ => QueueHeaderAlign()));
 
             _groupToolbar = panel;
             // Ширина известна только после раскладки, а подпись выравнивается
-            // по ней: пересчитываем, когда блок получил размер.
-            panel.GetObservable(Visual.BoundsProperty).Subscribe(new PropertyObserver<Rect>(_ => QueueHeaderAlign()));
+            // по ней. Следим за переключателем: он всегда крайний справа,
+            // поэтому именно он задаёт правый край блока. Bounds самой панели
+            // обрезаны колонками заголовка и на измерение не влияют.
+            _toolbarWidthLink?.Dispose();
+            _toolbarWidthLink = tagsToggle.GetObservable(Visual.BoundsProperty)
+                .Subscribe(new PropertyObserver<Rect>(_ => QueueHeaderAlign()));
             return panel;
         }
 
@@ -3248,19 +3264,81 @@ namespace Configuration_Management
             var menu = new NativeMenu();
             // Состав меню зависит от данных: недавние базы и выбранная база
             // меняются в работе. Штатный запрос обновления перед показом
-            // (NeedsUpdate) под KDE не приходит вовсе, проверено прогоном,
-            // поэтому меню ещё и пересобирается по изменению самих данных.
+            // (NeedsUpdate) на Linux не приходит: его поднимает только
+            // бэкенд macOS, в Avalonia.FreeDesktop вызова нет, проверено
+            // и прогоном, и разбором сборок. Поэтому меню пересобирается
+            // по изменению самих данных, а подписка оставлена на случай,
+            // если событие появится.
             menu.NeedsUpdate += (_, _) => FillTrayMenu(menu);
             FillTrayMenu(menu);
             _trayMenu = menu;
+            _traySignature = TrayMenuSignature();
             return menu;
         }
 
-        /// <summary>Пересобирает меню трея, если оно уже создано.</summary>
+        /// <summary>Снимает обработчики вьюмодели, навешенные прошлой сборкой окна.</summary>
+        private void DetachViewModelHandlers()
+        {
+            if (_vm is null)
+                return;
+            if (_groupNodesChanged is not null)
+                _vm.GroupNodes.CollectionChanged -= _groupNodesChanged;
+            if (_flatItemsChanged is not null)
+                _vm.FlatItems.CollectionChanged -= _flatItemsChanged;
+            if (_tagFiltersRebuilt is not null)
+                _vm.TagFiltersRebuilt -= _tagFiltersRebuilt;
+            if (_vmPropertyChanged is not null)
+                _vm.PropertyChanged -= _vmPropertyChanged;
+        }
+
+        /// <summary>
+        /// Ставит пересборку меню трея в очередь диспетчера. Одно действие даёт
+        /// несколько уведомлений подряд (выбор, список, запуск), а пересборка
+        /// заново экспортирует меню по DBus, поэтому вызовы склеиваются, как
+        /// это уже делают QueueHeaderAlign и QueueColumnHeaderRefresh.
+        /// </summary>
+        private void QueueTrayMenuRefresh()
+        {
+            if (_trayRefreshQueued || _trayMenu is null || _vm is null)
+                return;
+
+            _trayRefreshQueued = true;
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                _trayRefreshQueued = false;
+                RefreshTrayMenu();
+            }, Avalonia.Threading.DispatcherPriority.Background);
+        }
+
+        /// <summary>
+        /// Пересобирает меню трея, если его состав действительно изменился:
+        /// уведомления приходят и на поиск, и на фильтр, поэтому сверяется
+        /// отпечаток состава.
+        /// </summary>
         private void RefreshTrayMenu()
         {
-            if (_trayMenu is not null)
-                FillTrayMenu(_trayMenu);
+            if (_trayMenu is null || _vm is null)
+                return;
+
+            var signature = TrayMenuSignature();
+            if (signature == _traySignature)
+                return;
+
+            _traySignature = signature;
+            FillTrayMenu(_trayMenu);
+        }
+
+        /// <summary>Состав меню трея строкой: выбранная база и недавние.</summary>
+        private string TrayMenuSignature()
+        {
+            if (_vm is null)
+                return string.Empty;
+
+            var builder = new System.Text.StringBuilder();
+            builder.Append(_vm.SelectedInfobase?.Id).Append('|').Append(_vm.SelectedInfobase?.Name);
+            foreach (var ib in _vm.RecentInfobases)
+                builder.Append('|').Append(ib.Id).Append('~').Append(ib.Name);
+            return builder.ToString();
         }
 
         /// <summary>Наполняет меню трея заново по текущему состоянию списка баз.</summary>
@@ -3364,6 +3442,13 @@ namespace Configuration_Management
         {
             if (_vm is null)
                 return;
+            // Пункт меню держит ссылку на базу, а список мог смениться
+            // импортом или удалением: запускать исчезнувшую нельзя.
+            if (!_vm.Infobases.Contains(ib))
+            {
+                QueueTrayMenuRefresh();
+                return;
+            }
             _vm.SelectedInfobase = ib;
             _vm.LaunchEnterpriseCommand.Execute(null);
         }

--- a/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
+++ b/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
@@ -429,7 +429,7 @@ public class MainViewModel : ViewModelBase
         get => _selectedInfobase;
         set
         {
-            if (SetProperty(ref _selectedInfobase, value, nameof(SelectedInfobase), nameof(RightPanelTitle), nameof(RightPanelSubtitle),
+            if (SetPropertyWithRelated(ref _selectedInfobase, value, nameof(SelectedInfobase), nameof(RightPanelTitle), nameof(RightPanelSubtitle),
                     nameof(IsInfobaseSelected), nameof(ShowConnectionInfo),
                     nameof(RightPanelIconKey), nameof(HasRightPanelIcon)))
             {
@@ -446,7 +446,7 @@ public class MainViewModel : ViewModelBase
         get => _selectedGroupNode;
         set
         {
-            if (SetProperty(ref _selectedGroupNode, value, nameof(SelectedGroupNode), nameof(RightPanelTitle), nameof(RightPanelSubtitle),
+            if (SetPropertyWithRelated(ref _selectedGroupNode, value, nameof(SelectedGroupNode), nameof(RightPanelTitle), nameof(RightPanelSubtitle),
                     nameof(IsInfobaseSelected), nameof(ShowConnectionInfo),
                     nameof(RightPanelIconKey), nameof(HasRightPanelIcon)))
             {
@@ -463,7 +463,7 @@ public class MainViewModel : ViewModelBase
     public bool ShowRightPanelDetails
     {
         get => _showRightPanelDetails;
-        set => SetProperty(ref _showRightPanelDetails, value, nameof(ShowRightPanelDetails), nameof(RightPanelToggleTooltip), nameof(ShowConnectionInfo));
+        set => SetPropertyWithRelated(ref _showRightPanelDetails, value, nameof(ShowRightPanelDetails), nameof(RightPanelToggleTooltip), nameof(ShowConnectionInfo));
     }
 
     /// <summary>
@@ -706,7 +706,7 @@ public class MainViewModel : ViewModelBase
         get => _sessionClient;
         set
         {
-            if (!SetProperty(ref _sessionClient, value,
+            if (!SetPropertyWithRelated(ref _sessionClient, value, nameof(SessionClient),
                     nameof(IsSessionClientAuto), nameof(IsSessionClientOrdinary), nameof(IsSessionClientThick),
                     nameof(IsSessionClientThickOrdinary), nameof(IsSessionClientThin)))
                 return;
@@ -726,7 +726,7 @@ public class MainViewModel : ViewModelBase
         get => _sessionArch;
         set
         {
-            if (!SetProperty(ref _sessionArch, value, nameof(SessionArch), nameof(IsSessionArchAuto), nameof(IsSessionArch32), nameof(IsSessionArch64)))
+            if (!SetPropertyWithRelated(ref _sessionArch, value, nameof(SessionArch), nameof(IsSessionArchAuto), nameof(IsSessionArch32), nameof(IsSessionArch64)))
                 return;
 
             _settings.SessionArchitecture = SessionArchitectureMode().ToString();
@@ -936,6 +936,9 @@ public class MainViewModel : ViewModelBase
                 ?? (selectedKey is null ? null : FindNode(node =>
                     string.Equals(node.NodeKey, selectedKey, StringComparison.OrdinalIgnoreCase)));
 
+        // Состав списка мог смениться импортом, удалением или очисткой,
+        // а его показывает меню трея.
+        OnPropertyChanged(nameof(RecentInfobases));
     }
 
     /// <summary>Состав списка вот-вот сменится: окну нужно запомнить прокрутку.</summary>

--- a/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
+++ b/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
@@ -429,7 +429,7 @@ public class MainViewModel : ViewModelBase
         get => _selectedInfobase;
         set
         {
-            if (SetProperty(ref _selectedInfobase, value, nameof(RightPanelTitle), nameof(RightPanelSubtitle),
+            if (SetProperty(ref _selectedInfobase, value, nameof(SelectedInfobase), nameof(RightPanelTitle), nameof(RightPanelSubtitle),
                     nameof(IsInfobaseSelected), nameof(ShowConnectionInfo),
                     nameof(RightPanelIconKey), nameof(HasRightPanelIcon)))
             {
@@ -446,7 +446,7 @@ public class MainViewModel : ViewModelBase
         get => _selectedGroupNode;
         set
         {
-            if (SetProperty(ref _selectedGroupNode, value, nameof(RightPanelTitle), nameof(RightPanelSubtitle),
+            if (SetProperty(ref _selectedGroupNode, value, nameof(SelectedGroupNode), nameof(RightPanelTitle), nameof(RightPanelSubtitle),
                     nameof(IsInfobaseSelected), nameof(ShowConnectionInfo),
                     nameof(RightPanelIconKey), nameof(HasRightPanelIcon)))
             {
@@ -463,7 +463,7 @@ public class MainViewModel : ViewModelBase
     public bool ShowRightPanelDetails
     {
         get => _showRightPanelDetails;
-        set => SetProperty(ref _showRightPanelDetails, value, nameof(RightPanelToggleTooltip), nameof(ShowConnectionInfo));
+        set => SetProperty(ref _showRightPanelDetails, value, nameof(ShowRightPanelDetails), nameof(RightPanelToggleTooltip), nameof(ShowConnectionInfo));
     }
 
     /// <summary>
@@ -726,7 +726,7 @@ public class MainViewModel : ViewModelBase
         get => _sessionArch;
         set
         {
-            if (!SetProperty(ref _sessionArch, value, nameof(IsSessionArchAuto), nameof(IsSessionArch32), nameof(IsSessionArch64)))
+            if (!SetProperty(ref _sessionArch, value, nameof(SessionArch), nameof(IsSessionArchAuto), nameof(IsSessionArch32), nameof(IsSessionArch64)))
                 return;
 
             _settings.SessionArchitecture = SessionArchitectureMode().ToString();
@@ -1429,6 +1429,9 @@ public class MainViewModel : ViewModelBase
             SelectedInfobase.AddLaunchHistory(LocalizationManager.T("Main.LaunchAction"));
             SaveSilently();
         }
+
+        // Список недавних изменился, и его показывает меню трея.
+        OnPropertyChanged(nameof(RecentInfobases));
 
         // Одна точка на все пути запуска: команды окна, контекстное меню и трей
         // приходят сюда же, в отличие от WPF, где уведомление расставлено трижды.

--- a/Configuration Management/ViewModels/ViewModelBase.Avalonia.cs
+++ b/Configuration Management/ViewModels/ViewModelBase.Avalonia.cs
@@ -39,9 +39,12 @@ public abstract class ViewModelBase : INotifyPropertyChanged
     /// <summary>
     /// Устанавливает значение и дополнительно уведомляет о связанных свойствах.
     /// </summary>
-    protected bool SetProperty<T>(ref T field, T value, params string[] relatedProperties)
+    protected bool SetProperty<T>(ref T field, T value, string propertyName, params string[] relatedProperties)
     {
-        if (!SetProperty(ref field, value))
+        // Имя своего свойства передаётся явно: у вызова без него CallerMemberName
+        // подставлял имя самого метода, и подписчики на имя свойства уведомления
+        // не получали вовсе.
+        if (!SetProperty(ref field, value, propertyName))
             return false;
         foreach (var name in relatedProperties)
             OnPropertyChanged(name);

--- a/Configuration Management/ViewModels/ViewModelBase.Avalonia.cs
+++ b/Configuration Management/ViewModels/ViewModelBase.Avalonia.cs
@@ -38,12 +38,13 @@ public abstract class ViewModelBase : INotifyPropertyChanged
 
     /// <summary>
     /// Устанавливает значение и дополнительно уведомляет о связанных свойствах.
+    /// Имя своего свойства передаётся первым: у одноимённой перегрузки первый
+    /// строковый аргумент означал бы ровно обратное, и перепутать их было бы легко.
     /// </summary>
-    protected bool SetProperty<T>(ref T field, T value, string propertyName, params string[] relatedProperties)
+    protected bool SetPropertyWithRelated<T>(ref T field, T value, string propertyName, params string[] relatedProperties)
     {
-        // Имя своего свойства передаётся явно: у вызова без него CallerMemberName
-        // подставлял имя самого метода, и подписчики на имя свойства уведомления
-        // не получали вовсе.
+        // Имя передаётся явно: при вызове без него CallerMemberName подставлял
+        // имя самого метода, и подписчики на имя свойства не получали ничего.
         if (!SetProperty(ref field, value, propertyName))
             return false;
         foreach (var name in relatedProperties)


### PR DESCRIPTION
Три правки Linux/Avalonia-ветки, каждая проверена прогоном на живом окружении
(KDE Plasma, X11).

### Кнопка тегов налезала на подпись «Название»

Ширина блока кнопок шапки считалась по константам, а переключатель тегов сделан
сегментной кнопкой и шире обычной: 38 против 24. Плюс при пустом списке
выравнивание не выполнялось вовсе, метод выходил, не найдя строк для замера
левого края.

Мерить панель по её собственному `Bounds` нельзя: она зажата в узкие колонки
заголовка и обрезана по ним (замерено: `Bounds.Width` 98 при фактическом правом
крае содержимого 172), а `StackPanel` раскладывает детей по их `DesiredSize`
и рисует за своей границей. Поэтому ширина берётся по самому правому краю детей,
измеренное значение сохраняется в поле и обновляет минимум ширины области
списка, а расчёт по константам остаётся оценкой до первой раскладки.

Проверено: пустой список, полный список, отключение колонок звезды и булавки на
ходу. Заголовок и имена баз совпадают по левому краю.

### Справочник ключей командной строки

В окне параметров запуска колонка ключа была 150 при ширине окна 620, поэтому
длинные ключи обрезались без многоточия и слипались с описанием. Размеры
приведены к WPF-версии: окно 800 при минимуме 720, колонка ключа 220, зазор
между колонками, обрезка длинных значений многоточием.

### Меню значка в трее показывало состояние на момент запуска

В WPF меню пересобирается по событию открытия (`RebuildTrayMenu`, подписка на
`ContextMenuStrip.Opening`). В Avalonia под KDE не приходит ни одно из трёх
событий `NativeMenu`: ни `NeedsUpdate`, ни `Opening`, ни `Closed`, проверено
прогоном с выводом в журнал. Поэтому меню наполняется заново по изменению самих
данных, а подписка на `NeedsUpdate` оставлена для окружений, где событие
работает. Экспортёр меню через DBus изменение состава уже экспортированного
`NativeMenu` подхватывает: проверено сменой выбранной базы и запуском базы,
пункты меню обновились без пересоздания значка.

Попутно исправлена перегрузка `SetProperty` со списком связанных свойств
в `ViewModelBase.Avalonia.cs`: она вызывала базовую перегрузку без имени
свойства, и `CallerMemberName` подставлял имя самого метода. Уведомление уходило
под именем `SetProperty`, а подписчики на имя свойства не получали ничего.
Перегрузка используется в четырёх местах, все передают имя явно. Одноимённый
файл WPF-цели не тронут: там перегрузка не используется нигде, а собрать и
проверить эту цель на Linux нельзя.

### Правки по двум встречным аудитам

Дифф прошёл через два независимых аудита, их находки учтены:

* пересборка меню трея ставится в очередь диспетчера и сверяет отпечаток
  состава: одно действие давало несколько полных пересборок подряд, а клик
  по пункту пересобирал меню прямо внутри обработки этого же клика;
* состав меню обновляется и при смене списка баз (переименование, импорт,
  синхронизация, удаление): все эти пути проходят через `RebuildTree`;
* запуск из меню проверяет, что база ещё в списке;
* в шапке осталась одна подписка на размеры вместо двух, и она освобождается
  перед новой: `Bounds` самой панели в измерение не входят;
* фокусная рамка сегментной кнопки больше не меняет её ширину, иначе подпись
  «Название» уезжала на четыре пикселя при обходе с клавиатуры;
* у окна параметров запуска высота приведена к 640, как в WPF, а колонка
  ключа сделана 232 с учётом зазора, чтобы тексту осталось те же 220;
* перегрузка со связанными свойствами названа `SetPropertyWithRelated`:
  у одноимённых перегрузок первый строковый аргумент означал бы
  противоположное. Пятый вызов (`SessionClient`) исправлен вместе с остальными.
