### PR TITLE
Linux/Avalonia: выгрузки .dt и .cf, обновление сведений о конфигурации, остаток главного окна

### DIFF
--- a/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
+++ b/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
@@ -422,6 +422,9 @@ public class MainViewModel : ViewModelBase
     public ICommand QuickClearCacheCommand { get; private set; } = null!;
     public ICommand ClearCacheCommand { get; private set; } = null!;
     public ICommand ClearProgramCacheCommand { get; private set; } = null!;
+    public ICommand DumpInfobaseDtCommand { get; private set; } = null!;
+    public ICommand DumpConfigurationCfCommand { get; private set; } = null!;
+    public ICommand RefreshConfigurationInfoCommand { get; private set; } = null!;
     public ICommand ClearUserCacheCommand { get; private set; } = null!;
     public ICommand ClearCacheBothCommand { get; private set; } = null!;
 
@@ -487,6 +490,9 @@ public class MainViewModel : ViewModelBase
         ClearCacheCommand = new RelayCommand(_ => OpenCacheClean(OneCCacheKind.All),
             p => p is Infobase ? true : SelectedInfobase is not null);
         ClearProgramCacheCommand = new RelayCommand(_ => OpenCacheClean(OneCCacheKind.Program));
+        DumpInfobaseDtCommand = new RelayCommand(DumpInfobaseDt);
+        DumpConfigurationCfCommand = new RelayCommand(DumpConfigurationCf);
+        RefreshConfigurationInfoCommand = new RelayCommand(RefreshConfigurationInfo);
         ClearUserCacheCommand = new RelayCommand(_ => OpenCacheClean(OneCCacheKind.User));
         ClearCacheBothCommand = new RelayCommand(_ => OpenCacheClean(OneCCacheKind.All));
     }
@@ -612,8 +618,16 @@ public class MainViewModel : ViewModelBase
     public bool ShowRightPanelDetails
     {
         get => _showRightPanelDetails;
-        set => SetPropertyWithRelated(ref _showRightPanelDetails, value, nameof(ShowRightPanelDetails), nameof(RightPanelToggleTooltip), nameof(ShowConnectionInfo));
+        set => SetPropertyWithRelated(ref _showRightPanelDetails, value, nameof(ShowRightPanelDetails), nameof(RightPanelToggleTooltip), nameof(ShowConnectionInfo), nameof(OpenByLinkCaption));
     }
+
+    /// <summary>
+    /// Подпись кнопки открытия по ссылке: короткая, когда подробности правой
+    /// панели скрыты. В разметке WPF это триггер по ShowRightPanelDetails.
+    /// </summary>
+    public string OpenByLinkCaption => ShowRightPanelDetails
+        ? LocalizationManager.T("LinkInput.Title")
+        : LocalizationManager.T("Main.OpenByLinkShort");
 
     /// <summary>
     /// Заголовок правой панели: имя базы, имя группы или «Нет выбора».
@@ -3215,6 +3229,108 @@ public class MainViewModel : ViewModelBase
     private void ToggleFavorite() => ToggleFavoriteFor(SelectedInfobase);
 
     private void TogglePin() => TogglePinFor(SelectedInfobase);
