### PR TITLE
Linux/Avalonia: кнопки диалоговых окон приведены к разметке WPF

### DIFF
--- a/Configuration Management/App.axaml
+++ b/Configuration Management/App.axaml
@@ -15,6 +15,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceInclude Source="avares://ConfigurationManagement/Themes/Icons.axaml" />
                 <ResourceInclude Source="avares://ConfigurationManagement/Themes/LightTheme.axaml" />
+                <ResourceInclude Source="avares://ConfigurationManagement/Themes/Controls.axaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/Configuration Management/Themes/ControlThemes.Avalonia.cs
+++ b/Configuration Management/Themes/ControlThemes.Avalonia.cs
@@ -1,0 +1,51 @@
+#if LINUX
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Styling;
+
+namespace Configuration_Management.Themes
+{
+    /// <summary>
+    /// Применение именованных тем контролов из Themes/Controls.axaml к элементам,
+    /// которые собираются в коде. Аналог <c>Style="{DynamicResource ИмяСтиля}"</c>
+    /// из разметки WPF: ключи те же самые.
+    /// </summary>
+    public static class ControlThemes
+    {
+        /// <summary>Основная кнопка: акцентная заливка, скругление 6, высота от 36.</summary>
+        public const string ModernButton = "ModernButton";
+
+        /// <summary>Вторичная кнопка: в светлой теме мягкая заливка, в тёмной карточка в контуре.</summary>
+        public const string SecondaryButton = "SecondaryButton";
+
+        /// <summary>Кнопка подтверждения нижней панели диалога: зелёная заливка.</summary>
+        public const string DialogConfirmButton = "DialogConfirmButton";
+
+        /// <summary>Кнопка отмены нижней панели диалога: красный контур.</summary>
+        public const string DialogCancelButton = "DialogCancelButton";
+
+        /// <summary>
+        /// Ставит элементу тему контрола по ключу словаря и возвращает сам элемент,
+        /// чтобы вызов можно было встроить в инициализацию.
+        /// </summary>
+        /// <param name="control">Элемент, которому назначается тема.</param>
+        /// <param name="themeKey">Ключ ресурса, например <see cref="ModernButton"/>.</param>
+        /// <remarks>
+        /// Неизвестный ключ оставляет элемент со штатной темой Fluent и ничего не сообщает:
+        /// ресурсы ищутся по значению, а не по типу, и промах виден только глазами.
+        /// Поэтому ключи заданы здесь константами, а не строками по месту вызова.
+        /// </remarks>
+        public static T Styled<T>(this T control, string themeKey) where T : StyledElement
+        {
+            if (Application.Current is { } app
+                && app.TryFindResource(themeKey, out var found)
+                && found is ControlTheme theme)
+            {
+                control.Theme = theme;
+            }
+
+            return control;
+        }
+    }
+}
+#endif

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -101,12 +101,18 @@
         <Style Selector="^:pressed /template/ Border#PART_Surface">
             <Setter Property="Background" Value="{DynamicResource SecondaryButtonPressedSurfaceBrush}"/>
         </Style>
+        <!-- Гашение задано и здесь, хотя оно есть у основной кнопки: вторичная
+             переопределяет шаблон целиком, и вложенный стиль основной ссылается
+             на её часть шаблона, а не на эту. -->
+        <Style Selector="^:disabled /template/ Border#PART_Surface">
+            <Setter Property="Opacity" Value="0.5"/>
+        </Style>
     </ControlTheme>
     <!-- ===================== Кнопки нижней панели диалогов =====================
          В разметке WPF эти две кнопки заданы не именованным стилем, а встроенным
-         шаблоном, и повторены так в девяти окнах: AddEditWindow.xaml:152,
+         шаблоном, и повторены так в десяти окнах: AddEditWindow.xaml:152,
          CacheCleanWindow.xaml:206, ConnectionSettingsWindow.xaml:1026,
-         ConnectionStringInputWindow.xaml:71, CreateInfobaseWindow.xaml:208,
+         ConnectionStringInputWindow.xaml:71, CreateInfobaseWindow.xaml:185,
          GroupEditWindow.xaml:294, LaunchParametersWindow.xaml:78,
          LinkInputWindow.xaml:51, PlatformVersionPickerWindow.xaml:258,
          SettingsWindow.xaml:1527. Здесь это две темы контролов, чтобы девять

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -1,0 +1,201 @@
+<!-- Avalonia-версия стилей контролов (Linux). Соответствует именованным стилям
+     WPF-словарей LightTheme.xaml и DarkTheme.xaml: ключи те же, применяются так же
+     явно, по ключу. Цвета берутся из палитры, которую накладывает
+     ThemeManager.ApplyScheme, поэтому смена темы и схемы подхватывается сама.
+
+     Отличие от WPF по устройству, а не по виду: там два словаря целиком, и стиль
+     вторичной кнопки в каждом свой. Здесь словарь стилей один, а различающиеся
+     кисти вынесены в ThemeDictionaries и переключаются по RequestedThemeVariant,
+     который ApplyScheme и задаёт. -->
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ResourceDictionary.ThemeDictionaries>
+        <!-- Светлая: вторичная кнопка это заливка янтарного семейства без контура. -->
+        <ResourceDictionary x:Key="Light">
+            <SolidColorBrush x:Key="SecondaryButtonSurfaceBrush" Color="{DynamicResource SecondaryButtonBackgroundColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonTextBrush" Color="{DynamicResource ButtonTextColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonOutlineBrush" Color="{DynamicResource SecondaryButtonBackgroundColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonHoverSurfaceBrush" Color="{DynamicResource SecondaryButtonHoverColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonHoverOutlineBrush" Color="{DynamicResource SecondaryButtonHoverColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonPressedSurfaceBrush" Color="{DynamicResource SecondaryButtonPressedColor}"/>
+            <Thickness x:Key="SecondaryButtonOutlineThickness">0</Thickness>
+        </ResourceDictionary>
+        <!-- Тёмная: вторичная кнопка это карточка в контуре, при наведении контур акцентный. -->
+        <ResourceDictionary x:Key="Dark">
+            <SolidColorBrush x:Key="SecondaryButtonSurfaceBrush" Color="{DynamicResource CardBackgroundColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonTextBrush" Color="{DynamicResource TextPrimaryColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonOutlineBrush" Color="{DynamicResource BorderColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonHoverSurfaceBrush" Color="{DynamicResource ItemHoverColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonHoverOutlineBrush" Color="{DynamicResource AccentColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonPressedSurfaceBrush" Color="{DynamicResource SidebarHoverColor}"/>
+            <Thickness x:Key="SecondaryButtonOutlineThickness">1</Thickness>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+
+    <!-- ===================== Основная кнопка ===================== -->
+    <ControlTheme x:Key="ModernButton" TargetType="Button">
+        <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ButtonTextBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="14,9"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="MinHeight" Value="36"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        CornerRadius="6"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource AccentHoverBrush}"/>
+        </Style>
+        <Style Selector="^:pressed /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource AccentPressedBrush}"/>
+        </Style>
+        <Style Selector="^:disabled /template/ Border#PART_Surface">
+            <Setter Property="Opacity" Value="0.5"/>
+        </Style>
+    </ControlTheme>
+
+    <!-- ===================== Вторичная кнопка ===================== -->
+    <ControlTheme x:Key="SecondaryButton" TargetType="Button" BasedOn="{StaticResource ModernButton}">
+        <Setter Property="Background" Value="{DynamicResource SecondaryButtonSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryButtonTextBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryButtonOutlineBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource SecondaryButtonOutlineThickness}"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="6"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource SecondaryButtonHoverSurfaceBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SecondaryButtonHoverOutlineBrush}"/>
+        </Style>
+        <Style Selector="^:pressed /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource SecondaryButtonPressedSurfaceBrush}"/>
+        </Style>
+    </ControlTheme>
+    <!-- ===================== Кнопки нижней панели диалогов =====================
+         В разметке WPF эти две кнопки заданы не именованным стилем, а встроенным
+         шаблоном, и повторены так в девяти окнах: AddEditWindow.xaml:152,
+         CacheCleanWindow.xaml:206, ConnectionSettingsWindow.xaml:1026,
+         ConnectionStringInputWindow.xaml:71, CreateInfobaseWindow.xaml:208,
+         GroupEditWindow.xaml:294, LaunchParametersWindow.xaml:78,
+         LinkInputWindow.xaml:51, PlatformVersionPickerWindow.xaml:258,
+         SettingsWindow.xaml:1527. Здесь это две темы контролов, чтобы девять
+         повторений не разъезжались. Цвета в разметке заданы числом и от темы
+         не зависят, поэтому и тут они числом.
+         Гашение при недоступности автор задал только там, где кнопка бывает
+         недоступна (ConnectionStringInputWindow.xaml:86); в остальных окнах
+         состояние недостижимо, поэтому расхождения не видно. -->
+    <ControlTheme x:Key="DialogConfirmButton" TargetType="Button">
+        <Setter Property="Background" Value="#16A34A"/>
+        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="12,8"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Height" Value="36"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        CornerRadius="8"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="#15803D"/>
+        </Style>
+        <Style Selector="^:pressed /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="#166534"/>
+        </Style>
+        <!-- Недоступное состояние автор задал по-разному и только там, где оно
+             достижимо: серой заливкой (ConnectionStringInputWindow.xaml:86,
+             LinkInputWindow.xaml:66) и полупрозрачностью
+             (PlatformVersionPickerWindow.xaml:272 и CacheCleanWindow.xaml:220
+             дают 0.45, ConnectionSettingsWindow.xaml:1040 даёт 0.5; здесь у всех
+             0.45, разница в полшага не различима). Поэтому не в общем виде темы,
+             а двумя классами, и окно выбирает нужный. -->
+        <Style Selector="^.greyed:disabled /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="#9CA3AF"/>
+        </Style>
+        <Style Selector="^.dimmed:disabled /template/ Border#PART_Surface">
+            <Setter Property="Opacity" Value="0.45"/>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="DialogCancelButton" TargetType="Button">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="#EF4444"/>
+        <Setter Property="BorderBrush" Value="#EF4444"/>
+        <Setter Property="BorderThickness" Value="1.5"/>
+        <Setter Property="Padding" Value="12,8"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Height" Value="36"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="8"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="#FEF2F2"/>
+        </Style>
+    </ControlTheme>
+
+</ResourceDictionary>

