### PR TITLE
Linux/Avalonia: вкладка «Клавиши» приведена к разметке WPF; цифровые сочетания молча не срабатывали

### DIFF
--- a/Configuration Management/Controls/HotkeyBox.Avalonia.cs
+++ b/Configuration Management/Controls/HotkeyBox.Avalonia.cs
@@ -109,6 +109,13 @@ namespace Configuration_Management.Controls
                 _ => parts[^1]
             };
 
+            // Цифра показывается как «1», а Enum.TryParse принимает такую строку
+            // за числовое значение перечисления и отдаёт Key.Cancel вместо Key.D1.
+            // Сочетание при этом сохраняется и регистрируется, но не срабатывает
+            // никогда. Возвращаем цифре её имя до разбора.
+            if (parts[^1].Length == 1 && parts[^1][0] >= '0' && parts[^1][0] <= '9')
+                parts[^1] = "D" + parts[^1];
+
             // Последняя часть должна быть именно клавишей, а не модификатором:
             // «Ctrl» сам по себе Avalonia разбирает в жест с Key.None.
             if (!Enum.TryParse<Key>(parts[^1], true, out var key) || key == Key.None)

--- a/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
+++ b/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
@@ -300,6 +300,9 @@ public class MainViewModel : ViewModelBase
     public ICommand AddTagInlineCommand { get; private set; } = null!;
     public ICommand RemoveTagCommand { get; private set; } = null!;
     public ICommand ClearTagFiltersCommand { get; private set; } = null!;
+    public ICommand ShowAllCommand { get; private set; } = null!;
+    public ICommand ShowFavoritesCommand { get; private set; } = null!;
+    public ICommand ShowRecentCommand { get; private set; } = null!;
     public ICommand LaunchEnterpriseCommand { get; private set; } = null!;
     public ICommand LaunchConfiguratorCommand { get; private set; } = null!;
 
@@ -349,6 +352,11 @@ public class MainViewModel : ViewModelBase
         AddTagInlineCommand = new RelayCommand(AddTagInline);
         RemoveTagCommand = new RelayCommand(RemoveTag);
         ClearTagFiltersCommand = new RelayCommand(ClearTagFilters);
+        // Режимы списка вынесены в команды, чтобы их можно было повесить
+        // на горячую клавишу: привязка принимает команду, а не свойство.
+        ShowAllCommand = new RelayCommand(() => IsListModeAll = true);
+        ShowFavoritesCommand = new RelayCommand(() => IsListModeFavorites = true);
+        ShowRecentCommand = new RelayCommand(() => IsListModeRecent = true);
         LaunchEnterpriseCommand = new RelayCommand(_ => Launch(_launchVm.LaunchCommand, LaunchKind.Enterprise), _ => SelectedInfobase is not null);
         LaunchConfiguratorCommand = new RelayCommand(_ => Launch(_launchVm.LaunchCommand, LaunchKind.Configurator), _ => SelectedInfobase is not null);
         LaunchEnterpriseWithParamsCommand = new RelayCommand(_ => LaunchWithParams(LaunchKind.Enterprise), _ => SelectedInfobase is not null);
@@ -610,13 +618,17 @@ public class MainViewModel : ViewModelBase
     public string HotkeyPin => _settings.HotkeyPin;
     public string HotkeyDelete => _settings.HotkeyDelete;
     public string HotkeyClearCache => _settings.HotkeyClearCache;