+
+    private void DumpInfobaseDt(object? parameter) =>
+        DumpViaDesigner(parameter, OneCLauncher.DesignerBatchOperation.DumpIB, ".dt",
+            "Main.DumpDtDialogTitle", "Main.DtFileFilter", "Main.DumpDtStarted", "Main.DumpDtTitle");
+
+    private void DumpConfigurationCf(object? parameter) =>
+        DumpViaDesigner(parameter, OneCLauncher.DesignerBatchOperation.DumpCfg, ".cf",
+            "Main.DumpCfDialogTitle", "Main.CfFileFilter", "Main.DumpCfStarted", "Main.DumpCfTitle");
+
+    /// <summary>
+    /// Выгрузка базы или конфигурации пакетным запуском конфигуратора.
+    /// Общая часть обеих команд: в версии для Windows это два почти одинаковых метода.
+    /// </summary>
+    private void DumpViaDesigner(
+        object? parameter,
+        OneCLauncher.DesignerBatchOperation operation,
+        string extension,
+        string dialogTitleKey,
+        string filterKey,
+        string startedKey,
+        string titleKey)
+    {
+        var ib = parameter as Infobase ?? SelectedInfobase;
+        if (ib is null)
+            return;
+
+        var path = _dialog.SaveFileDialog(
+            LocalizationManager.T(dialogTitleKey),
+            BuildExportFileName(SanitizeFileName(ib.Name), extension,
+                _settings.AddTimestampToExportFileName, _settings.ExportTimestampFormat),
+            LocalizationManager.T(filterKey));
+        if (string.IsNullOrWhiteSpace(path))
+            return;
+
+        if (!OneCLauncher.RunDesignerBatch(ib, operation, path))
+            return;
+
+        ib.AddLaunchHistory(operation == OneCLauncher.DesignerBatchOperation.DumpIB ? "DumpDT" : "DumpCF", path);
+        SaveSilently();
+        _dialog.ShowInfo(LocalizationManager.T(startedKey), LocalizationManager.T(titleKey));
+    }
+
+    private void RefreshConfigurationInfo(object? parameter)
+    {
+        var ib = parameter as Infobase ?? SelectedInfobase;
+        if (ib is null)
+            return;
+
+        // Сброса вердиктов о недоступности COM здесь нет: он живёт
+        // в OneCComConnector.cs, а тот в Linux-сборку не входит.
+        var baseName = ib.Name;
+        _ = Task.Run(() =>
+        {
+            OneCConfigInfo? info = null;
+            try
+            {
+                info = ConfigurationInfoService.ReadAndApply(ib, overwriteExisting: true);
+            }
+            catch
+            {
+                // причина уходит в LastComError и показывается ниже
+            }
+
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                if (info is null)
+                {
+                    var comError = ConfigurationInfoService.LastComError;
+                    var detail = string.IsNullOrWhiteSpace(comError)
+                        ? LocalizationManager.T("Main.ConfigInfoCheckHint")
+                        : string.Format(LocalizationManager.T("Main.ConfigInfoReason"), comError);
+                    _logger.Warn($"Не удалось получить информацию о конфигурации базы «{baseName}». {detail}");
+                    _dialog.ShowWarning(
+                        string.Format(LocalizationManager.T("Main.ErrConfigInfo"), baseName, detail),
+                        LocalizationManager.T("Main.ConfigInfoTitle"));
+                    return;
+                }
+
+                RebuildTree();
+                SaveSilently();
+
+                var name = info.Value.Name.Trim();
+                var version = info.Value.Version.Trim();
+                _logger.Info($"Обновлена информация о конфигурации базы «{baseName}»: {name} ({version})");
+
+                var sb = new System.Text.StringBuilder();
+                sb.AppendLine(string.Format(LocalizationManager.T("Main.ConfigInfoBase"), baseName));
+                if (name.Length > 0)
+                    sb.AppendLine(string.Format(LocalizationManager.T("Main.ConfigInfoName"), name));
+                if (version.Length > 0)
+                    sb.AppendLine(string.Format(LocalizationManager.T("Main.ConfigInfoVersion"), version));
+                _dialog.ShowInfo(sb.ToString().TrimEnd(), LocalizationManager.T("Main.ConfigInfoTitle"));
+            });
+        });
+    }
+
+    private static string SanitizeFileName(string? name)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var s = new string((name ?? "base").Select(c => invalid.Contains(c) ? '_' : c).ToArray());
+        return string.IsNullOrWhiteSpace(s) ? "base" : s;
+    }
 
     private void ToggleFavoriteFor(Infobase? infobase)
     {

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -21,6 +21,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Utilities;
 using Avalonia.Platform;
 using Avalonia.Styling;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Configuration_Management.Controls;
 using Configuration_Management.Localization;
@@ -288,6 +289,19 @@ namespace Configuration_Management
             var themeBtn = TopBarIconButton("IconTheme", LocalizationManager.T("Main.Theme"));
             themeBtn.Bind(Button.CommandProperty, new Binding("ToggleThemeCommand"));
             actions.Children.Add(themeBtn);
+
+            // Быстрый переключатель плотности интерфейса, как в разметке WPF:
+            // тот же режим уже есть в настройках, здесь он под рукой.
+            var compactBtn = TopBarIconButton("IconCollapseAll", LocalizationManager.T("Main.CompactModeTooltip"));
+            compactBtn.Click += (_, _) =>
+            {
+                if (_vm is null)
+                    return;
+                var next = !_vm.CompactMode;
+                _vm.CompactMode = next;
+                ApplyCompactMode(next);
+            };
+            actions.Children.Add(compactBtn);
 
             var settingsBtn = TopBarSecondaryButton("IconSettings", LocalizationManager.T("Main.Settings"), LocalizationManager.T("Main.SettingsTooltip"));
             settingsBtn.Bind(Button.CommandProperty, new Binding("OpenSettingsCommand"));
@@ -1702,10 +1716,51 @@ namespace Configuration_Management
             // команд. Здесь остаются вторичные действия списком.
             panel.Children.Add(BuildActionList(
                 CompactActionButton("IconOpen", LocalizationManager.T("Main.OpenFolder"), "OpenInfobaseFolderCommand", LocalizationManager.T("Main.OpenFolderTooltip")),
-                CompactActionButton("IconKeyboard", LocalizationManager.T("Main.RunStarter"), "OpenNativeStarterCommand", LocalizationManager.T("Main.NativeStarterTooltipLinux")),
-                CompactActionButton("IconWeb", LocalizationManager.T("LinkInput.Title"), "OpenInfobaseByLinkCommand", LocalizationManager.T("Main.OpenLinkTooltip")),
+                CompactActionButton("IconKeyboard", LocalizationManager.T("Main.NativeStarter"), "OpenNativeStarterCommand", LocalizationManager.T("Main.NativeStarterTooltipLinux")),
+                CompactActionButtonBound("IconWeb", "OpenByLinkCaption", "OpenInfobaseByLinkCommand", LocalizationManager.T("Main.OpenLinkTooltip")),
                 CompactActionButton("IconShortcut", LocalizationManager.T("Main.DesktopShortcut"), "CreateDesktopShortcutCommand", LocalizationManager.T("Main.DesktopShortcutTooltip"))
             ));
+
+            // Бейдж «Закреплено» и секция тегов выбранной базы, как в разметке WPF.
+            var pinnedBadge = new Border
+            {
+                CornerRadius = new CornerRadius(8),
+                Padding = new Thickness(8, 3),
+                Margin = new Thickness(0, 0, 6, 4),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                Child = ThemedIconAndText("IconPin", LocalizationManager.T("Main.PinnedLabel"),
+                    "AccentColorBrush", 12, centered: false)
+            };
+            ThemeBrushes.Bind(pinnedBadge, Border.BackgroundProperty, "ItemHoverColorBrush");
+            pinnedBadge.Bind(Control.IsVisibleProperty, new Binding("SelectedInfobase.IsPinned"));
+            panel.Children.Add(pinnedBadge);
+
+            var tagsHeader = ThemedIconAndText("IconTag", LocalizationManager.T("Main.Tags"),
+                "TextSecondaryColorBrush", 14, centered: false);
+            var tagsList = new ItemsControl
+            {
+                Margin = new Thickness(0, 0, 0, 4),
+                ItemsPanel = new FuncTemplate<Panel?>(() => new WrapPanel()),
+                ItemTemplate = new FuncDataTemplate<string>((tag, _) =>
+                {
+                    var chip = new Border
+                    {
+                        CornerRadius = new CornerRadius(8),
+                        Padding = new Thickness(8, 3),
+                        Margin = new Thickness(0, 0, 4, 4),
+                        BorderThickness = new Thickness(1),
+                        Child = ThemedIconAndText("IconTag", tag ?? "", "AccentColorBrush", 10, centered: false)
+                    };
+                    ThemeBrushes.Bind(chip, Border.BackgroundProperty, "ItemHoverColorBrush");
+                    ThemeBrushes.Bind(chip, Border.BorderBrushProperty, "BorderColorBrush");
+                    return chip;
+                })
+            };
+            tagsList.Bind(ItemsControl.ItemsSourceProperty, new Binding("SelectedInfobase.Tags"));
+            var tagsBlock = new StackPanel { Spacing = 4 };
+            tagsBlock.Children.Add(tagsHeader);
+            tagsBlock.Children.Add(tagsList);
+            panel.Children.Add(tagsBlock);
 
             // Информация о подключении.
             // Блок сведений подчинён переключателю подробностей правой панели,
@@ -1799,7 +1854,32 @@ namespace Configuration_Management
         }
 
         /// <summary>Компактное содержимое кнопки: иконка + подпись меньшего размера.</summary>