--- a/Configuration Management/Views/AddEditWindow.Avalonia.cs
+++ b/Configuration Management/Views/AddEditWindow.Avalonia.cs
@@ -60,41 +60,20 @@ namespace Configuration_Management
             Grid.SetRow(options, 1);
             grid.Children.Add(options);
 
+            // Порядок и оформление по разметке (AddEditWindow.xaml:151):
+            // зелёное «Далее» слева, красная «Отмена» справа, зазор 10.
             var buttons = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8,
-                Margin = new Thickness(0, 12, 0, 0)
-            };
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 100, IsCancel = true };
-            cancel.Click += (_, _) => Close();
-            buttons.Children.Add(cancel);
-
-            var next = new Button
-            {
-                Content = new StackPanel
+                Spacing = 10,
+                Margin = new Thickness(0, 12, 0, 0),
+                Children =
                 {
-                    Orientation = Orientation.Horizontal,
-                    Spacing = 6,
-                    Children =
-                    {
-                        new TextBlock
-                        {
-                            Text = LocalizationManager.T("AddEdit.Next"),
-                            VerticalAlignment = VerticalAlignment.Center,
-                            Foreground = Brushes.White
-                        },
-                        IconHelper.MakeIcon("IconArrowRight", 16, "White")
-                    }
-                },
-                MinWidth = 110,
-                Background = new SolidColorBrush(Color.Parse("#16A34A")),
-                Foreground = Brushes.White,
-                IsDefault = true
+                    BuildConfirmActionButton("AddEdit.Next", "IconArrowRight", 130),
+                    BuildCancelActionButton(130)
+                }
             };
-            next.Click += (_, _) => { DialogResult = true; Close(); };
-            buttons.Children.Add(next);
 
             Grid.SetRow(buttons, 2);
             grid.Children.Add(buttons);

--- a/Configuration Management/Views/CacheCleanWindow.Avalonia.cs
+++ b/Configuration Management/Views/CacheCleanWindow.Avalonia.cs
@@ -374,20 +374,18 @@ namespace Configuration_Management
             _cleanButton.Classes.Add("dimmed");
             _cleanButton.Width = 180;
             _cleanButton.Height = 36;
+            var cleanCaption = new TextBlock
+            {
+                Text = LocalizationManager.T("CacheClean.Clean"),
+                VerticalAlignment = VerticalAlignment.Center
+            };
             _cleanButton.Content = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
                 Spacing = 6,
-                Children =
-                {
-                    IconHelper.MakeIcon("IconBroom", 16, Brushes.White),
-                    new TextBlock
-                    {
-                        Text = LocalizationManager.T("CacheClean.Clean"),
-                        VerticalAlignment = VerticalAlignment.Center
-                    }
-                }
+                Children = { IconHelper.MakeIcon("IconBroom", 16, Brushes.White), cleanCaption }
             };
+            RegisterConfirmCaption(cleanCaption, "CacheClean.Clean");
             _cleanButton.Click += (_, _) => OnClean_Click();
 
             var rightPanel = new StackPanel

--- a/Configuration Management/Views/CacheCleanWindow.Avalonia.cs
+++ b/Configuration Management/Views/CacheCleanWindow.Avalonia.cs
@@ -10,6 +10,7 @@ using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 using Configuration_Management.Models;
 using Configuration_Management.Services;
 
@@ -355,7 +356,6 @@ namespace Configuration_Management
             var bottom = new Grid { Margin = new Thickness(0, 12, 0, 0) };
             bottom.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
             bottom.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-            bottom.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
 
             var leftPanel = new StackPanel
             {
@@ -367,33 +367,38 @@ namespace Configuration_Management
             Grid.SetColumn(leftPanel, 0);
             bottom.Children.Add(leftPanel);
 
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 100, IsCancel = true };
-            cancel.Click += (_, _) => Close();
-            Grid.SetColumn(cancel, 1);
-            cancel.Margin = new Thickness(0, 0, 8, 0);
-            bottom.Children.Add(cancel);
-
-            _cleanButton.Background = new SolidColorBrush(Color.Parse("#16A34A"));
-            _cleanButton.Foreground = Brushes.White;
+            // Оформление и порядок по разметке (CacheCleanWindow.xaml:205):
+            // зелёная очистка шириной 180 слева, красная отмена справа, зазор 10.
+            // Пока нечего чистить, кнопка недоступна и приглушена, как там же.
+            _cleanButton.Styled(ControlThemes.DialogConfirmButton);
+            _cleanButton.Classes.Add("dimmed");
+            _cleanButton.Width = 180;
+            _cleanButton.Height = 36;
             _cleanButton.Content = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
                 Spacing = 6,
                 Children =
                 {
-                    IconHelper.MakeIcon("IconDelete", 16, "White"),
+                    IconHelper.MakeIcon("IconBroom", 16, Brushes.White),
                     new TextBlock
                     {
                         Text = LocalizationManager.T("CacheClean.Clean"),
-                        VerticalAlignment = VerticalAlignment.Center,
-                        Foreground = Brushes.White
+                        VerticalAlignment = VerticalAlignment.Center
                     }
                 }
             };
-            _cleanButton.MinWidth = 130;
             _cleanButton.Click += (_, _) => OnClean_Click();
-            Grid.SetColumn(_cleanButton, 2);
-            bottom.Children.Add(_cleanButton);
+
+            var rightPanel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Spacing = 10,
+                Children = { _cleanButton, BuildCancelActionButton(140) }
+            };
+            Grid.SetColumn(rightPanel, 1);
+            bottom.Children.Add(rightPanel);
 
             Grid.SetRow(bottom, 5);
             grid.Children.Add(bottom);

--- a/Configuration Management/Views/ColorPickerWindow.Avalonia.cs
+++ b/Configuration Management/Views/ColorPickerWindow.Avalonia.cs
@@ -48,6 +48,7 @@ namespace Configuration_Management
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
                 Spacing = 8,
+                Margin = new Thickness(0, 16, 0, 0),
                 Children =
                 {
                     BuildConfirmButton(LocalizationManager.T("Common.Ok"), 90, OnOk_Click, minimumWidth: true),

--- a/Configuration Management/Views/ColorPickerWindow.Avalonia.cs
+++ b/Configuration Management/Views/ColorPickerWindow.Avalonia.cs
@@ -40,7 +40,20 @@ namespace Configuration_Management
             Grid.SetRow(_picker, 0);
             root.Children.Add(_picker);
 
-            var buttons = BuildButtons(LocalizationManager.T("Common.Ok"), 90, OnOk_Click);
+            // Порядок и оформление как в разметке: подтверждение слева основной
+            // кнопкой, отмена справа вторичной. Общая панель базового класса
+            // ставит их наоборот, поэтому кнопки собираются здесь по одной.
+            var buttons = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Spacing = 8,
+                Children =
+                {
+                    BuildConfirmButton(LocalizationManager.T("Common.Ok"), 90, OnOk_Click, minimumWidth: true),
+                    BuildCancelButton(110, secondary: true, minimumWidth: true)
+                }
+            };
             Grid.SetRow(buttons, 1);
             root.Children.Add(buttons);
 

--- a/Configuration Management/Views/ConnectionStringInputWindow.Avalonia.cs
+++ b/Configuration Management/Views/ConnectionStringInputWindow.Avalonia.cs
@@ -7,6 +7,7 @@ using Avalonia.Input.Platform;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 using Configuration_Management.Services;
 
 namespace Configuration_Management
@@ -36,7 +37,14 @@ namespace Configuration_Management
 
             _dialogs = AppServices.GetRequiredService<IDialogService>();
 
-            _inputBox = new TextBox { Padding = new Thickness(8, 6), AcceptsReturn = true, MinHeight = 80 };
+            // Поле однострочное и во всю ширину, как в разметке
+            // (ConnectionStringInputWindow.xaml:44).
+            _inputBox = new TextBox
+            {
+                Padding = new Thickness(8, 6),
+                MinHeight = 34,
+                VerticalContentAlignment = VerticalAlignment.Center
+            };
             _inputBox.TextChanged += (_, _) => UpdateOkEnabled();
             _inputBox.KeyDown += OnInputBox_KeyDown;
 
@@ -48,55 +56,72 @@ namespace Configuration_Management
 
             var title = new TextBlock
             {
-                Text = LocalizationManager.T("ConnectionStringInput.Header"),
-                FontSize = 15,
-                FontWeight = FontWeight.SemiBold,
-                Margin = new Thickness(0, 0, 0, 8)
+                Text = LocalizationManager.T("ConnectionStringInput.Label"),
+                Margin = new Thickness(0, 0, 0, 6)
             };
             Grid.SetRow(title, 0);
             grid.Children.Add(title);
 
             var hint = new TextBlock
             {
-                Text = LocalizationManager.T("ConnectionStringInput.HintText"),
+                Text = LocalizationManager.T("ConnectionStringInput.Hint"),
                 TextWrapping = TextWrapping.Wrap,
-                FontSize = 12,
+                FontSize = 11,
                 Margin = new Thickness(0, 0, 0, 8)
             };
+            Themes.ThemeBrushes.Bind(hint, TextBlock.ForegroundProperty, "TextSecondaryBrush");
             Grid.SetRow(hint, 1);
             grid.Children.Add(hint);
 
-            var inputArea = new Grid();
-            inputArea.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-            inputArea.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-            Grid.SetColumn(_inputBox, 0);
-            _inputBox.HorizontalAlignment = HorizontalAlignment.Stretch;
-            inputArea.Children.Add(_inputBox);
+            Grid.SetRow(_inputBox, 2);
+            grid.Children.Add(_inputBox);
 
-            var pasteButton = new Button { Content = LocalizationManager.T("ConnectionStringInput.Paste"), MinWidth = 130, Margin = new Thickness(8, 0, 0, 0), VerticalAlignment = VerticalAlignment.Top };
+            // Нижняя строка: вставка из буфера слева, применение и отмена справа
+            // (ConnectionStringInputWindow.xaml:50).
+            var bottom = new Grid { Margin = new Thickness(0, 14, 0, 0) };
+            bottom.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+            bottom.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+            bottom.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+
+            var pasteCaption = new TextBlock
+            {
+                Text = LocalizationManager.T("ConnectionStringInput.Paste"),
+                FontSize = 12,
+                FontWeight = FontWeight.SemiBold,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            var pasteButton = new Button
+            {
+                Content = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6,
+                    Children = { IconHelper.MakeIcon("IconCopy", 15, "SecondaryButtonTextBrush"), pasteCaption }
+                },
+                Height = 38,
+                Padding = new Thickness(12, 0)
+            };
+            pasteButton.Styled(ControlThemes.SecondaryButton);
             ToolTip.SetTip(pasteButton, LocalizationManager.T("ConnectionStringInput.PasteTooltip"));
             pasteButton.Click += (_, _) => OnPasteClipboard_Click();
