### PR TITLE
Linux/Avalonia: сняты устаревшие API, предупреждений с 32 до 15

### DIFF
--- a/Configuration Management/CacheCleanWindow.Avalonia.cs
+++ b/Configuration Management/CacheCleanWindow.Avalonia.cs
@@ -79,12 +79,9 @@ namespace Configuration_Management
 
             _programCacheCheck.IsChecked = initialKind.HasFlag(OneCCacheKind.Program);
             _userCacheCheck.IsChecked = initialKind.HasFlag(OneCCacheKind.User);
-            _programCacheCheck.Checked += (_, _) => UpdateCleanEnabled();
-            _programCacheCheck.Unchecked += (_, _) => UpdateCleanEnabled();
-            _userCacheCheck.Checked += (_, _) => UpdateCleanEnabled();
-            _userCacheCheck.Unchecked += (_, _) => UpdateCleanEnabled();
-            _orphanCacheCheck.Checked += (_, _) => UpdateCleanEnabled();
-            _orphanCacheCheck.Unchecked += (_, _) => UpdateCleanEnabled();
+            _programCacheCheck.IsCheckedChanged += (_, _) => UpdateCleanEnabled();
+            _userCacheCheck.IsCheckedChanged += (_, _) => UpdateCleanEnabled();
+            _orphanCacheCheck.IsCheckedChanged += (_, _) => UpdateCleanEnabled();
             _searchBox.TextChanged += (_, _) => OnSearchTextChanged();
 
             LoadColumnWidths();
@@ -522,8 +519,7 @@ namespace Configuration_Management
                     VerticalContentAlignment = VerticalAlignment.Center
                 };
                 ToolTip.SetTip(check, string.IsNullOrWhiteSpace(ib.ConnectionPathDisplay) ? ib.Name : ib.ConnectionPathDisplay);
-                check.Checked += (_, _) => OnBaseChecked();
-                check.Unchecked += (_, _) => OnBaseChecked();
+                check.IsCheckedChanged += (_, _) => OnBaseChecked();
                 Grid.SetColumn(check, 0);
                 row.Children.Add(check);
 

--- a/Configuration Management/ConnectionStringInputWindow.Avalonia.cs
+++ b/Configuration Management/ConnectionStringInputWindow.Avalonia.cs
@@ -3,6 +3,7 @@ using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Localization;
@@ -154,7 +155,7 @@ namespace Configuration_Management
             string text;
             try
             {
-                text = await clipboard.GetTextAsync() ?? string.Empty;
+                text = await clipboard.TryGetTextAsync() ?? string.Empty;
             }
             catch
             {
@@ -179,7 +180,7 @@ namespace Configuration_Management
             string text;
             try
             {
-                text = await clipboard.GetTextAsync() ?? string.Empty;
+                text = await clipboard.TryGetTextAsync() ?? string.Empty;
             }
             catch
             {

--- a/Configuration Management/GroupPickerWindow.Avalonia.cs
+++ b/Configuration Management/GroupPickerWindow.Avalonia.cs
@@ -91,8 +91,16 @@ namespace Configuration_Management
             var sortPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8, Margin = new Thickness(0, 0, 0, 8) };
             _sortAsc.GroupName = "Sort";
             _sortDesc.GroupName = "Sort";
-            _sortAsc.Checked += (_, _) => { _sortAscending = true; _sortDesc.IsChecked = false; RefreshTree(); };
-            _sortDesc.Checked += (_, _) => { _sortAscending = false; _sortAsc.IsChecked = false; RefreshTree(); };
+            _sortAsc.IsCheckedChanged += (_, _) =>
+            {
+                if (_sortAsc.IsChecked != true) return;
+                _sortAscending = true; _sortDesc.IsChecked = false; RefreshTree();
+            };
+            _sortDesc.IsCheckedChanged += (_, _) =>
+            {
+                if (_sortDesc.IsChecked != true) return;
+                _sortAscending = false; _sortAsc.IsChecked = false; RefreshTree();
+            };
             sortPanel.Children.Add(new TextBlock { Text = LocalizationManager.T("Common.SortLabel"), VerticalAlignment = VerticalAlignment.Center });
             sortPanel.Children.Add(_sortAsc);
             sortPanel.Children.Add(_sortDesc);

--- a/Configuration Management/PlatformVersionPickerWindow.Avalonia.cs
+++ b/Configuration Management/PlatformVersionPickerWindow.Avalonia.cs
@@ -81,9 +81,21 @@ namespace Configuration_Management
             var top = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 16, Margin = new Thickness(0, 0, 0, 8), VerticalAlignment = VerticalAlignment.Center };
             var filterPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
             filterPanel.Children.Add(new TextBlock { Text = LocalizationManager.T("PlatformVersionPicker.FilterLabel"), VerticalAlignment = VerticalAlignment.Center });