-        private static Control CompactIconAndText(string iconKey, string text, string brushKey)
+        /// <summary>
+        /// Вариант кнопки действия с подписью из привязки: нужен там, где текст
+        /// меняется по состоянию, как короткая подпись открытия по ссылке.
+        /// </summary>
+        private static Control CompactActionButtonBound(string iconKey, string textPath, string commandPath, string tooltip)
+        {
+            var btn = new PanelButton(
+                "SecondaryButtonBackgroundBrush",
+                "SecondaryButtonHoverBrush",
+                "SecondaryButtonPressedBrush",
+                "BorderColorBrush",
+                new CornerRadius(UiMetrics.RadiusMd))
+            {
+                Content = CompactIconAndText(iconKey, "", "ButtonTextBrush", textPath),
+                HorizontalContentAlignment = HorizontalAlignment.Left,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                MinHeight = UiMetrics.ActionButtonMinHeight,
+                Padding = new Thickness(UiMetrics.ActionButtonPadH, UiMetrics.ActionButtonPadV),
+                Margin = new Thickness(0)
+            };
+            ToolTip.SetTip(btn, tooltip);
+            btn.Bind(Button.CommandProperty, new Binding(commandPath));
+            return btn;
+        }
+
+        private static Control CompactIconAndText(string iconKey, string text, string brushKey, string? textPath = null)
         {
             // Сеткой, а не горизонтальной панелью: панель меряет подпись
             // бесконечной шириной, поэтому обрезка многоточием не срабатывает
@@ -1817,6 +1897,8 @@ namespace Configuration_Management
                 TextTrimming = TextTrimming.CharacterEllipsis
             };
             ThemeBrushes.Bind(tb, TextBlock.ForegroundProperty, brushKey);