-            Grid.SetColumn(pasteButton, 1);
-            inputArea.Children.Add(pasteButton);
+            Grid.SetColumn(pasteButton, 0);
+            bottom.Children.Add(pasteButton);
 
-            Grid.SetRow(inputArea, 2);
-            grid.Children.Add(inputArea);
+            _okButton = BuildConfirmActionButton("Common.Apply", "IconCheck", 150, OnOk_Click, height: 38);
+            _okButton.Classes.Add("greyed");
 
             var buttons = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8,
-                Margin = new Thickness(0, 16, 0, 0)
+                Spacing = 10,
+                Children = { _okButton, BuildCancelActionButton(140, height: 38) }
             };
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 100, IsCancel = true };
-            cancel.Click += (_, _) => Close();
-            buttons.Children.Add(cancel);
-            _okButton = new Button { Content = LocalizationManager.T("Common.Apply"), MinWidth = 120, IsDefault = true };
-            _okButton.Click += (_, _) => OnOk_Click();
-            buttons.Children.Add(_okButton);
-            Grid.SetRow(buttons, 3);
-            grid.Children.Add(buttons);
+            Grid.SetColumn(buttons, 2);
+            bottom.Children.Add(buttons);
+
+            Grid.SetRow(bottom, 3);
+            grid.Children.Add(bottom);
 
             Content = grid;
             UpdateOkEnabled();
@@ -208,8 +233,6 @@ namespace Configuration_Management
         private void OnOk_Click()
         {
             Result = _inputBox.Text?.Trim();
-            DialogResult = true;
-            Close();
         }
 
         private void OnInputBox_KeyDown(object? sender, KeyEventArgs e)
@@ -217,6 +240,8 @@ namespace Configuration_Management
             if (e.Key == Key.Enter && _okButton.IsEnabled)
             {
                 OnOk_Click();
+                DialogResult = true;
+                Close();
                 e.Handled = true;
             }
         }

--- a/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
+++ b/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
@@ -368,26 +368,38 @@ namespace Configuration_Management
             {
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8,
+                Spacing = 10,
                 Margin = new Thickness(0, 16, 0, 0)
             };
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 100, IsCancel = true };
-            cancel.Click += (_, _) => Close();
-            buttons.Children.Add(cancel);
+            // Оформление и порядок по разметке (CreateInfobaseWindow.xaml:184):
+            // зелёное создание шириной 140 слева, красная отмена шириной 130 справа.
+            // Кнопка создания закрывает окно сама, только если проверки прошли,
+            // поэтому она собирается здесь, а не общим методом базового класса.
             var create = new Button
             {
-                Content = new TextBlock
+                Content = new StackPanel
                 {
-                    Text = LocalizationManager.T("CreateInfobase.Create"),
-                    Foreground = Brushes.White
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 8,
+                    Children =
+                    {
+                        IconHelper.MakeIcon("IconDatabase", 16, Brushes.White),
+                        new TextBlock
+                        {
+                            Text = LocalizationManager.T("CreateInfobase.Create"),
+                            VerticalAlignment = VerticalAlignment.Center
+                        }
+                    }
                 },
-                MinWidth = 120,
-                IsDefault = true,
-                Background = new SolidColorBrush(Color.Parse("#16A34A")),
-                Foreground = Brushes.White
+                Width = 140,
+                Height = 36,
+                IsDefault = true
             };
+            create.Styled(ControlThemes.DialogConfirmButton);
             create.Click += (_, _) => OnCreate_Click();
             buttons.Children.Add(create);
+            buttons.Children.Add(BuildCancelActionButton(130));
+
             Grid.SetRow(buttons, 5);
             grid.Children.Add(buttons);
 

--- a/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
+++ b/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
@@ -198,6 +198,8 @@ namespace Configuration_Management
             Grid.SetColumn(_groupPathBox, 1);
             groupRow.Children.Add(_groupPathBox);
             var pickGroup = new Button { Content = LocalizationManager.T("CreateInfobase.ChooseGroup"), MinWidth = 90, Margin = new Thickness(8, 0, 0, 0) };
+            pickGroup.Styled(ControlThemes.SecondaryButton);
+            pickGroup.Padding = new Thickness(10, 4);
             ToolTip.SetTip(pickGroup, LocalizationManager.T("CreateInfobase.ChooseGroupTooltip"));
             pickGroup.Click += (_, _) => OnPickGroup_Click();
             Grid.SetColumn(pickGroup, 2);
@@ -217,10 +219,14 @@ namespace Configuration_Management
             platRow.Children.Add(_platformBox);
             var platButtons = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6, Margin = new Thickness(8, 0, 0, 0) };
             var pickPlatform = new Button { Content = LocalizationManager.T("CreateInfobase.List"), MinWidth = 90 };
+            pickPlatform.Styled(ControlThemes.SecondaryButton);
+            pickPlatform.Padding = new Thickness(10, 4);
             ToolTip.SetTip(pickPlatform, LocalizationManager.T("CreateInfobase.ListTooltip"));
             pickPlatform.Click += (_, _) => OnPickPlatform_Click();
             platButtons.Children.Add(pickPlatform);
             var editPaths = new Button { Content = LocalizationManager.T("CreateInfobase.Paths"), MinWidth = 70 };
+            editPaths.Styled(ControlThemes.SecondaryButton);
+            editPaths.Padding = new Thickness(10, 4);
             ToolTip.SetTip(editPaths, LocalizationManager.T("CreateInfobase.PathsTooltip"));
             editPaths.Click += (_, _) => OnEditPlatformPaths_Click();
             platButtons.Children.Add(editPaths);
@@ -230,6 +236,8 @@ namespace Configuration_Management
 
             // Файловая база: путь к каталогу.
             var browseFile = new Button { Content = LocalizationManager.T("Common.Browse"), MinWidth = 90 };
+            browseFile.Styled(ControlThemes.SecondaryButton);
+            browseFile.Padding = new Thickness(10, 4);
             browseFile.Click += (_, _) => OnBrowseFolder_Click();
             var fileRow = new Grid();
             fileRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
@@ -340,10 +348,14 @@ namespace Configuration_Management
                 tplRow.Children.Add(_templateBox);
                 var tplButtons = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6, Margin = new Thickness(8, 0, 0, 0) };
                 var refreshTemplates = new Button { Content = LocalizationManager.T("CreateInfobase.Refresh"), MinWidth = 90 };
+                refreshTemplates.Styled(ControlThemes.SecondaryButton);
+                refreshTemplates.Padding = new Thickness(10, 4);
                 ToolTip.SetTip(refreshTemplates, LocalizationManager.T("CreateInfobase.RefreshTooltip"));
                 refreshTemplates.Click += (_, _) => LoadInstalledTemplates();
                 tplButtons.Children.Add(refreshTemplates);
                 var browseTemplate = new Button { Content = LocalizationManager.T("CreateInfobase.File"), MinWidth = 90 };
+                browseTemplate.Styled(ControlThemes.SecondaryButton);
+                browseTemplate.Padding = new Thickness(10, 4);
                 ToolTip.SetTip(browseTemplate, LocalizationManager.T("CreateInfobase.FileTooltip"));
                 browseTemplate.Click += (_, _) => OnBrowseTemplate_Click();
                 tplButtons.Children.Add(browseTemplate);
@@ -375,27 +387,25 @@ namespace Configuration_Management
             // зелёное создание шириной 140 слева, красная отмена шириной 130 справа.
             // Кнопка создания закрывает окно сама, только если проверки прошли,
             // поэтому она собирается здесь, а не общим методом базового класса.
+            var createCaption = new TextBlock
+            {
+                Text = LocalizationManager.T("CreateInfobase.Create"),
+                VerticalAlignment = VerticalAlignment.Center
+            };
             var create = new Button
             {
                 Content = new StackPanel
                 {
                     Orientation = Orientation.Horizontal,
                     Spacing = 8,
-                    Children =
-                    {
-                        IconHelper.MakeIcon("IconDatabase", 16, Brushes.White),
-                        new TextBlock
-                        {
-                            Text = LocalizationManager.T("CreateInfobase.Create"),
-                            VerticalAlignment = VerticalAlignment.Center
-                        }
-                    }
+                    Children = { IconHelper.MakeIcon("IconDatabase", 16, Brushes.White), createCaption }
                 },
                 Width = 140,
                 Height = 36,
                 IsDefault = true
             };
             create.Styled(ControlThemes.DialogConfirmButton);
+            RegisterConfirmCaption(createCaption, "CreateInfobase.Create");
             create.Click += (_, _) => OnCreate_Click();
             buttons.Children.Add(create);
             buttons.Children.Add(BuildCancelActionButton(130));

--- a/Configuration Management/Views/GroupEditWindow.Avalonia.cs
+++ b/Configuration Management/Views/GroupEditWindow.Avalonia.cs
@@ -151,8 +151,10 @@ namespace Configuration_Management
 
         private Control BuildRoot()
         {
-            var grid = new Grid { Margin = new Thickness(16) };
-            grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+            // Раскладка по разметке (GroupEditWindow.xaml:154): вкладки тянутся
+            // на всю высоту, кнопки прижаты к низу отдельной полосой с отбивкой.
+            var grid = new Grid();
+            grid.RowDefinitions.Add(new RowDefinition(new GridLength(1, GridUnitType.Star)));
             grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
 
             var tabs = new TabControl();
@@ -231,12 +233,35 @@ namespace Configuration_Management
             iconTab.Children.Add(iconScroll);
             tabs.Items.Add(new TabItem { Header = LocalizationManager.T("GroupEdit.TabIcon"), Content = iconTab });
 
+            tabs.Margin = new Thickness(16, 16, 16, 0);
             Grid.SetRow(tabs, 0);
             grid.Children.Add(tabs);
 
-            var buttons = BuildButtons(LocalizationManager.T("Common.Save"), 140, OnSave_Click);
-            Grid.SetRow(buttons, 1);
-            grid.Children.Add(buttons);
+            // Нижняя панель по разметке (GroupEditWindow.xaml:293): зелёное
+            // сохранение шириной 130 слева, красная отмена шириной 120 справа.
+            // Значок отмены в разметке взят из ключа IconClear, у нас тот же
+            // контур лежит под именем IconClose.
+            var buttons = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Spacing = 10,
+                Children =
+                {
+                    BuildConfirmActionButton("Common.Save", "IconSave", 130, OnSave_Click),
+                    BuildCancelActionButton(120, iconSize: 14)
+                }
+            };
+            var buttonsBar = new Border
+            {
+                Padding = new Thickness(16, 10, 16, 16),
+                BorderThickness = new Thickness(0, 1, 0, 0),
+                Child = buttons
+            };
+            Themes.ThemeBrushes.Bind(buttonsBar, Border.BorderBrushProperty, "BorderBrushColor");
+            Themes.ThemeBrushes.Bind(buttonsBar, Border.BackgroundProperty, "CardBackgroundBrush");
+            Grid.SetRow(buttonsBar, 1);
+            grid.Children.Add(buttonsBar);
 
             return grid;
         }

