### PR TITLE
Linux/Avalonia: цель net10.0 не собирается начиная с 0.3.4.7

### DIFF
--- a/Configuration Management/MainWindow.Avalonia.cs
+++ b/Configuration Management/MainWindow.Avalonia.cs
@@ -285,7 +285,7 @@ namespace Configuration_Management
                 "SecondaryButtonPressedBrush",
                 "BorderColorBrush")
             {
-                Content = new Path
+                Content = new Avalonia.Controls.Shapes.Path
                 {
                     Width = UiMetrics.Scaled(16),
                     Height = UiMetrics.Scaled(16),

--- a/Configuration Management/SettingsWindow.Avalonia.cs
+++ b/Configuration Management/SettingsWindow.Avalonia.cs
@@ -330,11 +330,6 @@ namespace Configuration_Management
 
             // Порядок колонок редактируется кнопками «Вверх»/«Вниз» по выбранной
             // строке; список хранит ключи колонок, а показывает локализованные имена.
-            record ColumnOrderItem(string Key, string Display)
-            {
-                public override string ToString() => Display;
-            }
-
             static string ColumnOrderLabel(string key) => LocalizationManager.T(key switch
             {
                 "Version" => "Column.Version",
@@ -1471,6 +1466,11 @@ namespace Configuration_Management
                 WindowStartupLocation = WindowStartupLocation.CenterOwner
             };
             _ = win.ShowDialog(this);
+        }
+
+        private sealed record ColumnOrderItem(string Key, string Display)
+        {
+            public override string ToString() => Display;
         }
     }
 }


### PR DESCRIPTION
Начиная с 0.3.4.7 цель `net10.0` (Linux/Avalonia) не собирается: 42 ошибки компилятора. На Windows это не видно, потому что оба файла в цель `net10.0-windows` не входят.

Проверено на чистом `main` (`c94f023`): `dotnet build "Configuration Management/Configuration Management.csproj" -f net10.0` даёт 42 ошибки.

## Причины

**1. `SettingsWindow.Avalonia.cs`, метод построения вкладки «Отображение»**

`record ColumnOrderItem` объявлен внутри тела метода. Типы внутри методов C# не допускает: парсер съезжает на объявлении и сыплет ошибки по всему остатку файла (41 из 42, начиная с CS1026 и CS8803).

Правка: тот же record вынесен вложенным типом класса, тело не менялось.

**2. `MainWindow.Avalonia.cs:288`, кнопка «Доступность»**

`new Path` неоднозначен между `Avalonia.Controls.Shapes.Path` и `System.IO.Path` (CS0104), оба пространства имён в файле подключены.

Правка: имя уточнено полностью в одной строке.

## Проверено

* До правок: 42 ошибки. После: 0 ошибок, 32 предупреждения, ровно как было до 0.3.4.7.
* Собранный бинарник запускается с изолированным `HOME`, окно живёт, локализация поднимается, падений нет.
* Цель `net10.0-windows` не затронута: правки только в двух `*.Avalonia.cs`, шесть строк.

## Про порядок колонок

Правка чинит только компиляцию. Сам редактор порядка колонок на Avalonia-стороне после этого собирается и открывается, поведение не менялось.