### PR TITLE
Срочно: на main не собирается Linux-цель после перехода на MaterialMessageWindow (4 ошибки CS0246)

### DIFF
--- a/Configuration Management/Configuration Management.csproj
+++ b/Configuration Management/Configuration Management.csproj
@@ -190,7 +190,6 @@
     <!-- Windows-only сервисы — Этап 5 -->
     <Compile Remove="Services\WpfDialogService.cs" />
     <Compile Remove="Services\MaterialMessageWindow.xaml.cs" />
-    <Compile Remove="Services\MaterialMessageWindow.Avalonia.cs" />
     <Compile Remove="Services\MaterialMessageKind.cs" />
     <Compile Include="Services\MaterialMessageKind.cs" />
     <Compile Remove="Services\OneCLauncher.cs" />

--- a/Configuration Management/Services/AvaloniaDialogService.cs
+++ b/Configuration Management/Services/AvaloniaDialogService.cs
@@ -195,7 +195,7 @@ namespace Configuration_Management.Services
             var frame = new DispatcherFrame();
             window.Closed += (_, _) =>
             {
-                result = window is MessageWindow mw ? mw.Result : true;
+                result = window is MaterialMessageWindowAvalonia mw ? mw.Confirmed : true;
                 frame.Continue = false;
             };
 

--- a/Configuration Management/Services/MaterialMessageWindow.Avalonia.cs
+++ b/Configuration Management/Services/MaterialMessageWindow.Avalonia.cs
@@ -1,6 +1,7 @@
 #if LINUX
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Localization;

--- a/Configuration Management/Views/SettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/SettingsWindow.Avalonia.cs
@@ -2480,7 +2480,7 @@ namespace Configuration_Management
         /// </summary>
         private void ShowAboutMessage(string message)
         {
-            var win = new MessageWindow(message, LocalizationManager.T("Common.Information"), MessageWindowKind.Info)
+            var win = new MaterialMessageWindowAvalonia(message, LocalizationManager.T("Common.Information"), MaterialMessageKind.Info)
             {
                 WindowStartupLocation = WindowStartupLocation.CenterOwner
             };


### PR DESCRIPTION
**Срочное: на `main` цель для Linux сейчас не собирается.**

Проверил сборкой чистого дерева апстрима на `070cc80`, без наших правок:
четыре ошибки `CS0246`. Переход на `MaterialMessageWindowAvalonia`
в коммите `new-version` (`13e7438`) остался незавершённым.

```
dotnet build "Configuration Management/Configuration Management.csproj" -c Release \
  -p:RuntimeIdentifier= -p:SelfContained=false -p:PublishSingleFile=false
```

```
Services/AvaloniaDialogService.cs(37,27):   error CS0246: MaterialMessageWindowAvalonia
Services/AvaloniaDialogService.cs(185,34):  error CS0246: MaterialMessageWindowAvalonia
Services/AvaloniaDialogService.cs(198,36):  error CS0246: MessageWindow
Views/SettingsWindow.Avalonia.cs(2483,27):  error CS0246: MessageWindow
    Ошибок: 4
```

## Четыре причины

**1. Файл с новым классом исключён из сборки под Linux.**
В `Configuration Management.csproj`, внутри `ItemGroup` с условием
`!IsOSPlatform('Windows')`, стояло

```xml
<Compile Remove="Services\MaterialMessageWindow.Avalonia.cs" />
```

то есть класс объявлен, но не компилируется. Строка удалена.

Соседнюю строку про `MaterialMessageWindow.xaml.cs` не трогал: это версия
для WPF, и её исключение из Linux-сборки верное.

**2. В самом файле не хватает `using Avalonia.Controls.Primitives`.**
Без него не разрешается `TemplatedControl`, три места. Это вскрывается
только после пункта 1, пока файл исключён, ошибки не видно.

**3. `AvaloniaDialogService.cs` ссылается на удалённый класс.**
Строка 198: `window is MessageWindow mw ? mw.Result : true`. Класса
`MessageWindow` в дереве больше нет. Заменено на
`MaterialMessageWindowAvalonia` и его свойство `Confirmed`.

**4. `SettingsWindow.Avalonia.cs` создаёт удалённый класс.**
Строка 2483: `new MessageWindow(message, ..., MessageWindowKind.Info)`.
Заменено на `MaterialMessageWindowAvalonia` с `MaterialMessageKind.Info`.

## Чего не трогал

Внутренний `enum MessageWindowKind` (`AvaloniaDialogService.cs:239`)
оставлен как есть: он используется в `ShowInfo`, `ShowWarning`
и `ShowError` и приводится к `MaterialMessageKind` в `ShowMessage`.
Это выглядит осознанной конструкцией, а не остатком переименования,
поэтому упрощать её в этом PR я не стал.

## Проверка

После правок Linux-цель собирается: **0 ошибок, 15 предупреждений**,
все прежние, ни одно не в изменённых файлах.

**Windows-цель не задета по построению:** правка `csproj` лежит внутри
`ItemGroup` с условием `!IsOSPlatform('Windows')`, а остальные три файла
имеют суффикс `.Avalonia.cs` и в сборку под Windows не входят. Проверить
это сборкой я не могу, у нас нет Windows-машины; попросил соседа собрать
Windows-цель и подтвердить, результат допишу комментарием.

PR намеренно узкий: только восстановление сборки, ничего больше.