+            if (textPath is not null)
+                tb.Bind(TextBlock.TextProperty, new Binding(textPath));
             Grid.SetColumn(tb, 1);
             sp.Children.Add(tb);
             return sp;
@@ -2739,6 +2821,9 @@ namespace Configuration_Management
             tools.ZIndex = 1;
 
             var nameHeader = ColumnHeader(LocalizationManager.T("Column.Name"), IconHelper.ColumnIconKey("Name"));
+            // У «Названия» отступ слева нулевой: заголовок равняется по тексту строк
+            // списка, а не по границе колонки. В разметке WPF так же (MainWindow.xaml:627).
+            nameHeader.Margin = new Thickness(0, 0, 8, 4);
             MakeSortableHeader(nameHeader, "Name", LocalizationManager.T("Main.ColumnNameSortTooltip"));
             _columnHeaderRow.Children.Add(nameHeader);
             Grid.SetColumn(nameHeader, NameHeaderColumn);
@@ -3357,7 +3442,12 @@ namespace Configuration_Management
             {
                 Orientation = Orientation.Horizontal,
                 Spacing = 5,
-                VerticalAlignment = VerticalAlignment.Center
+                VerticalAlignment = VerticalAlignment.Center,
+                // Отступы как в разметке WPF (Margin="6,0,6,4"): без них подпись
+                // встаёт вплотную к соседней, а горизонтальный StackPanel меряет
+                // детей без ограничения по ширине, поэтому сам текст не подрезается.
+                Margin = new Thickness(6, 0, 6, 4),
+                ClipToBounds = true
             };
             panel.Children.Add(IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(13), "TextSecondaryBrush"));
 
@@ -3762,6 +3852,9 @@ namespace Configuration_Management
             menu.Items.Add(MenuAction("Main.LaunchEnterprise", _vm.LaunchEnterpriseCommand, _vm.HotkeyEnterprise));
             menu.Items.Add(MenuAction("Main.LaunchConfigurator", _vm.LaunchConfiguratorCommand, _vm.HotkeyConfigurator));
             menu.Items.Add(MenuAction("Main.EditSettings", _vm.EditInfobaseCommand, _vm.HotkeyEdit));
+            menu.Items.Add(MenuAction("Main.RefreshConfigInfo", _vm.RefreshConfigurationInfoCommand));
+            // «Зарегистрировать COM-коннектор» здесь нет намеренно: внешнее соединение
+            // это COM, в Linux регистрировать нечего. Windows-сторона решение подтвердила.
             menu.Items.Add(new Separator());
             menu.Items.Add(MenuAction("Main.ToFavorites", _vm.ToggleFavoriteCommand, _vm.HotkeyFavorite));
             menu.Items.Add(MenuAction("Main.Pin", _vm.TogglePinCommand, _vm.HotkeyPin));
@@ -3771,6 +3864,9 @@ namespace Configuration_Management
             menu.Items.Add(MenuAction("Main.OpenCatalog", _vm.OpenInfobaseFolderCommand));
             menu.Items.Add(MenuAction("Main.DesktopShortcut", _vm.CreateDesktopShortcutCommand));
             menu.Items.Add(MenuAction("Main.AddBase", _vm.AddInfobaseCommand, _vm.HotkeyAdd));
