### PR TITLE
Linux/Avalonia: запоминание геометрии окна не работало; три настройки поведения были недоступны

### DIFF
--- a/Configuration Management/App.axaml.cs
+++ b/Configuration Management/App.axaml.cs
@@ -27,6 +27,15 @@ namespace Configuration_Management
         private static CancellationTokenSource? _activateCts;
         private static IClassicDesktopStyleApplicationLifetime? _desktopLifetime;
 
+        /// <summary>
+        /// Работает ли режим единственного экземпляра: блокировка взята и сигнал
+        /// от повторного запуска слушается. Значение относится к текущему
+        /// процессу и после старта не меняется, даже если настройку переключат:
+        /// блокировка берётся один раз, и снятый в окне настроек флажок не
+        /// делает окно возвращаемым повторным запуском.
+        /// </summary>
+        internal static bool SingleInstanceActive { get; private set; }
+
         private const string LockFileName = "configuration-management.lock";
         private const string ActivateFileName = "activate";
 
@@ -144,6 +153,7 @@ namespace Configuration_Management
                     }
                     // Слушаем сигнал от повторных запусков, чтобы поднять окно.
                     StartActivationListener();
+                    SingleInstanceActive = true;
                 }
 
                 if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)

--- a/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
+++ b/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
@@ -149,7 +149,6 @@ public class MainViewModel : ViewModelBase
     /// <summary>Настройки трея изменились: окну нужно обновить значок.</summary>
     public event Action? TraySettingsChanged;
 
-    /// <summary>Применяет настройки поведения трея из окна настроек.</summary>
     /// <summary>
     /// Применяет настройки поведения приложения. Обе лежали в общем с версией
     /// для Windows файле настроек, но в Linux-сборке их нечем было изменить.
@@ -165,6 +164,7 @@ public class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(RememberWindowLayout));
     }
 