+    public string HotkeyShowAll => _settings.HotkeyShowAll;
+    public string HotkeyShowFavorites => _settings.HotkeyShowFavorites;
+    public string HotkeyShowRecent => _settings.HotkeyShowRecent;
 
     /// <summary>
     /// Сохраняет назначенные сочетания и сообщает окну, что их надо
     /// перерегистрировать: подписи в меню и сами привязки берутся отсюда.
     /// </summary>
     public void ApplyHotkeys(string enterprise, string configurator, string edit, string add,
-        string favorite, string pin, string delete, string clearCache)
+        string favorite, string pin, string delete, string clearCache,
+        string showAll, string showFavorites, string showRecent)
     {
         _settings.HotkeyEnterprise = enterprise ?? string.Empty;
         _settings.HotkeyConfigurator = configurator ?? string.Empty;
@@ -626,6 +638,9 @@ public class MainViewModel : ViewModelBase
         _settings.HotkeyPin = pin ?? string.Empty;
         _settings.HotkeyDelete = delete ?? string.Empty;
         _settings.HotkeyClearCache = clearCache ?? string.Empty;
+        _settings.HotkeyShowAll = showAll ?? string.Empty;
+        _settings.HotkeyShowFavorites = showFavorites ?? string.Empty;
+        _settings.HotkeyShowRecent = showRecent ?? string.Empty;
 
         SaveSettingsSilently();
 
@@ -637,6 +652,9 @@ public class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(HotkeyPin));
         OnPropertyChanged(nameof(HotkeyDelete));
         OnPropertyChanged(nameof(HotkeyClearCache));
+        OnPropertyChanged(nameof(HotkeyShowAll));
+        OnPropertyChanged(nameof(HotkeyShowFavorites));
+        OnPropertyChanged(nameof(HotkeyShowRecent));
         HotkeysChanged?.Invoke(this, EventArgs.Empty);
     }
 

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -3684,6 +3684,10 @@ namespace Configuration_Management
             AddHotkey(_vm.HotkeyFavorite, _vm.ToggleFavoriteCommand);
             AddHotkey(_vm.HotkeyPin, _vm.TogglePinCommand);
             AddHotkey(_vm.HotkeyClearCache, _vm.ClearCacheCommand);
+            // Переключение режимов списка баз: Все, Избранное, Недавние.
+            AddHotkey(_vm.HotkeyShowAll, _vm.ShowAllCommand);
+            AddHotkey(_vm.HotkeyShowFavorites, _vm.ShowFavoritesCommand);
+            AddHotkey(_vm.HotkeyShowRecent, _vm.ShowRecentCommand);
         }
 
         /// <summary>

--- a/Configuration Management/Views/SettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/SettingsWindow.Avalonia.cs
@@ -1129,25 +1129,39 @@ namespace Configuration_Management
 
             // ===== Клавиши =====
             var hotkeys = new StackPanel { Spacing = 10 };
-            hotkeys.Children.Add(new TextBlock
+            var hotkeysTitle = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Margin = new Thickness(0, 0, 0, 2)
+            };
+            hotkeysTitle.Children.Add(new TextBlock
             {
                 Text = LocalizationManager.T("Settings.Hotkeys.Title"),
                 FontWeight = FontWeight.SemiBold,
-                Margin = new Thickness(0, 0, 0, 6)
+                VerticalAlignment = VerticalAlignment.Center
             });
+            hotkeysTitle.Children.Add(new Controls.HelpLink
+            {
+                HelpText = LocalizationManager.T("Settings.Hotkeys.HelpText"),
+                Margin = new Thickness(6, 0, 0, 0)
+            });
+            hotkeys.Children.Add(hotkeysTitle);
+            hotkeys.Children.Add(Hint(LocalizationManager.T("Settings.Hotkeys.Description")));
 
             // Поля назначения: HotkeyBox ловит сочетание с клавиатуры, Delete