+            menu.Items.Add(new Separator());
+            menu.Items.Add(MenuAction("Main.DumpToDt", _vm.DumpInfobaseDtCommand));
+            menu.Items.Add(MenuAction("Main.DumpConfigToCf", _vm.DumpConfigurationCfCommand));
             menu.Items.Add(new Separator());
             menu.Items.Add(MenuAction("Main.Delete", _vm.DeleteInfobaseCommand, _vm.HotkeyDelete));
             return menu;


### PR DESCRIPTION
Восемь мест из разметки `MainWindow.xaml`, которых не было в Linux-версии.
Механику переносить почти не пришлось: `OneCLauncher.RunDesignerBatch`
с операциями `DumpIB` и `DumpCfg` уже есть в `OneCLauncher.Linux.cs`,
а `ConfigurationInfoService` общий для обеих платформ.

Два файла: `Views/MainWindow.Avalonia.cs`, `ViewModels/MainViewModel.Avalonia.cs`.

## Контекстное меню строки базы

Пункты стоят там же, где у вас:

* **«Обновить информацию о конфигурации»** — сразу после «Изменить настройки»;
* **«Выгрузить в .dt»** и **«Выгрузить конфигурацию .cf»** — перед
  разделителем и «Удалить».

## Правая и верхняя панели

* быстрый переключатель плотности интерфейса с подсказкой. Сам режим уже
  был, но добраться до него можно было только через окно настроек;
* бейдж **«Закреплено»**, видимый по `IsPinned`;
* секция **«Теги»** со списком тегов выбранной базы, показывается всегда,
  как у вас;
* подпись кнопки штатного стартера взята ваша, **«1С:Стартер»**, вместо
  нашей «Запустить стартер 1С»;
* короткая подпись **«По ссылке»**, когда подробности правой панели скрыты.

Последнее у вас сделано триггером по `ShowRightPanelDetails`; здесь окно
строится кодом, поэтому это вычисляемое свойство модели и привязка,
для чего добавлен вариант кнопки действия с подписью из привязки.

## Что сведено в один метод

Две команды выгрузки: у вас это два почти одинаковых метода, отличающихся
операцией, расширением и четырьмя ключами словаря. Поведение то же.

## Про сброс вердиктов COM

В команде обновления сведений нет вызова `OneCComConnector.ResetComVerdicts`:
он живёт в `OneCComConnector.cs`, а тот в Linux-сборку не входит.
На Linux сведения читаются Linux-двойником коннектора через
`DESIGNER /DumpCfg` либо из файла базы, и кэша вердиктов там нет.

## Два пункта намеренно не переносятся

Проверяли отдельно, с прогоном на обеих платформах:

* **«Зарегистрировать COM-коннектор»** — внешнее соединение это COM,
  в Linux регистрировать нечего. `OneCComConnector.Linux.cs` уже
  возвращает `null` из `Connect()`;
* **«Запуск от имени администратора»** — UAC. Он и живёт не в этом меню,
  а в выпадающих меню кнопок запуска, и `OneCLauncher.Linux.cs` уже
  игнорирует `runAsAdmin`, то есть поведение и так правильное. Запускать
  клиент 1С под `root` вредно: профиль, кеш и лицензии уходят в `/root`.

Подсказка стартера оставлена нашей: у вас в тексте `1CEStart.exe`,
в Linux исполняемый файл называется `1cestart`.

## Проверка

Прогон на настоящей клиент-серверной базе кластера 8.3.27.2214:

* меню совпадает с вашим по составу и группировке, сверено со снимком;
* обе выгрузки доходят до платформы и дают настоящие файлы: `.dt`
  с подписью `1CIBDmpF`, `.cf` с контейнерной подписью. Размеры малы,
  потому что база пустая;
* сообщение о запуске выгрузки показывается;
* секция тегов, бейдж закрепления и подпись стартера видны в правой панели;
* сборка Linux-цели: 0 ошибок, 15 предупреждений, все прежние.

Разрыв интерфейса по префиксу `Main` сократился с 13 ключей до пяти:
два Windows-only выше, два расхождения по тексту (подсказка стартера
и подсказка раскрытия группы, у нас она меняется по состоянию, у вас одна
статичная) и «История запусков» — она идёт отдельным PR, потому что
на Linux история пока вообще не записывается, и это надо чинить раньше,
чем показывать.

**Зависимость:** PR ветвится от `main`, но собирать Linux-цель имеет смысл
после **PR 96**, который восстанавливает сборку.