+    /// <summary>Применяет настройки поведения трея из окна настроек.</summary>
     public void ApplyTraySettings(bool showTrayIcon, bool closeToTray, bool escapeToTray)
     {
         _settings.ShowTrayIcon = showTrayIcon;

--- a/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
+++ b/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
@@ -106,6 +106,37 @@ public class MainViewModel : ViewModelBase
     /// </summary>
     public bool AllowMultipleInstances => _settings.AllowMultipleInstances;
 
+    /// <summary>
+    /// Запоминать ли размер, положение и состояние главного окна между запусками.
+    /// </summary>
+    public bool RememberWindowLayout => _settings.RememberWindowLayout;
+
+    /// <summary>Сохранённая ширина главного окна; ноль означает «не сохранялась».</summary>
+    public double SavedWindowWidth => _settings.WindowWidth;
+
+    /// <summary>Сохранённая высота главного окна; ноль означает «не сохранялась».</summary>
+    public double SavedWindowHeight => _settings.WindowHeight;
+
+    /// <summary>Сохранённая позиция главного окна по горизонтали.</summary>
+    public double SavedWindowLeft => _settings.WindowLeft;
+
+    /// <summary>Сохранённая позиция главного окна по вертикали.</summary>
+    public double SavedWindowTop => _settings.WindowTop;
+
+    /// <summary>Сохранённое состояние главного окна (Normal, Maximized).</summary>
+    public string SavedWindowState => _settings.WindowState;
+
+    /// <summary>Сохраняет размер, положение и состояние главного окна.</summary>
+    public void SaveWindowLayout(double width, double height, double left, double top, string state)
+    {
+        _settings.WindowWidth = width;
+        _settings.WindowHeight = height;
+        _settings.WindowLeft = left;
+        _settings.WindowTop = top;
+        _settings.WindowState = state ?? string.Empty;
+        SaveSettingsSilently();
+    }
+
     /// <summary>Показывать ли значок в области уведомлений.</summary>
     public bool ShowTrayIcon => _settings.ShowTrayIcon;
 
@@ -119,6 +150,21 @@ public class MainViewModel : ViewModelBase
     public event Action? TraySettingsChanged;
 
     /// <summary>Применяет настройки поведения трея из окна настроек.</summary>
+    /// <summary>
+    /// Применяет настройки поведения приложения. Обе лежали в общем с версией
+    /// для Windows файле настроек, но в Linux-сборке их нечем было изменить.
+    /// </summary>
+    public void ApplyBehaviorSettings(bool allowMultipleInstances, bool rememberWindowLayout)
+    {
+        _settings.AllowMultipleInstances = allowMultipleInstances;
+        _settings.RememberWindowLayout = rememberWindowLayout;
+        if (!SaveSettingsSafe())
+            _dialog.ShowError(LocalizationManager.T("Main.SaveFailedHint"),
+                LocalizationManager.T("Settings.Title"));
+        OnPropertyChanged(nameof(AllowMultipleInstances));
+        OnPropertyChanged(nameof(RememberWindowLayout));
+    }
+
     public void ApplyTraySettings(bool showTrayIcon, bool closeToTray, bool escapeToTray)
     {
         _settings.ShowTrayIcon = showTrayIcon;

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -4002,7 +4002,11 @@ namespace Configuration_Management
                 Position = ClampToScreen(new PixelPoint((int)Math.Round(left), (int)Math.Round(top)));
             }
 
+            // IsDefined обязателен: TryParse принимает и числовую строку, даже
+            // когда числа нет среди членов перечисления, и «999» дошло бы
+            // до окна. Тот же класс ошибки уже стрелял на разборе клавиш.
             if (Enum.TryParse<WindowState>(settings.WindowState, out var state)
+                && Enum.IsDefined(state)
                 && state != WindowState.Minimized)
             {
                 WindowState = state;

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -99,7 +99,7 @@ namespace Configuration_Management
             Height = 760;
             MinWidth = 900;
             MinHeight = 600;
-            WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            ApplySavedWindowLayout();
 
             DataContext = viewModel;
 
@@ -3948,6 +3948,118 @@ namespace Configuration_Management
         private static WindowIcon? LoadTrayIcon() => Services.AppIconLoader.LoadAppIcon();
 
         /// <summary>
+        /// Восстанавливает сохранённые размер, позицию и состояние окна.
+        /// Настройки читаются здесь из репозитория, а не из модели: она
+        /// загружает их только в Initialize по событию Loaded, то есть уже
+        /// после того, как окно построено и показано.
+        /// </summary>
+        private void ApplySavedWindowLayout()
+        {
+            Models.AppSettings settings;
+            try
+            {
+                settings = AppServices.GetRequiredService<Services.IInfobaseRepository>().LoadSettings();
+            }
+            catch
+            {
+                // Настройки недоступны: окно открывается по центру, как раньше.
+                WindowStartupLocation = WindowStartupLocation.CenterScreen;
+                return;
+            }
+
+            if (!settings.RememberWindowLayout)
+            {
+                WindowStartupLocation = WindowStartupLocation.CenterScreen;
+                return;
+            }
+
+            if (settings.WindowWidth > 0 && settings.WindowHeight > 0)
+            {
+                Width = settings.WindowWidth;
+                Height = settings.WindowHeight;
+            }
+
+            var left = settings.WindowLeft;
+            var top = settings.WindowTop;
+            if (left == 0 && top == 0)
+            {
+                WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            }
+            else
+            {
+                WindowStartupLocation = WindowStartupLocation.Manual;
+                Position = ClampToScreen(new PixelPoint((int)Math.Round(left), (int)Math.Round(top)));
+            }
+
+            if (Enum.TryParse<WindowState>(settings.WindowState, out var state)
+                && state != WindowState.Minimized)
+            {
+                WindowState = state;
+            }
+        }
+
+        /// <summary>
+        /// Прижимает позицию к рабочей области монитора, на котором окно закрыли,
+        /// чтобы оно не оказалось за границей экрана после смены конфигурации мониторов.
+        /// </summary>
+        private PixelPoint ClampToScreen(PixelPoint point)
+        {
+            Screen? screen;
+            try
+            {
+                screen = Screens.ScreenFromPoint(point);
+            }
+            catch
+            {
+                // Сведений об экранах может не быть: на Wayland их отдаёт
+                // не всякий сервер. Тогда позиция остаётся как сохранена.
+                return point;
+            }
+
+            if (screen is null)
+                return point;
+
+            var area = screen.WorkingArea;
+            var scaling = screen.Scaling > 0 ? screen.Scaling : 1.0;
+            var width = Math.Min((int)Math.Round(Width * scaling), area.Width);
+            var height = Math.Min((int)Math.Round(Height * scaling), area.Height);
+            return new PixelPoint(
+                Math.Max(area.X, Math.Min(point.X, area.Right - width)),
+                Math.Max(area.Y, Math.Min(point.Y, area.Bottom - height)));
+        }
+
+        /// <summary>
+        /// Сохраняет размер, позицию и состояние окна. Позиция пишется в физических
+        /// пикселях: в Avalonia Position задан в них, в отличие от Left и Top в WPF.
+        /// </summary>
+        private void SaveWindowLayout()
+        {
+            if (_vm is null)
+                return;
+
+            if (!_vm.RememberWindowLayout)
+            {
+                // Настройка выключена: сохранённый макет сбрасывается, иначе
+                // следующий запуск открыл бы окно в старом месте и размере.
+                if (_vm.SavedWindowWidth != 0 || _vm.SavedWindowHeight != 0
+                    || _vm.SavedWindowLeft != 0 || _vm.SavedWindowTop != 0
+                    || !string.IsNullOrEmpty(_vm.SavedWindowState))
+                {
+                    _vm.SaveWindowLayout(0, 0, 0, 0, string.Empty);
+                }
+                return;
+            }
+
+            // Только в обычном состоянии: развёрнутое окно нельзя сохранять
+            // как размер по умолчанию.
+            if (WindowState != WindowState.Normal)
+                return;
+
+            _vm.SaveWindowLayout(Width, Height, Position.X, Position.Y,
+                WindowState.ToString());
+        }
+
+        /// <summary>
         /// Закрытие окна уводит приложение в трей, а не завершает его
         /// (свойство «закрытие в трей»). Реальный выход — команда «Выход».
         /// Перед уходом в трей сохраняем настройки (в т.ч. язык интерфейса),
@@ -3956,6 +4068,7 @@ namespace Configuration_Management
         protected override void OnClosing(WindowClosingEventArgs e)
         {
             base.OnClosing(e);
+            SaveWindowLayout();
             if (_allowCloseToTray && _vm is { CloseToTray: true } && CanRestoreHiddenWindow
                 && e.CloseReason == WindowCloseReason.WindowClosing)
             {

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -107,6 +107,12 @@ namespace Configuration_Management
             Loaded += OnWindowLoaded;
             KeyDown += OnWindowKeyDown;
 
+            // Геометрия обычного состояния запоминается на ходу: у Avalonia нет
+            // аналога RestoreBounds, а развёрнутое окно надо сохранять размером,
+            // к которому оно вернётся.
+            PositionChanged += (_, _) => RememberNormalBounds();
+            SizeChanged += (_, _) => RememberNormalBounds();
+
             // Действие после запуска базы или конфигуратора по глобальной настройке.
             _vm.AfterLaunchRequested += OnAfterLaunchRequested;
 
@@ -141,10 +147,13 @@ namespace Configuration_Management
         /// на GNOME Shell без AppIndicator он не появится, а ошибки при этом не
         /// будет. Второй путь, повторный запуск приложения через файл-сигнал,
         /// работает только пока включён режим единственного экземпляра.
+        /// Берётся состояние текущего процесса, а не настройка: блокировка
+        /// и слушатель сигнала заводятся один раз при старте, и снятый на ходу
+        /// флажок «несколько экземпляров» пути возврата не создаёт.
         /// </summary>
         private bool CanRestoreHiddenWindow =>
             (_trayIconCreated && TrayIconWanted && !Services.LinuxDesktopEnvironment.TrayMayBeUnavailable)
-            || _vm?.AllowMultipleInstances == false;
+            || App.SingleInstanceActive;
 
         /// <summary>Нужен ли значок по настройкам: сам значок либо закрытие в трей.</summary>
         private bool TrayIconWanted => _vm is null || _vm.ShowTrayIcon || _vm.CloseToTray;
@@ -172,6 +181,7 @@ namespace Configuration_Management
                     return;
                 }
 
+                SaveWindowLayout();
                 Hide();
                 if (action == Models.AfterLaunchAction.MinimizeToTray
                     && WindowState == WindowState.Minimized)
@@ -3709,6 +3719,7 @@ namespace Configuration_Management
                 && _vm.EscapeToTray && _vm.ShowTrayIcon && CanRestoreHiddenWindow
                 && FocusManager?.GetFocusedElement() is not TextBox)
             {
+                SaveWindowLayout();
                 _vm.PersistSettings();
                 ApplyTrayVisibility();
                 Hide();
@@ -4007,7 +4018,9 @@ namespace Configuration_Management
             Screen? screen;
             try
             {
-                screen = Screens.ScreenFromPoint(point);
+                // Точка вне всех экранов (монитор отключили) даёт null, а не
+                // исключение: тогда берётся основной, как это делает WPF-версия.
+                screen = Screens.ScreenFromPoint(point) ?? Screens.Primary;
             }
             catch
             {
@@ -4021,8 +4034,11 @@ namespace Configuration_Management
 
             var area = screen.WorkingArea;
             var scaling = screen.Scaling > 0 ? screen.Scaling : 1.0;
-            var width = Math.Min((int)Math.Round(Width * scaling), area.Width);
-            var height = Math.Min((int)Math.Round(Height * scaling), area.Height);
+            // Position это угол рамки, а Width и Height задают клиентскую часть,
+            // поэтому к размеру добавляется то, что рисует менеджер окон.
+            var frame = FrameSize ?? new Size(Width, Height);
+            var width = Math.Min((int)Math.Round(Math.Max(frame.Width, Width) * scaling), area.Width);
+            var height = Math.Min((int)Math.Round(Math.Max(frame.Height, Height) * scaling), area.Height);
             return new PixelPoint(
                 Math.Max(area.X, Math.Min(point.X, area.Right - width)),
                 Math.Max(area.Y, Math.Min(point.Y, area.Bottom - height)));
@@ -4050,13 +4066,51 @@ namespace Configuration_Management
                 return;
             }
 
-            // Только в обычном состоянии: развёрнутое окно нельзя сохранять
-            // как размер по умолчанию.
-            if (WindowState != WindowState.Normal)
+            // У спрятанного окна X11 отдаёт Position со сдвигом на высоту
+            // заголовка, и каждый уход в трей с последующим выходом сдвигал бы
+            // окно вниз. Геометрия такого окна уже записана перед Hide.
+            if (!IsVisible)
                 return;
 
-            _vm.SaveWindowLayout(Width, Height, Position.X, Position.Y,
-                WindowState.ToString());
+            if (WindowState == WindowState.Normal)
+            {
+                RememberNormalBounds();
+            }
+            else if (WindowState == WindowState.Minimized)
+            {
+                // Свёрнутое окно ничего не говорит о своей геометрии.
+                return;
+            }
+
+            // Развёрнутое окно сохраняется своим состоянием, но размером
+            // и положением обычного: иначе следующий запуск взял бы размер
+            // во весь экран как обычный. Так же устроена версия для Windows
+            // (MainWindow.Events.cs, ветка Maximized и RestoreBounds).
+            if (_normalBounds is not { } bounds)
+                return;
+
+            // Ничего не изменилось: лишняя запись настроек при закрытии не нужна.
+            var state = WindowState.ToString();
+            if (bounds.Width == _vm.SavedWindowWidth && bounds.Height == _vm.SavedWindowHeight
+                && bounds.Position.X == _vm.SavedWindowLeft && bounds.Position.Y == _vm.SavedWindowTop
+                && string.Equals(state, _vm.SavedWindowState, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _vm.SaveWindowLayout(bounds.Width, bounds.Height,
+                bounds.Position.X, bounds.Position.Y, state);
+        }
+
+        /// <summary>Геометрия окна в обычном состоянии, чтобы развёрнутое
+        /// сохранялось размером, к которому оно вернётся.</summary>
+        private (double Width, double Height, PixelPoint Position)? _normalBounds;
+
+        /// <summary>Запоминает геометрию, пока окно в обычном состоянии.</summary>
+        private void RememberNormalBounds()
+        {
+            if (WindowState == WindowState.Normal && IsVisible)
+                _normalBounds = (ClientSize.Width, ClientSize.Height, Position);
         }
 
         /// <summary>

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -4010,6 +4010,21 @@ namespace Configuration_Management
         }
 
         /// <summary>
+        /// Уточняет прижатие к экрану после показа окна. В конструкторе размер
+        /// рамки ещё не известен (FrameSize равен null), поэтому там прижатие
+        /// считается по содержимому и оставляет за краем высоту заголовка.
+        /// </summary>
+        protected override void OnOpened(EventArgs e)
+        {
+            base.OnOpened(e);
+            if (WindowStartupLocation == WindowStartupLocation.Manual
+                && WindowState == WindowState.Normal)
+            {
+                Position = ClampToScreen(Position);
+            }
+        }
+
+        /// <summary>
         /// Прижимает позицию к рабочей области монитора, на котором окно закрыли,
         /// чтобы оно не оказалось за границей экрана после смены конфигурации мониторов.
         /// </summary>
@@ -4035,7 +4050,9 @@ namespace Configuration_Management
             var area = screen.WorkingArea;
             var scaling = screen.Scaling > 0 ? screen.Scaling : 1.0;
             // Position это угол рамки, а Width и Height задают клиентскую часть,
-            // поэтому к размеру добавляется то, что рисует менеджер окон.
+            // поэтому размер берётся вместе с тем, что рисует менеджер окон.
+            // До показа окна рамка ещё не известна, и прижатие уточняется
+            // в OnOpened, когда FrameSize уже есть.
             var frame = FrameSize ?? new Size(Width, Height);
             var width = Math.Min((int)Math.Round(Math.Max(frame.Width, Width) * scaling), area.Width);
             var height = Math.Min((int)Math.Round(Math.Max(frame.Height, Height) * scaling), area.Height);

--- a/Configuration Management/Views/SettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/SettingsWindow.Avalonia.cs
@@ -127,12 +127,19 @@ namespace Configuration_Management
             themePanel.Children.Add(darkTheme);
             settings.Children.Add(themePanel);
 
-            // Язык интерфейса
+            // Язык интерфейса. Как в разметке WPF (SettingsWindow.xaml:1088):
+            // заголовок раздела и подпись самой строки это разные ключи.
             settings.Children.Add(new TextBlock
             {
-                Text = LocalizationManager.T("Settings.Language") + ":",
+                Text = LocalizationManager.T("Settings.Language"),
                 FontWeight = FontWeight.SemiBold,
                 Margin = new Thickness(0, 8, 0, 4)
+            });
+            var langRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 10 };
+            langRow.Children.Add(new TextBlock
+            {
+                Text = LocalizationManager.T("Settings.LanguageLabel"),
+                VerticalAlignment = VerticalAlignment.Center
             });
             var langBox = new ComboBox { MinWidth = 220, HorizontalAlignment = HorizontalAlignment.Left };
             langBox.ItemsSource = LocalizationManager.Instance.AvailableLanguages;
@@ -149,7 +156,8 @@ namespace Configuration_Management
                     _viewModel.ApplyLanguage(li.Code);
                 }
             };