-            _filterAll.Checked += (_, _) => { _archFilter = "all"; RefreshTree(); };
-            _filterX32.Checked += (_, _) => { _archFilter = "x32"; RefreshTree(); };
-            _filterX64.Checked += (_, _) => { _archFilter = "x64"; RefreshTree(); };
+            _filterAll.IsCheckedChanged += (_, _) =>
+            {
+                if (_filterAll.IsChecked != true) return;
+                _archFilter = "all"; RefreshTree();
+            };
+            _filterX32.IsCheckedChanged += (_, _) =>
+            {
+                if (_filterX32.IsChecked != true) return;
+                _archFilter = "x32"; RefreshTree();
+            };
+            _filterX64.IsCheckedChanged += (_, _) =>
+            {
+                if (_filterX64.IsChecked != true) return;
+                _archFilter = "x64"; RefreshTree();
+            };
             filterPanel.Children.Add(_filterAll);
             filterPanel.Children.Add(_filterX32);
             filterPanel.Children.Add(_filterX64);
@@ -91,8 +103,16 @@ namespace Configuration_Management
 
             var sortPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
             sortPanel.Children.Add(new TextBlock { Text = LocalizationManager.T("Common.SortLabel"), VerticalAlignment = VerticalAlignment.Center });
-            _sortAsc.Checked += (_, _) => { _sortAscending = true; _sortDesc.IsChecked = false; RefreshTree(); };
-            _sortDesc.Checked += (_, _) => { _sortAscending = false; _sortAsc.IsChecked = false; RefreshTree(); };
+            _sortAsc.IsCheckedChanged += (_, _) =>
+            {
+                if (_sortAsc.IsChecked != true) return;
+                _sortAscending = true; _sortDesc.IsChecked = false; RefreshTree();
+            };
+            _sortDesc.IsCheckedChanged += (_, _) =>
+            {
+                if (_sortDesc.IsChecked != true) return;
+                _sortAscending = false; _sortAsc.IsChecked = false; RefreshTree();
+            };
             sortPanel.Children.Add(_sortAsc);
             sortPanel.Children.Add(_sortDesc);
             top.Children.Add(sortPanel);


### PR DESCRIPTION
В Linux-цели (Avalonia) накопились обращения к API, помеченным `Obsolete` в Avalonia 11: 17 мест в четырёх окнах, 17 предупреждений `CS0618` из 32 всех предупреждений сборки. Правка их снимает. Windows-цель не затронута, файлы только `*.Avalonia.cs`.

Похоже на то, что вы сделали в 0.3.4.13 для проверки доступности клиент-серверных баз, только на Linux-стороне.

## Что заменено

**`ToggleButton.Checked` и `Unchecked` → `IsCheckedChanged`** (текст предупреждения рекомендует именно это).

У флажков в окне очистки кеша обе подписки шли на один обработчик, поэтому пара сведена к одной подписке: 8 подписок на 4 контрола стали 4.

У радиокнопок в окнах выбора группы и версии платформы замена **не эквивалентна напрямую**, и это главное в этой правке. `Checked` срабатывал только при установке отметки, а `IsCheckedChanged` срабатывает при любом изменении, включая снятие. Без защиты выбор соседней кнопки немедленно откатывался бы обработчиком той, с которой отметка снялась: он бы заново записал свой `_archFilter` или `_sortAscending`. Поэтому тело каждого обработчика выполняется, только если отметка встала:

```csharp
_sortAsc.IsCheckedChanged += (_, _) =>
{
    if (_sortAsc.IsChecked != true) return;
    _sortAscending = true; _sortDesc.IsChecked = false; RefreshTree();
};
```

Строка, гасящая соседнюю кнопку, намеренно оставлена: в Avalonia `RadioButton.OnPropertyChanged` вызывает базовую реализацию раньше, чем сообщает менеджеру группы, поэтому обработчик выполняется, пока соседка ещё отмечена, и гасит её именно он.

**`IClipboard.GetTextAsync` → `ClipboardExtensions.TryGetTextAsync`** в окне ввода строки подключения, два места. Понадобился `using Avalonia.Input.Platform`. Поведение то же: в Avalonia 11.3.20 старый метод и был обёрткой над новым (`Task<string?> IClipboard.GetTextAsync() => this.TryGetTextAsync();`), исключения по-прежнему долетают до `catch`, поэтому окно так же различает ошибку чтения и пустой буфер.

## Проверено

Сборка Linux-цели: ошибок 0, предупреждений было 32, стало 15. Все 17 исчезнувших это `CS0618`, новых предупреждений ноль (две строки `CS8603` в затронутых файлах сдвинулись по номерам строк, конструкции те же).

Прогон собранной сборки на всех четырёх окнах:

* **Очистка кеша**: снятие обоих типов кеша гасит кнопку «Очистить», возврат отметки включает её обратно; снятие отметки с базы даёт «Выбрано: 0 из 2» и тоже гасит кнопку.
* **Выбор группы**: сортировка переключается в обе стороны, порядок групп меняется и возвращается.
* **Выбор версии платформы**: три фильтра разрядности и обе сортировки, дерево перестраивается на каждый переход.
* **Строка подключения**: вставка по кнопке подставляет содержимое буфера; автоподстановка при пустой строке базы срабатывает, когда в буфере строка, похожая на путь.

## Что намеренно не тронуто

Три вызова `IClipboard.SetTextAsync` в других окнах: в 11.3.20 этот метод не помечен `Obsolete`.