### PR TITLE
Linux/Avalonia: в окне выбора группы пропала справка, а сама кнопка «?» невидима во всём приложении

### DIFF
--- a/Configuration Management/Controls/HelpLink.Avalonia.cs
+++ b/Configuration Management/Controls/HelpLink.Avalonia.cs
@@ -34,9 +34,15 @@ namespace Configuration_Management.Controls
 
         public HelpLink()
         {
-            // Круглая кнопка «?».
+            // Круглая кнопка «?». Отступы снимаются и содержимое центрируется явно:
+            // у кнопки по умолчанию Padding больше самой кнопки шириной 18, поэтому
+            // знак вопроса вытеснялся за границы и кнопка выглядела пустым квадратом.
             _helpToggle.Width = 18;
             _helpToggle.Height = 18;
+            _helpToggle.Padding = new Thickness(0);
+            _helpToggle.CornerRadius = new CornerRadius(9);
+            _helpToggle.HorizontalContentAlignment = HorizontalAlignment.Center;
+            _helpToggle.VerticalContentAlignment = VerticalAlignment.Center;
             _helpToggle.HorizontalAlignment = HorizontalAlignment.Center;
             _helpToggle.VerticalAlignment = VerticalAlignment.Center;
             _helpToggle.Content = new TextBlock

--- a/Configuration Management/Views/GroupPickerWindow.Avalonia.cs
+++ b/Configuration Management/Views/GroupPickerWindow.Avalonia.cs
@@ -114,6 +114,10 @@ namespace Configuration_Management
             grid.Children.Add(toolbar);
 
             var hint = ThemedText(LocalizationManager.T("GroupPicker.Hint"), 12, secondary: true, FontWeight.Normal);
+            // ThemedText не задаёт перенос, а TextBlock без него держит одну строку:
+            // пояснение и подзаголовок обрезались по краю окна. В разметке WPF
+            // на этих же строках TextWrapping="Wrap" стоит.
+            hint.TextWrapping = TextWrapping.Wrap;
             hint.Margin = new Thickness(0, 0, 0, 8);
             Grid.SetRow(hint, 2);
             grid.Children.Add(hint);
@@ -146,9 +150,22 @@ namespace Configuration_Management
             DockPanel.SetDock(headerIcon, Dock.Left);
             header.Children.Add(headerIcon);
 
+            // Справка добавляется до заголовка: в DockPanel последний ребёнок
+            // занимает остаток, и после titleStack кружок «?» встал бы не к краю.
+            var help = new HelpLink
+            {
+                HelpText = LocalizationManager.T("GroupPicker.Help"),
+                VerticalAlignment = VerticalAlignment.Top,
+                Margin = new Thickness(12, 4, 0, 0)
+            };
+            DockPanel.SetDock(help, Dock.Right);
+            header.Children.Add(help);
+
             var titleStack = new StackPanel { Spacing = 2 };
             titleStack.Children.Add(ThemedText(LocalizationManager.T("GroupPicker.Title"), 17, secondary: false, FontWeight.SemiBold));
-            titleStack.Children.Add(ThemedText(LocalizationManager.T("GroupPicker.Subtitle"), 12.5, secondary: true, FontWeight.Normal));
+            var subtitle = ThemedText(LocalizationManager.T("GroupPicker.Subtitle"), 12.5, secondary: true, FontWeight.Normal);
+            subtitle.TextWrapping = TextWrapping.Wrap;
+            titleStack.Children.Add(subtitle);
             header.Children.Add(titleStack);
 
             return header;


### PR DESCRIPTION
## Что не так

При переработке окна «Выбор родительской группы» в 0.4.4 из него пропала кнопка справки. В 0.3.5.10 подстроки `HelpLink` нет ни в одном из двух файлов окна:

* `Configuration Management/Views/GroupPickerWindow.xaml` — 0 вхождений;
* `Configuration Management/Views/GroupPickerWindow.Avalonia.cs` — 0 вхождений.

Ключ `GroupPicker.Help` в `ru.json` и `en.json` при этом остался и в 0.4.4 был дополнен описанием нового поиска и сортировки A→Z / Z→A. То есть текст справки обновлён, а показать его нечем: в коде на ключ больше никто не ссылается. Это единственный ключ справки в файле локализации, на который нет ни одной ссылки, у остальных тринадцати минимум по одной.

README обещает эту кнопку прямо: раздел «Интерфейс», «Такие подсказки добавлены в ... окна группы/выбора родителя».

Связано с issue #78: перенос текста и кнопка за краем оттуда исправлены, справка потеряна вместе с ними.

## Что сделано

PR трогает только Linux/Avalonia. Разметку WPF не трогаю намеренно, чтобы не пересечься с правкой той же шапки на стороне Windows.

**1. Справка возвращена** (`Views/GroupPickerWindow.Avalonia.cs`): в `BuildHeader()` добавлен существующий контрол `Controls.HelpLink` с текстом по ключу `GroupPicker.Help`, ровно как он уже применён в `Views/MainWindow.Avalonia.cs:308`. В `DockPanel` контрол добавляется **до** заголовка: последний ребёнок `DockPanel` занимает весь остаток независимо от `Dock`, и после `titleStack` кружок «?» встал бы не к правому краю.

**2. Перенос текста** там же: `ThemedText(...)` не задаёт `TextWrapping`, а `TextBlock` без него держит одну строку, поэтому пояснение `GroupPicker.Hint` обрезалось по краю окна шириной 520. В разметке WPF на этой строке `TextWrapping="Wrap"` уже стоит (`GroupPickerWindow.xaml:249`), правка выравнивает Avalonia по ней. Тот же перенос задан подзаголовку: в английской локализации он длиннее русского.

**3. Починен сам контрол справки** (`Controls/HelpLink.Avalonia.cs`), и это касается не только этого окна. Кнопка создаётся размером 18 на 18, а `Padding` у неё оставался дефолтным, который в Avalonia больше самой кнопки. Знак вопроса вытеснялся за границы, и вместо кружка «?» рисовался пустой серый квадрат. Проверено снимком: в главном окне (`Main.BaseListHelp`) справка выглядела так же. Сняты отступы, содержимое центрировано, добавлено скругление, чтобы форма совпала с шаблоном `HelpQuestionButton` из `Controls/HelpLink.xaml`.

## Проверено

* Сборка Linux: `dotnet build "Configuration Management/Configuration Management.csproj" -f net10.0` — **0 ошибок, 15 предупреждений**, столько же, сколько на чистом `main`, новых нет.
* Прогоном на живом окне: кнопка «?» стоит в правом верхнем углу шапки, по клику открывается карточка «Подсказка» с полным текстом, включая новые пункты про поиск и сортировку. Пояснение переносится на две строки и читается целиком. Поиск по имени группы и сортировка работают как прежде.
* Раскладка на минимальной ширине (`MinWidth = 440`): иконка 40 и справка 18 резервируют свои полосы, заголовку остаётся 318 точек, подзаголовок в них помещается и при необходимости переносится.

## Что осталось за рамками этого PR

* **Windows/WPF.** Ту же кнопку в `GroupPickerWindow.xaml` готовит Windows-сторона, поэтому файл здесь не тронут.
* **Текст справки говорит только про группы.** Окно открывается из шести мест, и в четырёх из них выбирается группа для информационной базы (`CreateInfobaseWindow`, `ConnectionSettingsWindow`, обе платформы), а `GroupPicker.Help`, `GroupPicker.Title` и `GroupPicker.Subtitle` описывают только размещение группы внутри группы. Пока ключ был сиротой, этого никто не видел; теперь текст станет виден и в тех окнах. Правка текста не входит в этот PR, скажите, заводить ли отдельный issue.
* **Справки нет в семи других окнах Avalonia**, где в разметке WPF она есть: `AddEdit`, `ConnectionSettings`, `CreateInfobase`, `DeleteInfobase`, `GroupEdit`, `LaunchParameters` (два места), `Settings` (три места) и фильтр тегов в главном окне. Одиннадцать мест, недостижимых на Linux. Готов дотянуть отдельным PR, если это в тему.

Зависимостей от других PR нет, ветка стоит прямо на `main` (520b3b6).