-            settings.Children.Add(langBox);
+            langRow.Children.Add(langBox);
+            settings.Children.Add(langRow);
             settings.Children.Add(new TextBlock
             {
                 Text = LocalizationManager.T("Settings.Language.AppliedHint"),
@@ -158,14 +166,33 @@ namespace Configuration_Management
                 Opacity = 0.7
             });
 
+            // Раздел поведения приложения: в разметке WPF (SettingsWindow.xaml:1104)
+            // он начинается своим заголовком, а первым в нём идёт разрешение
+            // нескольких экземпляров.
+            settings.Children.Add(new TextBlock
+            {
+                Text = LocalizationManager.T("Settings.General.Behavior"),
+                FontWeight = FontWeight.SemiBold,
+                Margin = new Thickness(0, 8, 0, 0)
+            });
+
+            // Несколько экземпляров: настройка лежит в общем с версией для
+            // Windows файле и уже учитывается при запуске (App.axaml.cs),
+            // но в Linux-сборке её нечем было изменить.
+            var multipleInstancesCheck = new CheckBox
+            {
+                Content = LocalizationManager.T("Settings.General.AllowMultipleInstances"),
+                IsChecked = _viewModel.AllowMultipleInstances
+            };
+            settings.Children.Add(multipleInstancesCheck);
+
             // Поведение значка в области уведомлений. До этого три настройки
             // жили только в файле и в версии для Windows: в Linux-сборке ни
             // флажков, ни учёта не было.
             var trayIconCheck = new CheckBox
             {
                 Content = LocalizationManager.T("Settings.General.ShowTrayIcon"),
-                IsChecked = _viewModel.ShowTrayIcon,
-                Margin = new Thickness(0, 8, 0, 0)
+                IsChecked = _viewModel.ShowTrayIcon
             };
             var closeToTrayCheck = new CheckBox
             {
@@ -230,6 +257,16 @@ namespace Configuration_Management
             };
             afterLaunchBox.SelectedIndex = (int)Models.AfterLaunchActionHelper.Parse(_viewModel.AfterLaunchAction);
             settings.Children.Add(afterLaunchBox);