-            // снимает назначение, Escape отменяет ввод.
-            var hotkeyEnterprise = HotkeyRow(hotkeys, LocalizationManager.T("Main.LaunchEnterprise"), _viewModel.HotkeyEnterprise);
-            var hotkeyConfigurator = HotkeyRow(hotkeys, LocalizationManager.T("Main.SectionConfigurator"), _viewModel.HotkeyConfigurator);
-            var hotkeyEdit = HotkeyRow(hotkeys, LocalizationManager.T("Main.EditSettings"), _viewModel.HotkeyEdit);
-            var hotkeyAdd = HotkeyRow(hotkeys, LocalizationManager.T("Main.AddBaseOrGroup"), _viewModel.HotkeyAdd);
-            var hotkeyFavorite = HotkeyRow(hotkeys, LocalizationManager.T("Main.Favorites"), _viewModel.HotkeyFavorite);
-            var hotkeyPin = HotkeyRow(hotkeys, LocalizationManager.T("Main.Pin"), _viewModel.HotkeyPin);
-            var hotkeyDelete = HotkeyRow(hotkeys, LocalizationManager.T("Common.Delete"), _viewModel.HotkeyDelete);
-            var hotkeyClearCache = HotkeyRow(hotkeys, LocalizationManager.T("Main.ClearCache"), _viewModel.HotkeyClearCache);
-
-            hotkeys.Children.Add(Hint(LocalizationManager.T("Hotkey.Tooltip")));
+            // снимает назначение, Escape отменяет ввод. Подписи и порядок строк
+            // взяты из разметки WPF (SettingsWindow.xaml, вкладка «Клавиши»).
+            var hotkeyEnterprise = HotkeyRow(hotkeys, LocalizationManager.T("Settings.Hotkeys.Enterprise"), _viewModel.HotkeyEnterprise);
+            var hotkeyConfigurator = HotkeyRow(hotkeys, LocalizationManager.T("Settings.Hotkeys.Configurator"), _viewModel.HotkeyConfigurator);
+            var hotkeyFavorite = HotkeyRow(hotkeys, LocalizationManager.T("Settings.Hotkeys.Favorites"), _viewModel.HotkeyFavorite);
+            var hotkeyEdit = HotkeyRow(hotkeys, LocalizationManager.T("Settings.Hotkeys.Edit"), _viewModel.HotkeyEdit);
+            var hotkeyDelete = HotkeyRow(hotkeys, LocalizationManager.T("Settings.Hotkeys.Delete"), _viewModel.HotkeyDelete);
+            var hotkeyClearCache = HotkeyRow(hotkeys, LocalizationManager.T("Settings.Hotkeys.ClearCache"), _viewModel.HotkeyClearCache);
+            var hotkeyAdd = HotkeyRow(hotkeys, LocalizationManager.T("Settings.Hotkeys.AddBase"), _viewModel.HotkeyAdd);
+            var hotkeyPin = HotkeyRow(hotkeys, LocalizationManager.T("Settings.Hotkeys.Pin"), _viewModel.HotkeyPin);
+            var hotkeyShowAll = HotkeyRow(hotkeys, LocalizationManager.T("Settings.Hotkeys.ShowAll"), _viewModel.HotkeyShowAll);
+            var hotkeyShowFavorites = HotkeyRow(hotkeys, LocalizationManager.T("Settings.Hotkeys.ShowFavorites"), _viewModel.HotkeyShowFavorites);
+            var hotkeyShowRecent = HotkeyRow(hotkeys, LocalizationManager.T("Settings.Hotkeys.ShowRecent"), _viewModel.HotkeyShowRecent);
 
             tabs.Items.Add(new TabItem { Header = LocalizationManager.T("Settings.TabHotkeys"), Content = new ScrollViewer { Content = hotkeys, VerticalScrollBarVisibility = ScrollBarVisibility.Auto } });
 