--- a/Configuration Management/Views/GroupEditWindow.Avalonia.cs
+++ b/Configuration Management/Views/GroupEditWindow.Avalonia.cs
@@ -10,6 +10,7 @@ using Avalonia.Media;
 using Path = Avalonia.Controls.Shapes.Path;
 using Configuration_Management.Controls;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 using Configuration_Management.Models;
 using Configuration_Management.ViewModels;
 
@@ -188,7 +189,14 @@ namespace Configuration_Management
                 Margin = new Thickness(8, 0, 0, 0),
                 VerticalAlignment = VerticalAlignment.Center
             };
-            var selectParent = new Button { Content = LocalizationManager.T("GroupEdit.SelectParent"), MinWidth = 90 };
+            var selectParent = new Button
+            {
+                Content = IconHelper.IconAndText("IconFolder", LocalizationManager.T("GroupEdit.SelectParent"), 14,
+                    "SecondaryButtonTextBrush"),
+                MinWidth = 90,
+                Padding = new Thickness(10, 4)
+            };
+            selectParent.Styled(Themes.ControlThemes.SecondaryButton);
             selectParent.IsEnabled = !_noGroupMode;
             selectParent.Click += (_, _) => OnSelectParent_Click();
             ToolTip.SetTip(selectParent, LocalizationManager.T("GroupEdit.SelectParentTooltip"));
@@ -248,8 +256,8 @@ namespace Configuration_Management
                 Spacing = 10,
                 Children =
                 {
-                    BuildConfirmActionButton("Common.Save", "IconSave", 130, OnSave_Click),
-                    BuildCancelActionButton(120, iconSize: 14)
+                    BuildConfirmActionButton("Common.Save", "IconSave", 130, OnSave_Click, iconGap: 8),
+                    BuildCancelActionButton(120, iconSize: 14, iconGap: 8)
                 }
             };
             var buttonsBar = new Border

--- a/Configuration Management/Views/GroupSettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/GroupSettingsWindow.Avalonia.cs
@@ -10,6 +10,7 @@ using Avalonia.Controls.Templates;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 using Configuration_Management.Models;
 using Configuration_Management.Services;
 using Configuration_Management.ViewModels;
@@ -26,7 +27,7 @@ namespace Configuration_Management
         private readonly ObservableCollection<Group> _groups;
         private readonly IDialogService _dialogs;
         private readonly TreeView _tree = new();
-        private readonly Button _doneButton = new() { Content = LocalizationManager.T("GroupSettings.Done"), MinWidth = 110, IsDefault = true };
+        private readonly Button _doneButton = new() { IsDefault = true };
 
         /// <summary>
         /// Создаёт диалог управления группами.
@@ -99,22 +100,48 @@ namespace Configuration_Management
             Grid.SetRow(treeBorder, 1);
             grid.Children.Add(treeBorder);
 
-            // Кнопки управления
+            // Кнопки управления по разметке (GroupSettingsWindow.xaml:67):
+            // добавление корневой группы основной кнопкой, остальные вторичными,
+            // все шириной 120.
             var actions = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 12, 0, 0), Spacing = 8 };
-            actions.Children.Add(MakeButton(LocalizationManager.T("GroupSettings.AddRoot"), "IconAdd", OnAddRoot_Click));
-            actions.Children.Add(MakeButton(LocalizationManager.T("GroupSettings.AddSubgroup"), "IconAdd", OnAddSubgroup_Click));
-            actions.Children.Add(MakeButton(LocalizationManager.T("Common.Edit"), "IconEdit", OnEdit_Click));
-            actions.Children.Add(MakeButton(LocalizationManager.T("Common.Delete"), "IconDelete", OnDelete_Click));
+            actions.Children.Add(MakeButton(LocalizationManager.T("Common.Add"), "IconAdd", OnAddRoot_Click, ControlThemes.ModernButton));
+            actions.Children.Add(MakeButton(LocalizationManager.T("GroupSettings.AddSubgroup"), "IconAdd", OnAddSubgroup_Click, ControlThemes.SecondaryButton));
+            actions.Children.Add(MakeButton(LocalizationManager.T("Common.Edit"), "IconEdit", OnEdit_Click, ControlThemes.SecondaryButton));
+            actions.Children.Add(MakeButton(LocalizationManager.T("Common.Delete"), "IconDelete", OnDelete_Click, ControlThemes.SecondaryButton));
             Grid.SetRow(actions, 2);
             grid.Children.Add(actions);
 
             // Нижняя панель
-            var bottom = new Grid { Margin = new Thickness(0, 12, 0, 0) };
-            bottom.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-            bottom.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+            // Нижняя панель по разметке (GroupSettingsWindow.xaml:101): готово
+            // основной кнопкой, отмена вторичной, обе 120 на 34, зазор 10.
+            var doneCaption = new TextBlock
+            {
+                Text = LocalizationManager.T("GroupSettings.Done"),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            _doneButton.Content = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 6,
+                Children = { IconHelper.MakeIcon("IconOk", 14, "ButtonTextBrush"), doneCaption }
+            };
+            _doneButton.Styled(ControlThemes.ModernButton);
+            _doneButton.Width = 120;
+            _doneButton.Height = 34;
             _doneButton.Click += (_, _) => { DialogResult = true; Close(); };
-            Grid.SetColumn(_doneButton, 1);
-            bottom.Children.Add(_doneButton);
+            RegisterConfirmCaption(doneCaption, "GroupSettings.Done");
+
+            var cancel = BuildCancelButton(120, secondary: true);
+            cancel.Height = 34;
+
+            var bottom = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Spacing = 10,
+                Margin = new Thickness(0, 12, 0, 0),
+                Children = { _doneButton, cancel }
+            };
             Grid.SetRow(bottom, 3);
             grid.Children.Add(bottom);
 
@@ -123,9 +150,17 @@ namespace Configuration_Management
             return grid;
         }
 
-        private Button MakeButton(string text, string iconKey, Action onClick)
+        private Button MakeButton(string text, string iconKey, Action onClick, string themeKey)
         {
-            var button = new Button { Content = IconHelper.IconAndText(iconKey, text) };
+            // Значок красится под тему кнопки: у основной подпись и значок идут
+            // цветом текста на акценте, у вторичной своим.
+            var button = new Button
+            {
+                Content = IconHelper.IconAndText(iconKey, text, 16,
+                    themeKey == ControlThemes.ModernButton ? "ButtonTextBrush" : "SecondaryButtonTextBrush"),
+                Width = 120
+            };
+            button.Styled(themeKey);
             button.Click += (_, _) => onClick();
             return button;
         }

--- a/Configuration Management/Views/LaunchParametersWindow.Avalonia.cs
+++ b/Configuration Management/Views/LaunchParametersWindow.Avalonia.cs
@@ -202,6 +202,7 @@ namespace Configuration_Management
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
                 Spacing = 10,
+                Margin = new Thickness(0, 8, 0, 0),
                 Children =
                 {
                     BuildConfirmActionButton("Common.Ok", "IconCheck", 140, OnOk_Click),

--- a/Configuration Management/Views/LaunchParametersWindow.Avalonia.cs
+++ b/Configuration Management/Views/LaunchParametersWindow.Avalonia.cs
@@ -196,18 +196,18 @@ namespace Configuration_Management
             grid.Children.Add(listBorder);
 
             // Кнопки
+            // Оформление и порядок по разметке (LaunchParametersWindow.xaml:77).
             var buttons = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8
+                Spacing = 10,
+                Children =
+                {
+                    BuildConfirmActionButton("Common.Ok", "IconCheck", 140, OnOk_Click),
+                    BuildCancelActionButton(140)
+                }
             };
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 100, IsCancel = true };
-            cancel.Click += (_, _) => Close();
-            buttons.Children.Add(cancel);
-            var ok = new Button { Content = LocalizationManager.T("Common.Ok"), MinWidth = 110, IsDefault = true };
-            ok.Click += (_, _) => OnOk_Click();
-            buttons.Children.Add(ok);
             Grid.SetRow(buttons, 6);
             grid.Children.Add(buttons);
 
@@ -235,8 +235,6 @@ namespace Configuration_Management
         private void OnOk_Click()
         {
             Result = (_txtCustom.Text ?? string.Empty).Trim();
-            DialogResult = true;
-            Close();
         }
 
         /// <summary>Строит каталог ключей командной строки 1С для справочника.</summary>

--- a/Configuration Management/Views/LinkInputWindow.axaml
+++ b/Configuration Management/Views/LinkInputWindow.axaml
@@ -27,22 +27,33 @@
                        Foreground="{DynamicResource TextSecondaryBrush}"/>
         </StackPanel>
 
+        <!-- Порядок, размеры и цвета по разметке WPF (LinkInputWindow.xaml:50):
+             зелёный переход слева, красная отмена справа, зазор 10. -->
         <StackPanel Grid.Row="2" Orientation="Horizontal"
-                    HorizontalAlignment="Right" Spacing="8" Margin="0,16,0,0">
-            <Button x:Name="CancelButton" MinWidth="110" IsCancel="True">
+                    HorizontalAlignment="Right" Spacing="10" Margin="0,16,0,0">
+            <Button x:Name="OkButton" Width="150" Height="38" IsDefault="True"
+                    Classes="greyed"
+                    Theme="{DynamicResource DialogConfirmButton}">
                 <StackPanel Orientation="Horizontal" Spacing="6">