+
+            // Запоминание геометрии окна. Значения лежали в общем файле настроек,
+            // но Linux-сборка их не читала и не писала вовсе.
+            var rememberLayoutCheck = new CheckBox
+            {
+                Content = LocalizationManager.T("Settings.General.RememberWindowLayout"),
+                IsChecked = _viewModel.RememberWindowLayout,
+                Margin = new Thickness(0, 8, 0, 0)
+            };
+            settings.Children.Add(rememberLayoutCheck);
 
             // Управление учётными записями (профилями).
             var manageProfilesButton = new Button
@@ -509,6 +546,9 @@ namespace Configuration_Management
             var rightPanelCheck = DisplayCheck("Settings.Panels.RightPanelDetails", _viewModel.ShowRightPanelDetails);
             var sessionPanelCheck = DisplayCheck("Settings.Panels.SessionLaunchPanel", _viewModel.ShowSessionLaunchPanel);
             var groupByGroupCheck = DisplayCheck("Settings.Panels.GroupByGroups", _viewModel.GroupByGroup);
+            // Режим списка «только избранные» тот же, что переключается кнопкой
+            // в главном окне: флажок и кнопка меняют одно значение.
+            var favoritesOnlyCheck = DisplayCheck("Settings.Panels.ShowFavoritesOnly", _viewModel.IsListModeFavorites);
             var emptyGroupsCheck = DisplayCheck("Settings.Panels.ShowEmptyGroups", _viewModel.ShowEmptyGroups);
 
             // Пояснения под переключателями стоят там же, где в разметке WPF