@@ -1169,16 +1183,22 @@ namespace Configuration_Management
             {
                 // Проверка дублей идёт первой: иначе при конфликте окно
                 // остаётся открытым, а часть настроек уже на диске.
+                // Имена действий в сообщении о дубле берутся не из подписей вкладки:
+                // там они с двоеточием на конце и в предложение не встают. Набор
+                // ключей тот же, что в проверке WPF (SettingsWindow.xaml.cs:149).
                 var assignments = new (string Action, Controls.HotkeyBox Box)[]
                 {
-                    (LocalizationManager.T("Main.LaunchEnterprise"), hotkeyEnterprise),
+                    (LocalizationManager.T("Main.Enterprise"), hotkeyEnterprise),
                     (LocalizationManager.T("Main.SectionConfigurator"), hotkeyConfigurator),
-                    (LocalizationManager.T("Main.EditSettings"), hotkeyEdit),
-                    (LocalizationManager.T("Main.AddBaseOrGroup"), hotkeyAdd),
                     (LocalizationManager.T("Main.Favorites"), hotkeyFavorite),
-                    (LocalizationManager.T("Main.Pin"), hotkeyPin),
+                    (LocalizationManager.T("Main.EditShort"), hotkeyEdit),
                     (LocalizationManager.T("Common.Delete"), hotkeyDelete),
-                    (LocalizationManager.T("Main.ClearCache"), hotkeyClearCache)
+                    (LocalizationManager.T("Main.ClearCache"), hotkeyClearCache),
+                    (LocalizationManager.T("Main.AddBase"), hotkeyAdd),
+                    (LocalizationManager.T("Main.Pin"), hotkeyPin),
+                    (LocalizationManager.T("Main.AllBasesTooltip"), hotkeyShowAll),
+                    (LocalizationManager.T("Main.FavoritesTooltip"), hotkeyShowFavorites),
+                    (LocalizationManager.T("Main.RecentTooltip"), hotkeyShowRecent)
                 };
 
                 if (!ValidateHotkeys(assignments))
@@ -1224,7 +1244,8 @@ namespace Configuration_Management
 
                 _viewModel.ApplyHotkeys(
                     hotkeyEnterprise.Value, hotkeyConfigurator.Value, hotkeyEdit.Value, hotkeyAdd.Value,
-                    hotkeyFavorite.Value, hotkeyPin.Value, hotkeyDelete.Value, hotkeyClearCache.Value);
+                    hotkeyFavorite.Value, hotkeyPin.Value, hotkeyDelete.Value, hotkeyClearCache.Value,
+                    hotkeyShowAll.Value, hotkeyShowFavorites.Value, hotkeyShowRecent.Value);
 
                 // Настройки отображения применяются и сохраняются одним вызовом.
                 // Видимость колонок читается из тех же элементов списка, где

--- a/Configuration Management/Views/SettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/SettingsWindow.Avalonia.cs
@@ -1128,7 +1128,9 @@ namespace Configuration_Management
             });
 
             // ===== Клавиши =====
-            var hotkeys = new StackPanel { Spacing = 10 };
+            // Spacing не задаётся: в Avalonia он складывается с полями соседей,
+            // а поля строк взяты из разметки WPF и уже держат нужный шаг.
+            var hotkeys = new StackPanel();
             var hotkeysTitle = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
@@ -1146,7 +1148,9 @@ namespace Configuration_Management
                 Margin = new Thickness(6, 0, 0, 0)
             });
             hotkeys.Children.Add(hotkeysTitle);
-            hotkeys.Children.Add(Hint(LocalizationManager.T("Settings.Hotkeys.Description")));
+            var hotkeysHint = Hint(LocalizationManager.T("Settings.Hotkeys.Description"));
+            hotkeysHint.Margin = new Thickness(0, 0, 0, 8);
+            hotkeys.Children.Add(hotkeysHint);
 
             // Поля назначения: HotkeyBox ловит сочетание с клавиатуры, Delete
             // снимает назначение, Escape отменяет ввод. Подписи и порядок строк
@@ -1185,7 +1189,9 @@ namespace Configuration_Management
                 // остаётся открытым, а часть настроек уже на диске.
                 // Имена действий в сообщении о дубле берутся не из подписей вкладки:
                 // там они с двоеточием на конце и в предложение не встают. Набор
-                // ключей тот же, что в проверке WPF (SettingsWindow.xaml.cs:149).
+                // ключей тот же, что в массиве assigned проверки WPF
+                // (Views/SettingsWindow.xaml.cs): номер строки там сдвинется
+                // при первом же обновлении от автора, имя переменной нет.
                 var assignments = new (string Action, Controls.HotkeyBox Box)[]
                 {
                     (LocalizationManager.T("Main.Enterprise"), hotkeyEnterprise),
@@ -1438,14 +1444,16 @@ namespace Configuration_Management
         /// <summary>Строка переназначения: подпись действия и поле ввода сочетания.</summary>
         private static Controls.HotkeyBox HotkeyRow(Panel host, string action, string value)
         {
-            var grid = new Grid { Margin = new Thickness(0, 2) };
+            // Раскладка строки из разметки WPF: подпись в колонке 170, поле тянется
+            // по остатку ширины, шаг между строками 6.
+            var grid = new Grid { Margin = new Thickness(0, 0, 0, 6) };
+            grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(170)));
             grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-            grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(190)));
 
             var label = new TextBlock { Text = action, VerticalAlignment = VerticalAlignment.Center };
             grid.Children.Add(label);
 