-                    <Path Data="{DynamicResource IconClose}" Width="14" Height="14"
-                          Stretch="Uniform" Fill="{DynamicResource TextPrimaryBrush}"
-                          VerticalAlignment="Center"/>
-                    <TextBlock Text="{loc:Loc Common.Cancel}" VerticalAlignment="Center"/>
+                    <!-- Контур кладётся в холст 24 на 24 и масштабируется целиком,
+                         как это делает IconHelper.MakeIcon и PackIcon в WPF. -->
+                    <Viewbox Width="16" Height="16" Stretch="Uniform" VerticalAlignment="Center">
+                        <Canvas Width="24" Height="24">
+                            <Path Data="{DynamicResource IconArrowRight}" Fill="White"/>
+                        </Canvas>
+                    </Viewbox>
+                    <TextBlock Text="{loc:Loc LinkInput.Go}" VerticalAlignment="Center"/>
                 </StackPanel>
             </Button>
-            <Button x:Name="OkButton" MinWidth="130" IsDefault="True">
+            <Button x:Name="CancelButton" Width="140" Height="38" IsCancel="True"
+                    Theme="{DynamicResource DialogCancelButton}">
                 <StackPanel Orientation="Horizontal" Spacing="6">
-                    <Path Data="{DynamicResource IconOk}" Width="14" Height="14"
-                          Stretch="Uniform" Fill="{DynamicResource TextPrimaryBrush}"
-                          VerticalAlignment="Center"/>
-                    <TextBlock Text="{loc:Loc LinkInput.Go}" VerticalAlignment="Center"/>
+                    <Viewbox Width="16" Height="16" Stretch="Uniform" VerticalAlignment="Center">
+                        <Canvas Width="24" Height="24">
+                            <Path Data="{DynamicResource IconClose}" Fill="#EF4444"/>
+                        </Canvas>
+                    </Viewbox>
+                    <TextBlock Text="{loc:Loc Common.Cancel}" VerticalAlignment="Center"/>
                 </StackPanel>
             </Button>
         </StackPanel>

--- a/Configuration Management/Views/LinkInputWindow.axaml
+++ b/Configuration Management/Views/LinkInputWindow.axaml
@@ -12,24 +12,27 @@
                        SizeToContent="Height"
                        CanResize="False"
                        SystemDecorations="Full">
-    <Grid Margin="16" RowDefinitions="Auto,Auto,Auto">
+    <Grid Margin="16" RowDefinitions="Auto,Auto,Auto,Auto">
 
+        <!-- Порядок по разметке (LinkInputWindow.xaml:35): подпись, примеры
+             допустимых ссылок, затем поле ввода. -->
         <TextBlock Grid.Row="0"
                    Text="{loc:Loc LinkInput.Label}"
                    TextWrapping="Wrap"
-                   Margin="0,0,0,8"/>
+                   Margin="0,0,0,6"/>
 
-        <StackPanel Grid.Row="1" Spacing="4">
-            <TextBox x:Name="LinkBox" Padding="8,6"/>
-            <!-- Примеры допустимых ссылок, как под полем в разметке WPF. -->
-            <TextBlock Text="{loc:Loc LinkInput.Hint}" FontSize="11"
-                       TextWrapping="Wrap"
-                       Foreground="{DynamicResource TextSecondaryBrush}"/>
-        </StackPanel>
+        <TextBlock Grid.Row="1"
+                   Text="{loc:Loc LinkInput.Hint}"
+                   FontSize="11"
+                   TextWrapping="Wrap"
+                   Margin="0,0,0,8"
+                   Foreground="{DynamicResource TextSecondaryBrush}"/>
+
+        <TextBox Grid.Row="2" x:Name="LinkBox" Padding="8,6"/>
 
         <!-- Порядок, размеры и цвета по разметке WPF (LinkInputWindow.xaml:50):
              зелёный переход слева, красная отмена справа, зазор 10. -->
-        <StackPanel Grid.Row="2" Orientation="Horizontal"
+        <StackPanel Grid.Row="3" Orientation="Horizontal"
                     HorizontalAlignment="Right" Spacing="10" Margin="0,16,0,0">
             <Button x:Name="OkButton" Width="150" Height="38" IsDefault="True"
                     Classes="greyed"

--- a/Configuration Management/Views/LoginWindow.Avalonia.cs
+++ b/Configuration Management/Views/LoginWindow.Avalonia.cs
@@ -160,26 +160,24 @@ namespace Configuration_Management
             var cancel = BuildCancelButton(110);
             panel.Children.Add(cancel);
 
+            var loginCaption = new TextBlock
+            {
+                Text = LocalizationManager.T("Auth.Login"),
+                VerticalAlignment = VerticalAlignment.Center
+            };
             var login = new Button
             {
                 Content = new StackPanel
                 {
                     Orientation = Orientation.Horizontal,
                     Spacing = 6,
-                    Children =
-                    {
-                        IconHelper.MakeIcon("IconOk", 14, "ButtonTextBrush"),
-                        new TextBlock
-                        {
-                            Text = LocalizationManager.T("Auth.Login"),
-                            VerticalAlignment = VerticalAlignment.Center
-                        }
-                    }
+                    Children = { IconHelper.MakeIcon("IconOk", 14, "ButtonTextBrush"), loginCaption }
                 },
                 Width = 130,
                 IsDefault = true
             };
             login.Styled(ControlThemes.ModernButton);
+            RegisterConfirmCaption(loginCaption, "Auth.Login");
             login.Click += (_, _) => TryLogin();
             panel.Children.Add(login);
 

--- a/Configuration Management/Views/LoginWindow.Avalonia.cs
+++ b/Configuration Management/Views/LoginWindow.Avalonia.cs
@@ -8,6 +8,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Controls;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 using Configuration_Management.Models;
 using Configuration_Management.Services;
 
@@ -154,11 +155,31 @@ namespace Configuration_Management
                 Spacing = 8
             };
 
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 110 };
-            cancel.Click += (_, _) => Close();
+            // Оформление по разметке (LoginWindow.xaml:62): обе кнопки в стиле
+            // основной, у отмены заливка мягкая, у входа акцентная.
+            var cancel = BuildCancelButton(110);
             panel.Children.Add(cancel);
 
-            var login = new Button { Content = LocalizationManager.T("Auth.Login"), MinWidth = 130 };
+            var login = new Button
+            {
+                Content = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6,
+                    Children =
+                    {
+                        IconHelper.MakeIcon("IconOk", 14, "ButtonTextBrush"),
+                        new TextBlock
+                        {
+                            Text = LocalizationManager.T("Auth.Login"),
+                            VerticalAlignment = VerticalAlignment.Center
+                        }
+                    }
+                },
+                Width = 130,
+                IsDefault = true
+            };
+            login.Styled(ControlThemes.ModernButton);
             login.Click += (_, _) => TryLogin();
             panel.Children.Add(login);
 

--- a/Configuration Management/Views/ModalWindowBase.cs
+++ b/Configuration Management/Views/ModalWindowBase.cs
@@ -23,8 +23,10 @@ namespace Configuration_Management
         /// <summary>
         /// Задаёт окну фон темы. В разметке WPF его ставит каждое окно
         /// (<c>Background="{DynamicResource ContentBackgroundBrush}"</c>),
-        /// здесь это одно место на все диалоги. Окно, которому нужен свой фон,
-        /// присваивает его после базового конструктора, и его значение старше.
+        /// здесь это одно место на все диалоги. Окну, которому нужен свой фон,
+        /// присвоения мало: привязка держит то же местное значение и вернёт своё
+        /// при следующей смене темы или схемы, поэтому её надо снимать
+        /// (<c>ClearValue(BackgroundProperty)</c>) до присвоения.
         /// </summary>
         protected ModalWindowBase()
         {
@@ -139,8 +141,12 @@ namespace Configuration_Management
         /// <param name="onOk">Что выполнить перед закрытием с положительным результатом.</param>
         /// <param name="cancelWidth">Ширина кнопки отмены.</param>
         /// <param name="okIconKey">Ключ значка кнопки подтверждения.</param>
+        /// <param name="okTextKey">
+        /// Ключ подписи подтверждения вместо готовой строки: только так подпись
+        /// переводится при смене языка.
+        /// </param>
         protected StackPanel BuildButtons(string? okText = null, double okWidth = 130, Action? onOk = null,
-            double cancelWidth = 110, string okIconKey = "IconOk")
+            double cancelWidth = 110, string okIconKey = "IconOk", string? okTextKey = null)
         {
             var panel = new StackPanel
             {
@@ -150,7 +156,7 @@ namespace Configuration_Management
             };
 
             panel.Children.Add(BuildCancelButton(cancelWidth));
-            panel.Children.Add(BuildConfirmButton(okText, okWidth, onOk, okIconKey: okIconKey));
+            panel.Children.Add(BuildConfirmButton(okText, okWidth, onOk, okIconKey: okIconKey, okTextKey: okTextKey));
             return panel;
         }
 
@@ -209,12 +215,15 @@ namespace Configuration_Management
         /// <param name="onOk">Что выполнить перед закрытием.</param>
         /// <param name="minimumWidth">Ширина задаётся как минимальная, а не жёсткая.</param>
         /// <param name="okIconKey">Ключ значка.</param>
+        /// <param name="okTextKey">Ключ подписи вместо готовой строки.</param>
         protected Button BuildConfirmButton(string? okText, double width = 130, Action? onOk = null,
-            bool minimumWidth = false, string okIconKey = "IconOk")
+            bool minimumWidth = false, string okIconKey = "IconOk", string? okTextKey = null)
         {
             var caption = new TextBlock
             {
-                Text = ResolveOkText(okText),
+                Text = okTextKey is { Length: > 0 } captionKey
+                    ? LocalizationManager.T(captionKey)
+                    : ResolveOkText(okText),
                 VerticalAlignment = VerticalAlignment.Center
             };
 
@@ -244,14 +253,14 @@ namespace Configuration_Management
 
             _lastOkText = caption;
             _lastOkRaw = okText ?? "";
-            _lastOkKey = null;
+            _lastOkKey = okTextKey;
             EnsureLanguageSubscription();
             return button;
         }
 
         /// <summary>
         /// Кнопка подтверждения нижней панели диалога: зелёная заливка, белые