@@ -520,6 +560,7 @@ namespace Configuration_Management
             displayPanels.Children.Add(sessionPanelCheck);
             displayPanels.Children.Add(Hint(LocalizationManager.T("Settings.Panels.SessionLaunchPanelHint")));
             displayPanels.Children.Add(groupByGroupCheck);
+            displayPanels.Children.Add(favoritesOnlyCheck);
             displayPanels.Children.Add(emptyGroupsCheck);
             displayPanels.Children.Add(Hint(LocalizationManager.T("Settings.Panels.ShowEmptyGroupsHint")));
 
@@ -1582,6 +1623,9 @@ namespace Configuration_Management
                 _viewModel.ApplyColorScheme(editedScheme);
 
                 _viewModel.ApplyPlatformSettings(paths, archBox.SelectedItem as string ?? "X64");
+                _viewModel.ApplyBehaviorSettings(
+                    multipleInstancesCheck.IsChecked == true,
+                    rememberLayoutCheck.IsChecked == true);
                 _viewModel.ApplyTraySettings(
                     trayIconCheck.IsChecked == true,
                     closeToTrayCheck.IsChecked == true,
@@ -1635,6 +1679,14 @@ namespace Configuration_Management
                     groupByGroupCheck.IsChecked == true,
                     emptyGroupsCheck.IsChecked == true,
                     orderItems.Select(o => o.Key).ToList());