-            var box = new Controls.HotkeyBox { Value = value ?? string.Empty, HorizontalAlignment = HorizontalAlignment.Right, Width = 180 };
+            var box = new Controls.HotkeyBox { Value = value ?? string.Empty, HorizontalAlignment = HorizontalAlignment.Stretch, Height = 34 };
             Grid.SetColumn(box, 1);
             grid.Children.Add(box);
 


### PR DESCRIPTION
Ветка стоит на `520b3b6` (0.3.5.10). Изменены только файлы Avalonia, WPF-цель не затронута.
Сборка Linux самой ветки PR: 0 ошибок, 15 предупреждений, набор тот же, что на чистом `main`
(множества сверены пересборкой с `--no-incremental` на обеих ветках, разница пуста).

Пересечений с открытым PR 86 нет: в его диффе слово `Hotkey` не встречается ни разу.

## Что было не так

Вкладка «Клавиши» в Avalonia расходилась с разметкой WPF по трём пунктам:

1. **Подписи брались из чужих ключей.** В коде стояли `Main.LaunchEnterprise`,
   `Main.SectionConfigurator`, `Main.EditSettings`, `Main.AddBaseOrGroup`, `Common.Delete`,
   хотя для этой вкладки в `Views/SettingsWindow.xaml` есть свой набор `Settings.Hotkeys.*`
   (строки 973-1028). Порядок строк тоже был другой.
2. **Не было заголовка со справкой и описания вкладки.** В разметке WPF это
   `Settings.Hotkeys.Title` с `controls:HelpLink` и `Settings.Hotkeys.Description`
   (строки 946-953).
3. **Не было трёх полей назначения:** показать все базы, показать избранное,
   показать недавние. При этом значения давно лежат в общей с WPF модели настроек
   (`Models/AppSettings.cs:241,244,247`), просто Linux-версия их не читала и не писала.

## Что сделано

* Подписи и порядок строк выровнены по разметке WPF: 11 строк вместо 8, порядок
  буквальный (Enterprise, Configurator, Favorites, Edit, Delete, ClearCache, AddBase,
  Pin, ShowAll, ShowFavorites, ShowRecent).
* Добавлен заголовок с кнопкой справки (`Settings.Hotkeys.HelpText`) и описание вкладки.
* Добавлены три поля назначения. Режимы списка вынесены в команды `ShowAllCommand`,
  `ShowFavoritesCommand`, `ShowRecentCommand`: привязка клавиши принимает команду,
  а свойство `IsListModeAll` на неё не повесить. Путь у команд тот же, что у сегментных
  кнопок сверху, через `SetListMode`.
* Новые поля участвуют в проверке дублей. Имена действий в сообщении берутся из тех же
  ключей, что в WPF (`Main.AllBasesTooltip` и соседние, `Views/SettingsWindow.xaml.cs:149`),
  а не из подписей вкладки: у подписей на конце двоеточие, и в предложение они не встают.
* Нижняя подсказка `Hotkey.Tooltip` снята: описание вкладки говорит то же самое.
  Ключ не осиротел, он остаётся подсказкой на самом поле
  (`Controls/HotkeyBox.Avalonia.cs:39`, как и `Controls/HotkeyBox.cs:49` в WPF).
* Плотность и раскладка строки приведены к разметке WPF: подпись в колонке 170,
  поле тянется по остатку ширины, шаг между строками 6. У контейнера снят `Spacing`:
  в Avalonia он складывается с полями соседей, из-за чего вкладка выходила вдвое выше
  образца. Одиннадцать строк теперь видны без прокрутки.

## Заодно вылечен дефект, из-за которого цифровые сочетания не работали

Назначить `Alt+1` можно было и раньше, оно сохранялось и регистрировалось, но клавиша
не срабатывала никогда, и никакого сообщения пользователь не видел.

Причина в `Controls/HotkeyBox.Avalonia.cs`: поле показывает клавишу как «1»
(`KeyToDisplay` разворачивает `Key.D1` в цифру), а при обратном разборе
`Enum.TryParse<Key>("1", ...)` принимает строку за **числовое значение перечисления**
и отдаёт `Key.Cancel` (значение 1), а не `Key.D1`. Проверка «безопасно ли сочетание»
получает уже подменённый жест и молчит. Правка возвращает цифре имя (`D1`) до разбора.