-        /// значок и подпись. Так эта кнопка задана в разметке WPF у девяти окон.
+        /// значок и подпись. Так эта кнопка задана в разметке WPF у десяти окон.
         /// </summary>
         /// <param name="textKey">Ключ локализации подписи.</param>
         /// <param name="iconKey">Ключ значка.</param>
@@ -259,8 +268,14 @@ namespace Configuration_Management
         /// <param name="onOk">Что выполнить перед закрытием с положительным результатом.</param>
         /// <param name="height">Высота кнопки.</param>
         /// <param name="iconSize">Размер значка.</param>
+        /// <param name="iconGap">Зазор между значком и подписью.</param>
+        /// <param name="closeOnClick">
+        /// Закрывать окно по нажатию. Ложь нужна окнам, где кнопка сначала
+        /// проверяет введённое и закрывает окно сама.
+        /// </param>
         protected Button BuildConfirmActionButton(string textKey, string iconKey, double width,
-            Action? onOk = null, double height = 36, double iconSize = 16)
+            Action? onOk = null, double height = 36, double iconSize = 16, double iconGap = 6,
+            bool closeOnClick = true)
         {
             var caption = new TextBlock
             {
@@ -273,7 +288,7 @@ namespace Configuration_Management
                 Content = new StackPanel
                 {
                     Orientation = Orientation.Horizontal,
-                    Spacing = 6,
+                    Spacing = iconGap,
                     Children =
                     {
                         IconHelper.MakeIcon(iconKey, iconSize, Brushes.White),
@@ -286,12 +301,19 @@ namespace Configuration_Management
             };
 
             button.Styled(ControlThemes.DialogConfirmButton);
-            button.Click += (_, _) =>
+            if (closeOnClick)
             {
-                onOk?.Invoke();
-                DialogResult = true;
-                Close();
-            };
+                button.Click += (_, _) =>
+                {
+                    onOk?.Invoke();
+                    DialogResult = true;
+                    Close();
+                };
+            }
+            else if (onOk is not null)
+            {
+                button.Click += (_, _) => onOk();
+            }
 
             _lastOkText = caption;
             _lastOkKey = textKey;
@@ -306,7 +328,9 @@ namespace Configuration_Management
         /// <param name="width">Ширина кнопки.</param>
         /// <param name="height">Высота кнопки.</param>
         /// <param name="iconSize">Размер значка.</param>
-        protected Button BuildCancelActionButton(double width = 140, double height = 36, double iconSize = 16)
+        /// <param name="iconGap">Зазор между значком и подписью.</param>
+        protected Button BuildCancelActionButton(double width = 140, double height = 36,
+            double iconSize = 16, double iconGap = 6)
         {
             var caption = new TextBlock
             {
@@ -319,7 +343,7 @@ namespace Configuration_Management
                 Content = new StackPanel
                 {
                     Orientation = Orientation.Horizontal,
-                    Spacing = 6,
+                    Spacing = iconGap,
                     Children =
                     {
                         IconHelper.MakeIcon("IconClose", iconSize, DangerBrush),
@@ -341,6 +365,20 @@ namespace Configuration_Management
 
         /// <summary>Красный цвет отмены и удаления: в разметке WPF он задан числом.</summary>
         protected static readonly IBrush DangerBrush = new SolidColorBrush(Color.Parse("#EF4444"));
+
+        /// <summary>
+        /// Берёт на себя перевод подписи кнопки, которую окно собрало само.
+        /// Без этого при смене языка переводится только «Отмена», и панель
+        /// остаётся двуязычной.
+        /// </summary>
+        /// <param name="caption">Подпись кнопки подтверждения.</param>
+        /// <param name="textKey">Ключ локализации этой подписи.</param>
+        protected void RegisterConfirmCaption(TextBlock caption, string textKey)
+        {
+            _lastOkText = caption;
+            _lastOkKey = textKey;
+            EnsureLanguageSubscription();
+        }
 
         private static void SetButtonWidth(Button button, double width, bool minimumWidth)
         {

--- a/Configuration Management/Views/ModalWindowBase.cs
+++ b/Configuration Management/Views/ModalWindowBase.cs
@@ -4,8 +4,10 @@ using System.Threading;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Avalonia.Threading;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 
 namespace Configuration_Management
 {
@@ -19,6 +21,17 @@ namespace Configuration_Management
     public abstract class ModalWindowBase : Window
     {
         /// <summary>
+        /// Задаёт окну фон темы. В разметке WPF его ставит каждое окно
+        /// (<c>Background="{DynamicResource ContentBackgroundBrush}"</c>),
+        /// здесь это одно место на все диалоги. Окно, которому нужен свой фон,
+        /// присваивает его после базового конструктора, и его значение старше.
+        /// </summary>
+        protected ModalWindowBase()
+        {
+            Themes.ThemeBrushes.Bind(this, BackgroundProperty, "ContentBackgroundBrush");
+        }
+
+        /// <summary>
         /// Источник локализации для привязок XAML: <c>{Binding Loc[Key]}</c>.
         /// При смене языка открытые окна автоматически обновляют текст.
         /// </summary>
@@ -28,6 +41,9 @@ namespace Configuration_Management
         private TextBlock? _lastCancelText;
         private TextBlock? _lastOkText;
         private string _lastOkRaw = "";
+        // Ключ подписи подтверждения, когда кнопку строили по ключу, а не по
+        // готовой строке: только так подпись переводится при смене языка.
+        private string? _lastOkKey;
         private bool _languageSubscribed;
 
         /// <summary>Результат диалога: true — подтверждён (ОК), false — отменён.</summary>
@@ -114,7 +130,17 @@ namespace Configuration_Management
             return mark;
         }
 
-        protected StackPanel BuildButtons(string? okText = null, double okWidth = 130, Action? onOk = null)
+        /// <summary>
+        /// Строит правую панель кнопок «Отмена» и подтверждение, как в разметке WPF:
+        /// отмена мягкой заливкой, подтверждение акцентом, зазор 8.
+        /// </summary>
+        /// <param name="okText">Подпись кнопки подтверждения; пусто означает «ОК».</param>
+        /// <param name="okWidth">Ширина кнопки подтверждения.</param>
+        /// <param name="onOk">Что выполнить перед закрытием с положительным результатом.</param>
+        /// <param name="cancelWidth">Ширина кнопки отмены.</param>
+        /// <param name="okIconKey">Ключ значка кнопки подтверждения.</param>
+        protected StackPanel BuildButtons(string? okText = null, double okWidth = 130, Action? onOk = null,
+            double cancelWidth = 110, string okIconKey = "IconOk")
         {
             var panel = new StackPanel
             {
@@ -123,10 +149,28 @@ namespace Configuration_Management
                 Spacing = 8
             };
 
-            var cancelText = new TextBlock { Text = LocalizationManager.T("Common.Cancel"), VerticalAlignment = VerticalAlignment.Center };
-            var okTextBlock = new TextBlock { Text = ResolveOkText(okText), VerticalAlignment = VerticalAlignment.Center };
+            panel.Children.Add(BuildCancelButton(cancelWidth));
+            panel.Children.Add(BuildConfirmButton(okText, okWidth, onOk, okIconKey: okIconKey));
+            return panel;
+        }
 
-            var cancel = new Button
+        /// <summary>
+        /// Кнопка отмены. По умолчанию это основная кнопка с мягкой заливкой и
+        /// основным цветом текста, как её задаёт разметка WPF в диалогах ввода;
+        /// <paramref name="secondary"/> переключает её на стиль вторичной кнопки.
+        /// </summary>
+        /// <param name="width">Ширина кнопки.</param>
+        /// <param name="secondary">Оформлять стилем вторичной кнопки.</param>
+        /// <param name="minimumWidth">Ширина задаётся как минимальная, а не жёсткая.</param>
+        protected Button BuildCancelButton(double width = 110, bool secondary = false, bool minimumWidth = false)
+        {
+            var caption = new TextBlock
+            {
+                Text = LocalizationManager.T("Common.Cancel"),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            var button = new Button
             {
                 Content = new StackPanel
                 {
@@ -134,17 +178,47 @@ namespace Configuration_Management
                     Spacing = 6,
                     Children =
                     {
-                        IconHelper.MakeIcon("IconClose", 14),
-                        cancelText
+                        IconHelper.MakeIcon("IconClose", 14, secondary ? "SecondaryButtonTextBrush" : "TextPrimaryBrush"),
+                        caption
                     }
                 },
-                MinWidth = 110,
                 IsCancel = true
             };
-            cancel.Click += (_, _) => Close();
-            panel.Children.Add(cancel);
 
-            var ok = new Button
+            button.Styled(secondary ? ControlThemes.SecondaryButton : ControlThemes.ModernButton);
+            if (!secondary)
+            {
+                Themes.ThemeBrushes.Bind(button, BackgroundProperty, "ItemHoverBrush");
+                Themes.ThemeBrushes.Bind(button, ForegroundProperty, "TextPrimaryBrush");
+            }
+
+            SetButtonWidth(button, width, minimumWidth);
+            button.Click += (_, _) => Close();
+
+            _lastCancelText = caption;
+            EnsureLanguageSubscription();
+            return button;
+        }
+
+        /// <summary>
+        /// Кнопка подтверждения: акцентная заливка, значок и подпись, закрытие
+        /// с положительным результатом.
+        /// </summary>
+        /// <param name="okText">Подпись; пусто означает «ОК».</param>
+        /// <param name="width">Ширина кнопки.</param>
+        /// <param name="onOk">Что выполнить перед закрытием.</param>
+        /// <param name="minimumWidth">Ширина задаётся как минимальная, а не жёсткая.</param>
+        /// <param name="okIconKey">Ключ значка.</param>
+        protected Button BuildConfirmButton(string? okText, double width = 130, Action? onOk = null,
+            bool minimumWidth = false, string okIconKey = "IconOk")
+        {
+            var caption = new TextBlock
+            {
+                Text = ResolveOkText(okText),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            var button = new Button
             {
                 Content = new StackPanel
                 {
@@ -152,28 +226,128 @@ namespace Configuration_Management
                     Spacing = 6,
                     Children =
                     {
-                        IconHelper.MakeIcon("IconOk", 14),
-                        okTextBlock
+                        IconHelper.MakeIcon(okIconKey, 14, "ButtonTextBrush"),
+                        caption
                     }
                 },
-                MinWidth = okWidth,
                 IsDefault = true
             };
-            ok.Click += (_, _) =>
+
+            button.Styled(ControlThemes.ModernButton);
+            SetButtonWidth(button, width, minimumWidth);
+            button.Click += (_, _) =>
             {
                 onOk?.Invoke();
                 DialogResult = true;
                 Close();
             };
-            panel.Children.Add(ok);
 
-            // Живое обновление кнопок при смене языка.
-            _lastCancelText = cancelText;
-            _lastOkText = okTextBlock;
+            _lastOkText = caption;
             _lastOkRaw = okText ?? "";
+            _lastOkKey = null;
             EnsureLanguageSubscription();
+            return button;
+        }
 
-            return panel;
+        /// <summary>
+        /// Кнопка подтверждения нижней панели диалога: зелёная заливка, белые
+        /// значок и подпись. Так эта кнопка задана в разметке WPF у девяти окон.
+        /// </summary>
+        /// <param name="textKey">Ключ локализации подписи.</param>
+        /// <param name="iconKey">Ключ значка.</param>
+        /// <param name="width">Ширина кнопки.</param>
+        /// <param name="onOk">Что выполнить перед закрытием с положительным результатом.</param>
+        /// <param name="height">Высота кнопки.</param>
+        /// <param name="iconSize">Размер значка.</param>
+        protected Button BuildConfirmActionButton(string textKey, string iconKey, double width,
+            Action? onOk = null, double height = 36, double iconSize = 16)
+        {
+            var caption = new TextBlock
+            {
+                Text = LocalizationManager.T(textKey),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            var button = new Button
+            {
+                Content = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6,
+                    Children =
+                    {
+                        IconHelper.MakeIcon(iconKey, iconSize, Brushes.White),
+                        caption
+                    }
+                },
+                Width = width,
+                Height = height,
+                IsDefault = true
+            };
+
+            button.Styled(ControlThemes.DialogConfirmButton);
+            button.Click += (_, _) =>
+            {
+                onOk?.Invoke();
+                DialogResult = true;
+                Close();
+            };
+
+            _lastOkText = caption;
+            _lastOkKey = textKey;
+            EnsureLanguageSubscription();
+            return button;
+        }
+
+        /// <summary>
+        /// Кнопка отмены нижней панели диалога: прозрачная заливка, красный контур,
+        /// красные значок и подпись, как в разметке WPF.
+        /// </summary>
+        /// <param name="width">Ширина кнопки.</param>
+        /// <param name="height">Высота кнопки.</param>
+        /// <param name="iconSize">Размер значка.</param>
+        protected Button BuildCancelActionButton(double width = 140, double height = 36, double iconSize = 16)
+        {
+            var caption = new TextBlock
+            {
+                Text = LocalizationManager.T("Common.Cancel"),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            var button = new Button
+            {
+                Content = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6,
+                    Children =
+                    {
+                        IconHelper.MakeIcon("IconClose", iconSize, DangerBrush),
+                        caption
+                    }
+                },
+                Width = width,
+                Height = height,
+                IsCancel = true
+            };
+
+            button.Styled(ControlThemes.DialogCancelButton);
+            button.Click += (_, _) => Close();
+
+            _lastCancelText = caption;
+            EnsureLanguageSubscription();
+            return button;
+        }
+
+        /// <summary>Красный цвет отмены и удаления: в разметке WPF он задан числом.</summary>
+        protected static readonly IBrush DangerBrush = new SolidColorBrush(Color.Parse("#EF4444"));
+
+        private static void SetButtonWidth(Button button, double width, bool minimumWidth)
+        {
+            if (minimumWidth)
+                button.MinWidth = width;
+            else
+                button.Width = width;
         }
 
         /// <summary>
@@ -201,7 +375,9 @@ namespace Configuration_Management
             if (_lastCancelText is not null)
                 _lastCancelText.Text = LocalizationManager.T("Common.Cancel");
             if (_lastOkText is not null)
-                _lastOkText.Text = ResolveOkText(_lastOkRaw);
+                _lastOkText.Text = _lastOkKey is { Length: > 0 } key
+                    ? LocalizationManager.T(key)
+                    : ResolveOkText(_lastOkRaw);
         }
     }
 }

--- a/Configuration Management/Views/NameInputWindow.axaml
+++ b/Configuration Management/Views/NameInputWindow.axaml
@@ -13,6 +13,7 @@
     <Grid Margin="16" RowDefinitions="Auto,Auto,Auto">
         <TextBlock Grid.Row="0" x:Name="Prompt" Margin="0,0,0,8"/>
         <TextBox Grid.Row="1" x:Name="NameBox" Padding="8,6"/>
-        <ContentControl Grid.Row="2" x:Name="ButtonsHost"/>
+        <!-- Отступ панели кнопок сверху взят из разметки WPF. -->
+        <ContentControl Grid.Row="2" x:Name="ButtonsHost" Margin="0,16,0,0"/>
     </Grid>
 </local:ModalWindowBase>

--- a/Configuration Management/Views/PlatformVersionPickerWindow.Avalonia.cs
+++ b/Configuration Management/Views/PlatformVersionPickerWindow.Avalonia.cs
@@ -34,7 +34,7 @@ namespace Configuration_Management
         private HashSet<PlatformVersionGroup>? _initialAncestors;
 
         private readonly TreeView _tree = new();
-        private readonly Button _selectButton = new() { Content = LocalizationManager.T("Common.Select"), MinWidth = 110, IsDefault = true };
+        private Button _selectButton = null!;
         private readonly RadioButton _filterAll = new() { Content = LocalizationManager.T("Common.All"), IsChecked = true, GroupName = "Arch" };
         private readonly RadioButton _filterX32 = new() { Content = LocalizationManager.T("PlatformVersionPicker.FilterX32"), GroupName = "Arch" };
         private readonly RadioButton _filterX64 = new() { Content = LocalizationManager.T("PlatformVersionPicker.FilterX64"), GroupName = "Arch" };
@@ -78,6 +78,13 @@ namespace Configuration_Management
 
         private Control BuildRoot()
         {
+            // Кнопка выбора создаётся до дерева: её доступность меняет обработчик
+            // выделения, а выделение дерево умеет выставить само при подготовке
+            // контейнеров.
+            _selectButton = BuildConfirmActionButton("Common.Select", "IconCheck", 140);
+            _selectButton.Classes.Add("dimmed");
+            _selectButton.IsEnabled = false;
+
             var grid = new Grid { Margin = new Thickness(16) };
             grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
             grid.RowDefinitions.Add(new RowDefinition(new GridLength(1, GridUnitType.Star)));
@@ -185,14 +192,13 @@ namespace Configuration_Management
             {
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8,
+                Spacing = 10,
                 Margin = new Thickness(0, 12, 0, 0)
             };
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 100, IsCancel = true };
-            cancel.Click += (_, _) => Close();
-            buttons.Children.Add(cancel);
-            _selectButton.Click += (_, _) => OnSelect_Click();
+            // Оформление и порядок по разметке (PlatformVersionPickerWindow.xaml:257):
+            // зелёный «Выбрать» слева, красная «Отмена» справа, зазор 10.
             buttons.Children.Add(_selectButton);
+            buttons.Children.Add(BuildCancelActionButton(140));
             Grid.SetRow(buttons, 2);
             grid.Children.Add(buttons);
 

--- a/Configuration Management/Views/PlatformVersionPickerWindow.Avalonia.cs
+++ b/Configuration Management/Views/PlatformVersionPickerWindow.Avalonia.cs
@@ -81,7 +81,10 @@ namespace Configuration_Management
             // Кнопка выбора создаётся до дерева: её доступность меняет обработчик
             // выделения, а выделение дерево умеет выставить само при подготовке
             // контейнеров.
-            _selectButton = BuildConfirmActionButton("Common.Select", "IconCheck", 140);
+            // Закрывает окно сам обработчик: у него есть проверка на пустой выбор,
+            // и терять её нельзя (PlatformVersionPickerWindow.xaml:259).
+            _selectButton = BuildConfirmActionButton("Common.Select", "IconCheck", 140,
+                OnSelect_Click, closeOnClick: false);
             _selectButton.Classes.Add("dimmed");
             _selectButton.IsEnabled = false;
 
@@ -150,6 +153,7 @@ namespace Configuration_Management
                 }
                 else
                 {
+                    _selectedVersion = string.Empty;
                     _selectButton.IsEnabled = false;
                 }
             };

--- a/Configuration Management/Views/ProfilesWindow.Avalonia.cs
+++ b/Configuration Management/Views/ProfilesWindow.Avalonia.cs
@@ -7,6 +7,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Controls;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 using Configuration_Management.Models;
 using Configuration_Management.Services;
 
@@ -96,11 +97,14 @@ namespace Configuration_Management
             return panel;
         }
 
-        private StackPanel BuildButtons()
+        private Control BuildButtons()
         {
+            // Раскладка по разметке (ProfilesWindow.xaml:161): отмена прижата
+            // влево, остальные кнопки вправо. Удаление, как и отмена, идёт мягкой
+            // заливкой, три остальные акцентом.
             var panel = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right, Spacing = 8 };
 
-            var delete = new Button { Content = LocalizationManager.T("Profiles.Delete"), MinWidth = 110 };
+            var delete = SoftButton("Profiles.Delete", "IconDelete", 120);
             delete.Click += (_, _) => OnDelete();
             panel.Children.Add(delete);
 
@@ -108,19 +112,55 @@ namespace Configuration_Management
             // (ProfilesWindow.xaml:183). Без неё сменить активный профиль
             // из интерфейса было нельзя вовсе: команда живёт в ProfilesViewModel,
             // а тот в Linux-сборку не входит.
-            var activate = new Button { Content = LocalizationManager.T("Profiles.Activate"), MinWidth = 150 };
+            var activate = AccentButton("Profiles.Activate", "IconStar", 150);
             activate.Click += (_, _) => OnActivate();
             panel.Children.Add(activate);
 
-            var save = new Button { Content = LocalizationManager.T("Profiles.Save"), MinWidth = 130 };
+            var save = AccentButton("Profiles.Save", "IconOk", 130);
             save.Click += (_, _) => OnSave();
             panel.Children.Add(save);
 
-            var create = new Button { Content = LocalizationManager.T("Profiles.Create"), MinWidth = 130 };
+            var create = AccentButton("Profiles.Create", "IconAdd", 130);
             create.Click += (_, _) => OnCreate();
             panel.Children.Add(create);
 
-            return panel;
+            var row = new Grid();
+            row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+            row.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+
+            var cancel = BuildCancelButton(110);
+            Grid.SetColumn(cancel, 0);
+            row.Children.Add(cancel);
+
+            Grid.SetColumn(panel, 1);
+            row.Children.Add(panel);
+            return row;
+        }
+
+        /// <summary>Кнопка акцентной заливки со значком и подписью.</summary>
+        private static Button AccentButton(string textKey, string iconKey, double width)
+        {
+            var button = new Button
+            {
+                Content = IconHelper.IconAndText(iconKey, LocalizationManager.T(textKey), 14, "ButtonTextBrush"),
+                Width = width
+            };
+            button.Styled(Themes.ControlThemes.ModernButton);
+            return button;
+        }
+
+        /// <summary>Кнопка мягкой заливки: в разметке ей задан фон ItemHoverBrush.</summary>
+        private static Button SoftButton(string textKey, string iconKey, double width)
+        {
+            var button = new Button
+            {
+                Content = IconHelper.IconAndText(iconKey, LocalizationManager.T(textKey), 14, "TextPrimaryBrush"),
+                Width = width
+            };
+            button.Styled(Themes.ControlThemes.ModernButton);
+            Themes.ThemeBrushes.Bind(button, Button.BackgroundProperty, "ItemHoverBrush");
+            Themes.ThemeBrushes.Bind(button, Button.ForegroundProperty, "TextPrimaryBrush");
+            return button;
         }
 
         private UserProfile? SelectedProfile => _profilesList.SelectedItem as UserProfile;

--- a/Configuration Management/Views/TagInputWindow.Avalonia.cs
+++ b/Configuration Management/Views/TagInputWindow.Avalonia.cs
@@ -26,7 +26,8 @@ namespace Configuration_Management
             // Кнопки строит базовый класс: у них общий вид и поведение
             // на все модальные окна, поэтому в разметке стоит только место.
             var buttonsHost = this.FindControl<ContentControl>("ButtonsHost")!;
-            buttonsHost.Content = BuildButtons(null, 130, OnOk_Click);
+            buttonsHost.Content = BuildButtons(Localization.LocalizationManager.T("Common.Add"), 110, OnOk_Click,
+                cancelWidth: 90, okIconKey: "IconAdd");
 
             Opened += (_, _) =>
             {

--- a/Configuration Management/Views/TagInputWindow.Avalonia.cs
+++ b/Configuration Management/Views/TagInputWindow.Avalonia.cs
@@ -26,8 +26,8 @@ namespace Configuration_Management
             // Кнопки строит базовый класс: у них общий вид и поведение
             // на все модальные окна, поэтому в разметке стоит только место.
             var buttonsHost = this.FindControl<ContentControl>("ButtonsHost")!;
-            buttonsHost.Content = BuildButtons(Localization.LocalizationManager.T("Common.Add"), 110, OnOk_Click,
-                cancelWidth: 90, okIconKey: "IconAdd");
+            buttonsHost.Content = BuildButtons(null, 110, OnOk_Click,
+                cancelWidth: 90, okIconKey: "IconAdd", okTextKey: "Common.Add");
 
             Opened += (_, _) =>
             {

--- a/Configuration Management/Views/TagInputWindow.axaml
+++ b/Configuration Management/Views/TagInputWindow.axaml
@@ -16,6 +16,7 @@
                    Text="{loc:Loc TagInput.Prompt}"
                    Margin="0,0,0,8"/>
         <TextBox Grid.Row="1" x:Name="TagBox" Padding="8,6"/>
-        <ContentControl Grid.Row="2" x:Name="ButtonsHost"/>
+        <!-- Отступ панели кнопок сверху взят из разметки WPF. -->
+        <ContentControl Grid.Row="2" x:Name="ButtonsHost" Margin="0,16,0,0"/>
     </Grid>
 </local:ModalWindowBase>


### PR DESCRIPTION
# Linux/Avalonia: кнопки диалоговых окон приведены к разметке WPF

## Зачем

В Linux-ветке диалоги собираются кодом, и кнопки в них до сих пор оставались
штатными кнопками Fluent: серые, со скруглением темы, в порядке «Отмена, ОК».
В разметке WPF нижняя панель диалога выглядит иначе и одинаково в десяти окнах:
слева зелёная кнопка подтверждения (`#16A34A`, скругление 8, отступы 12,8,
высота 36, белые значок и подпись SemiBold), справа отмена прозрачной заливкой
в красном контуре (`#EF4444`, толщина 1.5). Эта пара задана не именованным
стилем, а встроенным шаблоном, повторённым в каждом окне: `AddEditWindow.xaml:152`,
`CacheCleanWindow.xaml:206`, `ConnectionSettingsWindow.xaml:1026`,
`ConnectionStringInputWindow.xaml:71`, `CreateInfobaseWindow.xaml:184`,
`GroupEditWindow.xaml:294`, `LaunchParametersWindow.xaml:78`,
`LinkInputWindow.xaml:51`, `PlatformVersionPickerWindow.xaml:258`,
`SettingsWindow.xaml:1527`.

## Что сделано

**Новый словарь `Themes/Controls.axaml`.** Четыре темы контролов:
`ModernButton` и `SecondaryButton` повторяют одноимённые стили словарей
`Themes/LightTheme.xaml` и `Themes/DarkTheme.xaml`, а `DialogConfirmButton`
и `DialogCancelButton` это та самая пара нижней панели. Применяются они так же
явно, по ключу, как `Style="{DynamicResource ...}"` в разметке: помощник
`Themes/ControlThemes.Avalonia.cs` ставит тему контролу, собранному в коде.

`SecondaryButton` в разметке разный в светлой и тёмной теме (в светлой заливка
янтарного семейства без контура, в тёмной карточка в контуре, при наведении
контур акцентный). В Avalonia словарь стилей один, поэтому различающиеся кисти
вынесены в `ThemeDictionaries` и переключаются по `RequestedThemeVariant`,
который приложение и так задаёт.

**Окна.** По разметке выровнены порядок кнопок (подтверждение слева), ширины,
высоты, зазор 10, зазор значка и подписи, значки и ключи подписей в окнах:
добавления в список, очистки кеша, ввода строки подключения, создания базы,
настройки группы, параметров запуска, ввода ссылки, выбора версии платформы,
входа, выбора цвета, ввода имени, ввода тега, управления группами и профилей.
Вторичная тема применена и к служебным кнопкам этих окон (обзор, выбор
платформы, пути, обновление шаблонов, выбор родительской группы): в разметке
у них стиль `SecondaryButton`, в Linux-ветке они оставались штатными.

Попутно, по той же разметке:

* фон окна (`ContentBackgroundBrush`) теперь ставит базовый класс диалогов:
  в разметке его задаёт каждое окно, в Linux-ветке не задавал никто, и диалоги
  выходили на системном чёрном вместо тёмно-синего темы;
* окно ввода строки подключения перестроено по разметке: поле однострочное и во
  всю ширину, вставка из буфера ушла в нижнюю строку слева, подпись и подсказка
  взяты по тем ключам, которые использует разметка (`ConnectionStringInput.Label`
  и `.Hint` вместо самодельных `.Header` и `.HintText`);
* в окне настройки группы кнопки прижаты к низу отдельной полосой с отбивкой
  сверху и фоном карточки, как в `GroupEditWindow.xaml:290`;
* окно ввода тега подтверждается кнопкой «Добавить» шириной 110, как в разметке,
  а не «ОК» шириной 130.

**Заодно закрыто то, что нашли аудиты.** Подпись кнопки подтверждения теперь
переводится при смене языка и в окнах, где кнопку собирает само окно (очистка
кеша, создание базы, вход, управление группами): раньше при смене языка панель
становилась двуязычной. У окна выбора версии платформы вернулась проверка перед
закрытием, потерянная при переходе на общую кнопку, а выбранная версия
сбрасывается при переходе на узел-группу, иначе двойной щелчок по группе
подтверждал устаревший выбор. В окне управления группами появилась кнопка
отмены, которой в Linux-ветке не было вовсе, а добавление корневой группы взяло
ключ подписи из разметки (`Common.Add`).

## Отличия от разметки, сделанные сознательно

1. **Гашение недоступной кнопки.** Автор задал его по-разному и только там, где
   состояние достижимо: серой заливкой `#9CA3AF` в двух окнах и прозрачностью
   0.45 и 0.5 в трёх. В теме это два класса, `greyed` и `dimmed`, и окно выбирает
   нужный; прозрачность у всех 0.45. В окнах, где недоступного состояния нет,
   поведение не меняется.
2. **Значки.** В разметке часть значков берётся из пакета MaterialDesign
   (`PackIcon Kind="DatabasePlus"`, `Broom`, `ArrowRightBoldCircle`), которого
   в Linux-сборке нет. Взяты ближайшие контуры из собственного словаря автора
   `Themes/Icons.axaml`: `IconDatabase`, `IconBroom`, `IconArrowRight`.
3. **Ключ значка отмены.** В разметке это `IconClear`; в Linux-словаре тот же
   контур лежит под именем `IconClose` (геометрия совпадает символ в символ),
   дубликат заводить не стали.
4. **Значок кнопки вставки** в окне строки подключения: в разметке
   `PackIcon Kind="ContentPaste"`, здесь `IconCopy`, ближайший из словаря.
5. **Размер значка в окне группы.** Там разметка рисует значок голым `Path`
   со `Stretch="Uniform"`, то есть контур занимает все 16 пикселей, а во всех
   остальных местах и у нас, и у автора значок кладётся в холст 24 на 24.
   Взят холст: так значок совпадает по оптическому размеру с соседними окнами.

## Чего этот PR не трогает

`SettingsWindow` и `ConnectionSettingsWindow`: их нижние панели такие же, но сами
окна большие и идут следующим куском.

## Как проверено

Сборка Linux-цели без ошибок и без новых предупреждений (15, как и до правки),
публикация, прогон приложения в отдельном каталоге данных. Сняты и осмотрены
окна добавления в список, ввода ссылки (в том числе недоступное состояние
кнопки перехода), настройки группы и вставки строки подключения. Последнее
снято в обеих темах: вторичная кнопка в тёмной выглядит карточкой в контуре,
в светлой мягкой заливкой без контура, то есть тематические словари
переключаются в рантайме так же, как в WPF переключается словарь целиком.
