### PR TITLE
Linux/Avalonia: приложение не запускалось при недоступном каталоге настроек

### DIFF
--- a/Configuration Management/App.axaml.cs
+++ b/Configuration Management/App.axaml.cs
@@ -30,11 +30,15 @@ namespace Configuration_Management
         private const string LockFileName = "configuration-management.lock";
         private const string ActivateFileName = "activate";
 
-        /// <summary>Каталог данных приложения (например ~/.config/ConfigurationManagement).</summary>
+        /// <summary>
+        /// Каталог данных приложения (например ~/.config/ConfigurationManagement).
+        /// Считается тем же механизмом, что и у репозитория настроек: расчёт
+        /// напрямую через SpecialFolder.ApplicationData на Linux даёт пустую
+        /// строку, когда каталога из XDG_CONFIG_HOME нет, путь становится
+        /// относительным, и приложение молча не запускается.
+        /// </summary>
         private static string DataDirectory =>
-            _dataDir ??= Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "ConfigurationManagement");
+            _dataDir ??= Services.PlatformPaths.AppDataDirectory;
 
         public override void Initialize()
         {


### PR DESCRIPTION
Приложение молча не запускалось, если каталог настроек недоступен: ни окна, ни записи в журнале, ни `errors.log`, процесс завершался с кодом 0 сразу после инициализации локализации.

Причина в том, что каталог данных считают два разных механизма. Репозиторий настроек берёт его через `PlatformPaths.AppDataDirectory`, где `XDG_CONFIG_HOME` обрабатывается явно, а старт приложения считал сам, через `Environment.GetFolderPath(SpecialFolder.ApplicationData)`. На Linux этот вызов возвращает пустую строку, когда каталога из `XDG_CONFIG_HOME` нет, дальше `Path.Combine` даёт относительный путь `ConfigurationManagement`, и запуск обрывается.

Видно прямо в отладочном выводе локализации: `LoadSettings` печатает правильный полный путь, а `Initialize` получает `dataDir=ConfigurationManagement`.

Правка сводит оба места к одному механизму.

Проверено прогоном на Linux: с несуществующим каталогом настроек до правки процесс завершался за секунду с кодом 0, после правки приложение запускается и создаёт каталог там, где ожидалось. Обычный запуск с существующим профилем не изменился.