Проверено прогоном: `Alt+1`, назначенный показу всех баз, переключает режим списка.

**В WPF ошибка ровно та же** (`Controls/HotkeyBox.cs:135` и `Views/MainWindow.Hotkeys.cs:108`,
там тот же `Enum.TryParse`), но Windows-цель я не трогаю. Правка на той стороне
такая же в три строки, если решите её брать.

Для этого PR дефект не посторонний: три добавленных действия (показать все базы,
избранное, недавние) это ровно те, которым цифра назначается в первую очередь.

## Проверено запуском, а не сборкой

* F6 назначен показу избранного, сохранён в `settings.json` как
  `HotkeyShowFavorites: "F6"`, после сохранения переключает режим списка без перезапуска,
  при повторном открытии окна возвращается в поле.
* Дубль F6 на двух действиях останавливает сохранение предупреждением
  «F6 назначена для: Все базы, Избранные базы».
* Карточка справки по кнопке «?» открывается и показывает текст целиком.

## Чего в этом PR нет намеренно

**Секция «Порядок избранного»** (`SettingsWindow.xaml`, строки 1030-1075: список слотов
Alt+1 … Alt+9 и кнопки перемещения). Она не перенесена, потому что в Avalonia-ветке нет
самого механизма: `FavoriteHotkeyIds` и `FavoriteHotkeyNumber` из общей модели читает
только WPF-сторона, Alt+цифра в главном окне не регистрируется, номер слота в строке
списка не показывается. Настройка порядка без этого ничего бы не меняла. Это следующий
кусок, отдельным PR.

## Два расхождения с WPF, которые нашлись при разборе и в этот PR не вошли

1. **Delete, назначенный не действию «Удалить», уходит в привязки окна.**
   `HotkeyDelete` намеренно не идёт в `KeyBindings` и обрабатывается отдельно
   с проверкой фокуса (`Views/MainWindow.Avalonia.cs`), потому что привязки окна
   проверяются раньше поля ввода. Но защита привязана к действию, а не к клавише:
   если снять назначение у «Удалить», ту же клавишу можно отдать любому другому
   действию, и она пройдёт в `KeyBindings`, после чего Delete в поле поиска начнёт
   удалять базу. Дефект был и до правки, на восьми действиях; правка расширяет
   площадь до одиннадцати. Чинится обобщением уже принятого решения на любое
   назначение с текстовой клавишей без модификатора, но это правка механизма
   регистрации, а не вкладки, поэтому отдельным куском.
2. **Проверка дублей останавливается на первом конфликте** и называет два действия
   (`Views/SettingsWindow.Avalonia.cs`, `ValidateHotkeys`), тогда как в WPF конфликты
   группируются и показываются все сразу (`Views/SettingsWindow.xaml.cs:163`). Код
   авторский, диффом не вводился, поэтому трогать его в правке про подписи я не стал.
   Если хотите, приведу к WPF отдельной правкой.
3. **Заголовок вкладки без значка.** В разметке WPF заголовок каждой вкладки настроек
   это `StackPanel` со значком и подписью (`Views/SettingsWindow.xaml:935`), у нас
   значок есть только у вкладки резервного копирования, остальные семь заголовков
   текстовые. Добавлять значок одной вкладке значит рассогласовать окно ещё сильнее,
   поэтому это отдельная работа сразу по всем восьми. К ней же относится дефект,
   который видно на вкладке резервного копирования: у `Path` не задан `Stretch`,
   и значок в координатах до 22 рисуется поверх подписи в элементе шириной 16.

## Мелочь на ваше решение

Ключ `Main.AddBaseOrGroup` после этой правки остался без потребителей: оба его
использования были в перенесённых подписях. Он апстримный и лежит в общих языковых
файлах (`Localization/Languages/ru.json:71`, `en.json:71`), поэтому удалять его я
не стал: если он вам ещё пригодится для WPF-стороны, пусть лежит.