+
+                // «Только избранные» это режим списка, а не отдельный фильтр:
+                // снятие флажка возвращает список к показу всех баз, но режим
+                // «недавние» не трогает, иначе флажок отменял бы чужой выбор.
+                if (favoritesOnlyCheck.IsChecked == true)
+                    _viewModel.IsListModeFavorites = true;
+                else if (_viewModel.IsListModeFavorites)
+                    _viewModel.IsListModeAll = true;
 
                 _viewModel.ApplyStatusBarSettings(
                     statusPathCheck.IsChecked == true,


### PR DESCRIPTION
Три настройки лежат в общем с версией для Windows файле, но в Linux-сборке их
нечем было изменить, а одна из них не работала вовсе.

## Что было не так

* **`AllowMultipleInstances`.** Учёт уже был (`App.axaml.cs`, ветка с блокировкой
  единственного экземпляра), а флажка не было: выключить режим единственного
  экземпляра в Linux-версии было нечем.
* **`RememberWindowLayout`.** В Avalonia-ветке значение не читалось и не писалось
  вовсе: геометрию главного окна никто не сохранял и не восстанавливал.
  `Views/MainWindow.Events.cs`, где это делает WPF, целиком под `#if WINDOWS`.
  README при этом обещает, что приложение запоминает размер, позицию, состояние
  и монитор окна.
* **`ShowFavoritesOnly`.** У WPF это флажок в разделе «Панели», в Avalonia
  значение служило только хранилищем режима списка, флажка не было.

Плюс две подписи из разметки WPF: заголовок раздела «Поведение приложения»
(`SettingsWindow.xaml:1104`) и подпись строки языка `Settings.LanguageLabel`
(`SettingsWindow.xaml:1091`), вместо которой собиралась конкатенация
`Settings.Language` с двоеточием.

## Что сделано

**Окно настроек** (`Views/SettingsWindow.Avalonia.cs`): заголовок раздела
и два флажка на вкладке «Общие» в порядке разметки WPF, флажок «Показывать
только избранные базы» в разделе «Панели» между «Группировать по группам»
и «Показывать пустые группы», подпись строки языка.

**Запоминание геометрии** (`Views/MainWindow.Avalonia.cs`): восстановление
при открытии, сохранение при закрытии, прижатие к рабочей области монитора,
сброс сохранённого макета при выключенной настройке. Устроено по образцу
`MainWindow.Events.cs`, включая ветку для развёрнутого окна.

**Настройки для геометрии читаются в конструкторе окна из репозитория**
(`AppServices.GetRequiredService<IInfobaseRepository>().LoadSettings()`),
а не из модели. Это не лишний вызов: модель загружает настройки в `Initialize`,
а тот вызывается из обработчика `Loaded`, то есть уже после того, как окно
построено и показано. Первая версия читала из модели и всегда получала нули:
окно молча открывалось по центру с размером по умолчанию, хотя и компиляция,
и дифф выглядели правильными. Тот же приём уже применён
в `Views/CacheCleanWindow.Avalonia.cs`.

## Осознанные расхождения с версией для Windows

* **Позиция пишется в физических пикселях, размер в аппаратно-независимых
  единицах.** В Avalonia `Window.Position` это `PixelPoint`, а `Width`
  и `Height` это единицы компоновки; в WPF `Left`/`Top` и `Width`/`Height`
  однородны. Внутри Linux-стороны запись и чтение симметричны, но файл
  настроек общий, и при масштабе экрана, отличном от 100%, значение,
  записанное одной платформой, другая прочитает со сдвигом. Приводить
  к единицам WPF я не стал: обратное преобразование требует знать масштаб
  того монитора, на котором окно было закрыто, а он в файле не хранится.
  Если предпочтительнее хранить DIP, скажите, переделаю.
* **`Position` это угол рамки, а `Width` и `Height` задают содержимое**, поэтому
  прижатие к экрану уточняется после показа окна: в конструкторе `FrameSize`
  ещё равен `null`, и высота заголовка в расчёт не попадает.
* **Точка вне всех экранов** даёт у `Screens.ScreenFromPoint` штатный `null`,
  и берётся основной экран. WPF в этом случае через `Screen.FromPoint` берёт
  ближайший; при трёх и более мониторах основной может оказаться не ближайшим.
* **Возврат спрятанного окна больше не зависит от самой настройки.** Блокировка
  единственного экземпляра и слушатель сигнала заводятся один раз при старте,
  поэтому снятый на ходу флажок «несколько экземпляров» пути возврата не создаёт.
  Иначе на GNOME без AppIndicator получался бы процесс со спрятанным окном,
  которое нечем показать. Предикат теперь смотрит на `App.SingleInstanceActive`.
* **Флажок «Показывать только избранные базы» в Linux-версии работает,
  а в WPF нет.** Проверьте, пожалуйста, свою сторону: там фильтрация идёт
  по `_listViewMode` (`MainViewModel.Launch.cs`, `MainViewModel.Tools.cs`),
  а `_showFavoritesOnly` (`MainViewModel.Display.cs:145`) пишется в файл
  и больше нигде не читается; `_listViewMode` при старте жёстко `= ListViewMode.All`
  (`MainViewModel.cs:59`). То есть флажок в версии для Windows не даёт
  наблюдаемого эффекта ни в текущем сеансе, ни после перезапуска. В Avalonia
  то же значение и есть режим списка, поэтому флажок переключает список сразу
  и переживает перезапуск. Это не выравнивание по WPF, а расхождение,
  и решать, как быть, вам.

## Чего эта правка не делает

* **Режим «Недавние» не переживает перезапуск.** Настройка булева и закодировать
  три режима не может: при выборе «Недавних» пишется `ShowFavoritesOnly=false`,
  и следующий запуск открывает список в режиме «Все». Поведение было и до правки.
* **Удаление активного профиля.** Окно профилей позволяет удалить текущий профиль
  (`Views/ProfilesWindow.Avalonia.cs`), `ProfileService.DeleteProfile` тут же
  назначает текущим другой, а путь репозитория вычисляется по текущему профилю.
  Настройки удалённого профиля при следующей записи ложатся в файл выжившего.
  Дефект предсуществующий, но сохранение геометрии добавляет ему ещё один путь.
  Чтобы не делать лишних записей, сохранение пропускается, если геометрия
  не менялась.
* **Вертикальные отступы вкладки «Общие» шире, чем в разметке WPF:** `Spacing`
  контейнера в Avalonia складывается с полями соседей. Это касается всей вкладки,
  а не только новых строк, поэтому в этот PR не вошло.
* **Свёрнутое окно** не сохраняется: у него нет осмысленной геометрии.

## Как проверялось

Сборка самой ветки PR отдельно от ветки разработки: 0 ошибок, 15 предупреждений,
тот же набор, что на чистом апстриме.

Прогоном на живом окне, с отдельным каталогом данных:

* окно 1050x680 в позиции 300,200 легло в `settings.json` этими же числами
  и вернулось туда при следующем запуске;
* закрытие развёрнутого окна пишет `WindowState: Maximized` с размером обычного
  (1200x760), следующий запуск открывает окно развёрнутым, возврат из
  развёрнутого даёт ровно 1200x760;
* три цикла «в трей по Esc и выход» подряд дают одну и ту же позицию:
  у спрятанного окна X11 отдаёт `Position` со сдвигом на высоту заголовка,
  поэтому геометрия пишется перед `Hide`, а закрытие спрятанного окна её
  не перезаписывает;
* сохранённая позиция 300,1200 при рабочей области высотой 1336 и заголовке 28
  даёт 548, то есть нижний край рамки ровно на границе;
* `WindowLeft/Top = 99999` прижимается к правому нижнему углу рабочей области;
* `WindowState = "999"` игнорируется (`Enum.TryParse` принимает числовую строку,
  даже когда числа нет среди членов перечисления), окно открывается обычным;
* снятие флажка «Запоминать расположение…» обнуляет макет при закрытии,
  следующий запуск открывает окно по центру с размером по умолчанию;
* «Разрешить несколько экземпляров» после сохранения пускает второй процесс;
* «Показывать только избранные базы» переключает главное окно в режим
  «Избранное» сразу после сохранения.

Правку смотрели три независимых аудитора с разными задачами: сверка с документацией
и reference-сборками Avalonia, чтение вглубь по репозиторию и проверка исполнением.
Найденное ими вошло сюда: дрейф позиции спрятанного окна, потеря развёрнутого
состояния, `null` от `ScreenFromPoint`, прижатие по содержимому вместо рамки,
зависимость возврата окна от изменяемой на ходу настройки и числовые значения
в `Enum.TryParse`.

## Зависимости

Пересечений с PR 82, 85, 86 и 87 нет, все четыре уже смержены. Ветка нарезана
от `80faf46`.
