### PR TITLE
Linux/Avalonia: окно настройки подключения перестроено по разметке WPF

### DIFF
--- a/Configuration Management/App.axaml
+++ b/Configuration Management/App.axaml
@@ -15,6 +15,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceInclude Source="avares://ConfigurationManagement/Themes/Icons.axaml" />
                 <ResourceInclude Source="avares://ConfigurationManagement/Themes/LightTheme.axaml" />
+                <ResourceInclude Source="avares://ConfigurationManagement/Themes/Controls.axaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/Configuration Management/Themes/ControlThemes.Avalonia.cs
+++ b/Configuration Management/Themes/ControlThemes.Avalonia.cs
@@ -1,0 +1,51 @@
+#if LINUX
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Styling;
+
+namespace Configuration_Management.Themes
+{
+    /// <summary>
+    /// Применение именованных тем контролов из Themes/Controls.axaml к элементам,
+    /// которые собираются в коде. Аналог <c>Style="{DynamicResource ИмяСтиля}"</c>
+    /// из разметки WPF: ключи те же самые.
+    /// </summary>
+    public static class ControlThemes
+    {
+        /// <summary>Основная кнопка: акцентная заливка, скругление 6, высота от 36.</summary>
+        public const string ModernButton = "ModernButton";
+
+        /// <summary>Вторичная кнопка: в светлой теме мягкая заливка, в тёмной карточка в контуре.</summary>
+        public const string SecondaryButton = "SecondaryButton";
+
+        /// <summary>Кнопка подтверждения нижней панели диалога: зелёная заливка.</summary>
+        public const string DialogConfirmButton = "DialogConfirmButton";
+
+        /// <summary>Кнопка отмены нижней панели диалога: красный контур.</summary>
+        public const string DialogCancelButton = "DialogCancelButton";
+
+        /// <summary>
+        /// Ставит элементу тему контрола по ключу словаря и возвращает сам элемент,
+        /// чтобы вызов можно было встроить в инициализацию.
+        /// </summary>
+        /// <param name="control">Элемент, которому назначается тема.</param>
+        /// <param name="themeKey">Ключ ресурса, например <see cref="ModernButton"/>.</param>
+        /// <remarks>
+        /// Неизвестный ключ оставляет элемент со штатной темой Fluent и ничего не сообщает:
+        /// ресурсы ищутся по значению, а не по типу, и промах виден только глазами.
+        /// Поэтому ключи заданы здесь константами, а не строками по месту вызова.
+        /// </remarks>
+        public static T Styled<T>(this T control, string themeKey) where T : StyledElement
+        {
+            if (Application.Current is { } app
+                && app.TryFindResource(themeKey, out var found)
+                && found is ControlTheme theme)
+            {
+                control.Theme = theme;
+            }
+
+            return control;
+        }
+    }
+}
+#endif

--- a/Configuration Management/Themes/ControlThemes.Avalonia.cs
+++ b/Configuration Management/Themes/ControlThemes.Avalonia.cs
@@ -24,6 +24,15 @@ namespace Configuration_Management.Themes
         /// <summary>Кнопка отмены нижней панели диалога: красный контур.</summary>
         public const string DialogCancelButton = "DialogCancelButton";
 
+        /// <summary>Набор вертикальных вкладок окна подключения.</summary>
+        public const string ConnTabControl = "ConnTabControl";
+
+        /// <summary>Вертикальная вкладка: полоса акцента справа у выбранной.</summary>
+        public const string ConnTabItem = "ConnTabItem";
+
+        /// <summary>Карточка варианта выбора: рамка вокруг переключателя с подписью и пояснением.</summary>
+        public const string OptionCard = "OptionCard";
+
         /// <summary>
         /// Ставит элементу тему контрола по ключу словаря и возвращает сам элемент,
         /// чтобы вызов можно было встроить в инициализацию.

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -204,4 +204,129 @@
         </Style>
     </ControlTheme>
 
+    <!-- ===================== Вертикальные вкладки окна подключения =====================
+         Стили ConnTabControl и ConnTabItem из словарей WPF
+         (LightTheme.xaml не содержит их, они объявлены в самом окне:
+         ConnectionSettingsWindow.xaml:81 и :106). Вкладки идут слева колонкой,
+         у выбранной акцентная полоса справа шириной 3. -->
+    <ControlTheme x:Key="ConnTabControl" TargetType="TabControl">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="ItemsPanel">
+            <ItemsPanelTemplate>
+                <StackPanel/>
+            </ItemsPanelTemplate>
+        </Setter>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="TabControl">
+                <Grid ColumnDefinitions="Auto,*">
+                    <Border Grid.Column="0" Padding="0,4,8,12" Background="Transparent">
+                        <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}"/>
+                    </Border>
+                    <ContentPresenter Grid.Column="1"
+                                      Name="PART_SelectedContentHost"
+                                      Margin="8,0,0,0"
+                                      Content="{TemplateBinding SelectedContent}"
+                                      ContentTemplate="{TemplateBinding SelectedContentTemplate}"/>
+                </Grid>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+
+    <ControlTheme x:Key="ConnTabItem" TargetType="TabItem">
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Padding" Value="14,12"/>
+        <Setter Property="Margin" Value="0,3"/>
+        <Setter Property="Width" Value="180"/>
+        <Setter Property="MinHeight" Value="40"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="TabItem">
+                <Border Name="PART_Surface"
+                        Background="Transparent"
+                        BorderBrush="Transparent"
+                        BorderThickness="0,0,3,0"
+                        CornerRadius="8"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Header}"
+                                      ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Left"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover:not(:selected) /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+        </Style>
+        <Style Selector="^:selected /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource TreeSelectedBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        </Style>
+        <Style Selector="^:selected">
+            <Setter Property="Foreground" Value="{DynamicResource ButtonTextBrush}"/>
+        </Style>
+        <Style Selector="^:disabled">
+            <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}"/>
+        </Style>
+    </ControlTheme>
+
+    <!-- ===================== Карточка варианта выбора =====================
+         В разметке это Border со своим DataTrigger вокруг обычного RadioButton
+         (ConnectionSettingsWindow.xaml:263 и ещё четырнадцать таких же).
+         Здесь это тема самого переключателя: рамка и кружок нарисованы шаблоном,
+         поэтому состояние выбора красит их без привязок и без кода. -->
+    <ControlTheme x:Key="OptionCard" TargetType="RadioButton">
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Margin" Value="0,0,0,4"/>
+        <Setter Property="Padding" Value="8,6"/>
+        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="RadioButton">
+                <Border Name="PART_Surface"
+                        Background="{DynamicResource CardBackgroundBrush}"
+                        BorderBrush="{DynamicResource BorderBrushColor}"
+                        BorderThickness="1.5"
+                        CornerRadius="6"
+                        Padding="{TemplateBinding Padding}">
+                    <Grid ColumnDefinitions="Auto,*">
+                        <Panel Grid.Column="0" Width="16" Height="16" Margin="0,1,8,0" VerticalAlignment="Top">
+                            <Ellipse Name="PART_Bullet" Width="16" Height="16"
+                                     StrokeThickness="1.5"
+                                     Stroke="{DynamicResource BorderBrushColor}"/>
+                            <Ellipse Name="PART_Dot" Width="8" Height="8" IsVisible="False"
+                                     Fill="{DynamicResource AccentBrush}"/>
+                        </Panel>
+                        <ContentPresenter Grid.Column="1"
+                                          Name="PART_ContentPresenter"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"/>
+                    </Grid>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:checked /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        </Style>
+        <Style Selector="^:checked /template/ Ellipse#PART_Bullet">
+            <Setter Property="Stroke" Value="{DynamicResource AccentBrush}"/>
+        </Style>
+        <Style Selector="^:checked /template/ Ellipse#PART_Dot">
+            <Setter Property="IsVisible" Value="True"/>
+        </Style>
+        <Style Selector="^:disabled /template/ Border#PART_Surface">
+            <Setter Property="Opacity" Value="0.5"/>
+        </Style>
+    </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -101,12 +101,18 @@
         <Style Selector="^:pressed /template/ Border#PART_Surface">
             <Setter Property="Background" Value="{DynamicResource SecondaryButtonPressedSurfaceBrush}"/>
         </Style>
+        <!-- Гашение задано и здесь, хотя оно есть у основной кнопки: вторичная
+             переопределяет шаблон целиком, и вложенный стиль основной ссылается
+             на её часть шаблона, а не на эту. -->
+        <Style Selector="^:disabled /template/ Border#PART_Surface">
+            <Setter Property="Opacity" Value="0.5"/>
+        </Style>
     </ControlTheme>
     <!-- ===================== Кнопки нижней панели диалогов =====================
          В разметке WPF эти две кнопки заданы не именованным стилем, а встроенным
-         шаблоном, и повторены так в девяти окнах: AddEditWindow.xaml:152,
+         шаблоном, и повторены так в десяти окнах: AddEditWindow.xaml:152,
          CacheCleanWindow.xaml:206, ConnectionSettingsWindow.xaml:1026,
-         ConnectionStringInputWindow.xaml:71, CreateInfobaseWindow.xaml:208,
+         ConnectionStringInputWindow.xaml:71, CreateInfobaseWindow.xaml:185,
          GroupEditWindow.xaml:294, LaunchParametersWindow.xaml:78,
          LinkInputWindow.xaml:51, PlatformVersionPickerWindow.xaml:258,
          SettingsWindow.xaml:1527. Здесь это две темы контролов, чтобы девять

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -325,8 +325,10 @@
         <Style Selector="^:checked /template/ Ellipse#PART_Dot">
             <Setter Property="IsVisible" Value="True"/>
         </Style>
+        <!-- Гашение 0.45, как у недоступных карточек в разметке
+             (ConnectionSettingsWindow.xaml:744 и :862). -->
         <Style Selector="^:disabled /template/ Border#PART_Surface">
-            <Setter Property="Opacity" Value="0.5"/>
+            <Setter Property="Opacity" Value="0.45"/>
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -1,0 +1,201 @@
+<!-- Avalonia-версия стилей контролов (Linux). Соответствует именованным стилям
+     WPF-словарей LightTheme.xaml и DarkTheme.xaml: ключи те же, применяются так же
+     явно, по ключу. Цвета берутся из палитры, которую накладывает
+     ThemeManager.ApplyScheme, поэтому смена темы и схемы подхватывается сама.
+
+     Отличие от WPF по устройству, а не по виду: там два словаря целиком, и стиль
+     вторичной кнопки в каждом свой. Здесь словарь стилей один, а различающиеся
+     кисти вынесены в ThemeDictionaries и переключаются по RequestedThemeVariant,
+     который ApplyScheme и задаёт. -->
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ResourceDictionary.ThemeDictionaries>
+        <!-- Светлая: вторичная кнопка это заливка янтарного семейства без контура. -->
+        <ResourceDictionary x:Key="Light">
+            <SolidColorBrush x:Key="SecondaryButtonSurfaceBrush" Color="{DynamicResource SecondaryButtonBackgroundColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonTextBrush" Color="{DynamicResource ButtonTextColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonOutlineBrush" Color="{DynamicResource SecondaryButtonBackgroundColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonHoverSurfaceBrush" Color="{DynamicResource SecondaryButtonHoverColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonHoverOutlineBrush" Color="{DynamicResource SecondaryButtonHoverColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonPressedSurfaceBrush" Color="{DynamicResource SecondaryButtonPressedColor}"/>
+            <Thickness x:Key="SecondaryButtonOutlineThickness">0</Thickness>
+        </ResourceDictionary>
+        <!-- Тёмная: вторичная кнопка это карточка в контуре, при наведении контур акцентный. -->
+        <ResourceDictionary x:Key="Dark">
+            <SolidColorBrush x:Key="SecondaryButtonSurfaceBrush" Color="{DynamicResource CardBackgroundColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonTextBrush" Color="{DynamicResource TextPrimaryColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonOutlineBrush" Color="{DynamicResource BorderColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonHoverSurfaceBrush" Color="{DynamicResource ItemHoverColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonHoverOutlineBrush" Color="{DynamicResource AccentColor}"/>
+            <SolidColorBrush x:Key="SecondaryButtonPressedSurfaceBrush" Color="{DynamicResource SidebarHoverColor}"/>
+            <Thickness x:Key="SecondaryButtonOutlineThickness">1</Thickness>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+
+    <!-- ===================== Основная кнопка ===================== -->
+    <ControlTheme x:Key="ModernButton" TargetType="Button">
+        <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ButtonTextBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="14,9"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="MinHeight" Value="36"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        CornerRadius="6"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource AccentHoverBrush}"/>
+        </Style>
+        <Style Selector="^:pressed /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource AccentPressedBrush}"/>
+        </Style>
+        <Style Selector="^:disabled /template/ Border#PART_Surface">
+            <Setter Property="Opacity" Value="0.5"/>
+        </Style>
+    </ControlTheme>
+
+    <!-- ===================== Вторичная кнопка ===================== -->
+    <ControlTheme x:Key="SecondaryButton" TargetType="Button" BasedOn="{StaticResource ModernButton}">
+        <Setter Property="Background" Value="{DynamicResource SecondaryButtonSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryButtonTextBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryButtonOutlineBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource SecondaryButtonOutlineThickness}"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="6"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource SecondaryButtonHoverSurfaceBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SecondaryButtonHoverOutlineBrush}"/>
+        </Style>
+        <Style Selector="^:pressed /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource SecondaryButtonPressedSurfaceBrush}"/>
+        </Style>
+    </ControlTheme>
+    <!-- ===================== Кнопки нижней панели диалогов =====================
+         В разметке WPF эти две кнопки заданы не именованным стилем, а встроенным
+         шаблоном, и повторены так в девяти окнах: AddEditWindow.xaml:152,
+         CacheCleanWindow.xaml:206, ConnectionSettingsWindow.xaml:1026,
+         ConnectionStringInputWindow.xaml:71, CreateInfobaseWindow.xaml:208,
+         GroupEditWindow.xaml:294, LaunchParametersWindow.xaml:78,
+         LinkInputWindow.xaml:51, PlatformVersionPickerWindow.xaml:258,
+         SettingsWindow.xaml:1527. Здесь это две темы контролов, чтобы девять
+         повторений не разъезжались. Цвета в разметке заданы числом и от темы
+         не зависят, поэтому и тут они числом.
+         Гашение при недоступности автор задал только там, где кнопка бывает
+         недоступна (ConnectionStringInputWindow.xaml:86); в остальных окнах
+         состояние недостижимо, поэтому расхождения не видно. -->
+    <ControlTheme x:Key="DialogConfirmButton" TargetType="Button">
+        <Setter Property="Background" Value="#16A34A"/>
+        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="12,8"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Height" Value="36"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        CornerRadius="8"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="#15803D"/>
+        </Style>
+        <Style Selector="^:pressed /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="#166534"/>
+        </Style>
+        <!-- Недоступное состояние автор задал по-разному и только там, где оно
+             достижимо: серой заливкой (ConnectionStringInputWindow.xaml:86,
+             LinkInputWindow.xaml:66) и полупрозрачностью
+             (PlatformVersionPickerWindow.xaml:272 и CacheCleanWindow.xaml:220
+             дают 0.45, ConnectionSettingsWindow.xaml:1040 даёт 0.5; здесь у всех
+             0.45, разница в полшага не различима). Поэтому не в общем виде темы,
+             а двумя классами, и окно выбирает нужный. -->
+        <Style Selector="^.greyed:disabled /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="#9CA3AF"/>
+        </Style>
+        <Style Selector="^.dimmed:disabled /template/ Border#PART_Surface">
+            <Setter Property="Opacity" Value="0.45"/>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="DialogCancelButton" TargetType="Button">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="#EF4444"/>
+        <Setter Property="BorderBrush" Value="#EF4444"/>
+        <Setter Property="BorderThickness" Value="1.5"/>
+        <Setter Property="Padding" Value="12,8"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Height" Value="36"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="8"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="#FEF2F2"/>
+        </Style>
+    </ControlTheme>
+
+</ResourceDictionary>

--- a/Configuration Management/Views/AddEditWindow.Avalonia.cs
+++ b/Configuration Management/Views/AddEditWindow.Avalonia.cs
@@ -60,41 +60,20 @@ namespace Configuration_Management
             Grid.SetRow(options, 1);
             grid.Children.Add(options);
 
+            // Порядок и оформление по разметке (AddEditWindow.xaml:151):
+            // зелёное «Далее» слева, красная «Отмена» справа, зазор 10.
             var buttons = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8,
-                Margin = new Thickness(0, 12, 0, 0)
-            };
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 100, IsCancel = true };
-            cancel.Click += (_, _) => Close();
-            buttons.Children.Add(cancel);
-
-            var next = new Button
-            {
-                Content = new StackPanel
+                Spacing = 10,
+                Margin = new Thickness(0, 12, 0, 0),
+                Children =
                 {
-                    Orientation = Orientation.Horizontal,
-                    Spacing = 6,
-                    Children =
-                    {
-                        new TextBlock
-                        {
-                            Text = LocalizationManager.T("AddEdit.Next"),
-                            VerticalAlignment = VerticalAlignment.Center,
-                            Foreground = Brushes.White
-                        },
-                        IconHelper.MakeIcon("IconArrowRight", 16, "White")
-                    }
-                },
-                MinWidth = 110,
-                Background = new SolidColorBrush(Color.Parse("#16A34A")),
-                Foreground = Brushes.White,
-                IsDefault = true
+                    BuildConfirmActionButton("AddEdit.Next", "IconArrowRight", 130),
+                    BuildCancelActionButton(130)
+                }
             };
-            next.Click += (_, _) => { DialogResult = true; Close(); };
-            buttons.Children.Add(next);
 
             Grid.SetRow(buttons, 2);
             grid.Children.Add(buttons);

--- a/Configuration Management/Views/CacheCleanWindow.Avalonia.cs
+++ b/Configuration Management/Views/CacheCleanWindow.Avalonia.cs
@@ -374,20 +374,18 @@ namespace Configuration_Management
             _cleanButton.Classes.Add("dimmed");
             _cleanButton.Width = 180;
             _cleanButton.Height = 36;
+            var cleanCaption = new TextBlock
+            {
+                Text = LocalizationManager.T("CacheClean.Clean"),
+                VerticalAlignment = VerticalAlignment.Center
+            };
             _cleanButton.Content = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
                 Spacing = 6,
-                Children =
-                {
-                    IconHelper.MakeIcon("IconBroom", 16, Brushes.White),
-                    new TextBlock
-                    {
-                        Text = LocalizationManager.T("CacheClean.Clean"),
-                        VerticalAlignment = VerticalAlignment.Center
-                    }
-                }
+                Children = { IconHelper.MakeIcon("IconBroom", 16, Brushes.White), cleanCaption }
             };
+            RegisterConfirmCaption(cleanCaption, "CacheClean.Clean");
             _cleanButton.Click += (_, _) => OnClean_Click();
 
             var rightPanel = new StackPanel

--- a/Configuration Management/Views/CacheCleanWindow.Avalonia.cs
+++ b/Configuration Management/Views/CacheCleanWindow.Avalonia.cs
@@ -10,6 +10,7 @@ using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 using Configuration_Management.Models;
 using Configuration_Management.Services;
 
@@ -355,7 +356,6 @@ namespace Configuration_Management
             var bottom = new Grid { Margin = new Thickness(0, 12, 0, 0) };
             bottom.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
             bottom.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-            bottom.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
 
             var leftPanel = new StackPanel
             {
@@ -367,33 +367,38 @@ namespace Configuration_Management
             Grid.SetColumn(leftPanel, 0);
             bottom.Children.Add(leftPanel);
 
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 100, IsCancel = true };
-            cancel.Click += (_, _) => Close();
-            Grid.SetColumn(cancel, 1);
-            cancel.Margin = new Thickness(0, 0, 8, 0);
-            bottom.Children.Add(cancel);
-
-            _cleanButton.Background = new SolidColorBrush(Color.Parse("#16A34A"));
-            _cleanButton.Foreground = Brushes.White;
+            // Оформление и порядок по разметке (CacheCleanWindow.xaml:205):
+            // зелёная очистка шириной 180 слева, красная отмена справа, зазор 10.
+            // Пока нечего чистить, кнопка недоступна и приглушена, как там же.
+            _cleanButton.Styled(ControlThemes.DialogConfirmButton);
+            _cleanButton.Classes.Add("dimmed");
+            _cleanButton.Width = 180;
+            _cleanButton.Height = 36;
             _cleanButton.Content = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
                 Spacing = 6,
                 Children =
                 {
-                    IconHelper.MakeIcon("IconDelete", 16, "White"),
+                    IconHelper.MakeIcon("IconBroom", 16, Brushes.White),
                     new TextBlock
                     {
                         Text = LocalizationManager.T("CacheClean.Clean"),
-                        VerticalAlignment = VerticalAlignment.Center,
-                        Foreground = Brushes.White
+                        VerticalAlignment = VerticalAlignment.Center
                     }
                 }
             };
-            _cleanButton.MinWidth = 130;
             _cleanButton.Click += (_, _) => OnClean_Click();
-            Grid.SetColumn(_cleanButton, 2);
-            bottom.Children.Add(_cleanButton);
+
+            var rightPanel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Spacing = 10,
+                Children = { _cleanButton, BuildCancelActionButton(140) }
+            };
+            Grid.SetColumn(rightPanel, 1);
+            bottom.Children.Add(rightPanel);
 
             Grid.SetRow(bottom, 5);
             grid.Children.Add(bottom);

--- a/Configuration Management/Views/ColorPickerWindow.Avalonia.cs
+++ b/Configuration Management/Views/ColorPickerWindow.Avalonia.cs
@@ -48,6 +48,7 @@ namespace Configuration_Management
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
                 Spacing = 8,
+                Margin = new Thickness(0, 16, 0, 0),
                 Children =
                 {
                     BuildConfirmButton(LocalizationManager.T("Common.Ok"), 90, OnOk_Click, minimumWidth: true),

--- a/Configuration Management/Views/ColorPickerWindow.Avalonia.cs
+++ b/Configuration Management/Views/ColorPickerWindow.Avalonia.cs
@@ -40,7 +40,20 @@ namespace Configuration_Management
             Grid.SetRow(_picker, 0);
             root.Children.Add(_picker);
 
-            var buttons = BuildButtons(LocalizationManager.T("Common.Ok"), 90, OnOk_Click);
+            // Порядок и оформление как в разметке: подтверждение слева основной
+            // кнопкой, отмена справа вторичной. Общая панель базового класса
+            // ставит их наоборот, поэтому кнопки собираются здесь по одной.
+            var buttons = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Spacing = 8,
+                Children =
+                {
+                    BuildConfirmButton(LocalizationManager.T("Common.Ok"), 90, OnOk_Click, minimumWidth: true),
+                    BuildCancelButton(110, secondary: true, minimumWidth: true)
+                }
+            };
             Grid.SetRow(buttons, 1);
             root.Children.Add(buttons);
 

--- a/Configuration Management/Views/ConnectionSettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/ConnectionSettingsWindow.Avalonia.cs
@@ -9,7 +9,9 @@ using Avalonia.Data;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Controls;
+using Avalonia.Input;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 using Configuration_Management.Models;
 using Configuration_Management.Services;
 using Configuration_Management.ViewModels;
@@ -47,11 +49,13 @@ namespace Configuration_Management
             IEnumerable<string>? installedPlatformVersions = null, string? defaultGroupPath = null,
             IEnumerable<string>? availableServers = null, IEnumerable<int>? availablePorts = null)
         {
+            // Размеры и базовый кегль по разметке (ConnectionSettingsWindow.xaml:13).
             Title = LocalizationManager.T("ConnectionSettings.Title");
-            Width = 720;
-            Height = 620;
-            MinWidth = 620;
-            MinHeight = 520;
+            Width = 760;
+            Height = 780;
+            MinWidth = 680;
+            MinHeight = 680;
+            FontSize = 13;
 
             _dialogs = AppServices.GetRequiredService<IDialogService>();
 
@@ -100,11 +104,18 @@ namespace Configuration_Management
 
         // ===================== Вспомогательные построители =====================
 
+        /// <summary>Ширина колонки подписей, как в разметке (ConnectionSettingsWindow.xaml:203).</summary>
+        private const double LabelColumn = 120;
+
         private static TextBox Tb(string path, string? watermark = null, bool multiline = false)
         {
             var tb = new TextBox
             {
-                Padding = new Thickness(8, 5),
+                Padding = new Thickness(6, 4),
+                MinHeight = 28,
+                FontSize = 12,
+                Margin = new Thickness(0, 3),
+                VerticalContentAlignment = VerticalAlignment.Center,
                 Watermark = watermark,
                 AcceptsReturn = multiline
             };
@@ -116,326 +127,648 @@ namespace Configuration_Management
 
         private static ComboBox EditableCombo(string textPath, string itemsPath)
         {
-            var combo = new ComboBox { IsEditable = true };
+            var combo = new ComboBox
+            {
+                IsEditable = true,
+                Margin = new Thickness(0, 3),
+                MinHeight = 28,
+                FontSize = 12,
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
             combo.Bind(ComboBox.TextProperty, new Binding(textPath) { Mode = BindingMode.TwoWay });
             combo.Bind(ComboBox.ItemsSourceProperty, new Binding(itemsPath));
             return combo;
         }
 
-        private static Grid Field(string label, Control control, bool isEnabled = true)
+        /// <summary>Сетка «подпись / поле»: колонка подписей и остаток под поле.</summary>
+        private static Grid FieldsGrid(int rows)
         {
-            var grid = new Grid { Margin = new Thickness(0, 0, 0, 10) };
-            grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(160)));
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(LabelColumn)));
             grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-
-            var labelBlock = new TextBlock { Text = label, VerticalAlignment = VerticalAlignment.Center };
-            Grid.SetColumn(labelBlock, 0);
-            grid.Children.Add(labelBlock);
-
-            control.IsEnabled = isEnabled;
-            Grid.SetColumn(control, 1);
-            grid.Children.Add(control);
+            for (var i = 0; i < rows; i++)
+                grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
             return grid;
         }
 
-        private static StackPanel RadioGroup(params RadioButton[] radios)
+        /// <summary>
+        /// Кладёт в сетку строку «подпись и поле». Путь видимости нужен строкам,
+        /// которые в разметке лежат в одной и той же строке и переключаются
+        /// по типу подключения.
+        /// </summary>
+        private static void Place(Grid grid, int row, string labelKey, Control control,
+            string? visibilityPath = null, VerticalAlignment labelAlignment = VerticalAlignment.Center)
         {
-            var panel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 14, VerticalAlignment = VerticalAlignment.Center };
-            foreach (var r in radios)
-                panel.Children.Add(r);
-            return panel;
+            var label = new TextBlock
+            {
+                Text = LocalizationManager.T(labelKey),
+                VerticalAlignment = labelAlignment,
+                Margin = new Thickness(0, 3)
+            };
+            Grid.SetRow(label, row);
+            Grid.SetColumn(label, 0);
+            grid.Children.Add(label);
+
+            Grid.SetRow(control, row);
+            Grid.SetColumn(control, 1);
+            grid.Children.Add(control);
+
+            if (visibilityPath is null)
+                return;
+
+            label.Bind(Visual.IsVisibleProperty, new Binding(visibilityPath));
+            control.Bind(Visual.IsVisibleProperty, new Binding(visibilityPath));
         }
 
-        private static RadioButton Radio(string groupName, string path, string content)
+        /// <summary>Строка «поле и кнопка справа», как в разметке.</summary>
+        private static Grid WithButton(Control field, Button button)
         {
-            var r = new RadioButton { Content = content, GroupName = groupName };
-            r.Bind(Avalonia.Controls.Primitives.ToggleButton.IsCheckedProperty,
-                new Binding(path) { Mode = BindingMode.TwoWay });
-            return r;
+            var grid = new Grid { Margin = new Thickness(0, 3) };
+            grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+            grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+            field.Margin = new Thickness(0);
+            Grid.SetColumn(field, 0);
+            grid.Children.Add(field);
+            button.Margin = new Thickness(6, 0, 0, 0);
+            Grid.SetColumn(button, 1);
+            grid.Children.Add(button);
+            return grid;
         }
+
+        /// <summary>Вторичная кнопка со значком и подписью, как в разметке окна.</summary>
+        private static Button SecondaryButton(string iconKey, string textKey, Action onClick,
+            string? tooltipKey = null, double iconSize = 14)
+        {
+            var button = new Button
+            {
+                Content = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 4,
+                    Children =
+                    {
+                        IconHelper.MakeIcon(iconKey, iconSize, "SecondaryButtonTextBrush"),
+                        new TextBlock
+                        {
+                            Text = LocalizationManager.T(textKey),
+                            FontSize = 12,
+                            VerticalAlignment = VerticalAlignment.Center
+                        }
+                    }
+                },
+                Padding = new Thickness(10, 4),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            button.Styled(ControlThemes.SecondaryButton);
+            button.Click += (_, _) => onClick();
+            if (tooltipKey is not null)
+                ToolTip.SetTip(button, LocalizationManager.T(tooltipKey));
+            return button;
+        }
+
+        /// <summary>
+        /// Группа с заголовком: рамка карточки, а над ней подпись со значком.
+        /// Повторяет шаблон GroupBox из разметки (ConnectionSettingsWindow.xaml:42).
+        /// </summary>
+        private static Control Group(string iconKey, string titleKey, Control content)
+        {
+            var grid = new Grid { Margin = new Thickness(4, 6, 4, 4), VerticalAlignment = VerticalAlignment.Top };
+            grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+            grid.RowDefinitions.Add(new RowDefinition(new GridLength(1, GridUnitType.Star)));
+
+            var frame = new Border { BorderThickness = new Thickness(1), CornerRadius = new CornerRadius(8) };
+            Themes.ThemeBrushes.Bind(frame, Border.BackgroundProperty, "CardBackgroundBrush");
+            Themes.ThemeBrushes.Bind(frame, Border.BorderBrushProperty, "BorderBrushColor");
+            Grid.SetRow(frame, 0);
+            Grid.SetRowSpan(frame, 2);
+            grid.Children.Add(frame);
+
+            var header = new Border
+            {
+                Padding = new Thickness(10, 4, 10, 0),
+                Margin = new Thickness(8, 0, 0, 0),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                Child = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 8,
+                    Children =
+                    {
+                        IconHelper.MakeIcon(iconKey, 16, "AccentBrush"),
+                        new TextBlock
+                        {
+                            Text = LocalizationManager.T(titleKey),
+                            FontWeight = FontWeight.SemiBold,
+                            FontSize = 13,
+                            VerticalAlignment = VerticalAlignment.Center
+                        }
+                    }
+                }
+            };
+            Themes.ThemeBrushes.Bind(header, Border.BackgroundProperty, "CardBackgroundBrush");
+            Grid.SetRow(header, 0);
+            grid.Children.Add(header);
+
+            content.Margin = new Thickness(10, 8);
+            Grid.SetRow(content, 1);
+            grid.Children.Add(content);
+            return grid;
+        }
+
+        /// <summary>
+        /// Карточка варианта выбора: переключатель в рамке с подписью и пояснением.
+        /// </summary>
+        private static RadioButton OptionCard(string groupName, string path, string titleKey, string hintKey,
+            string? enabledPath = null)
+        {
+            var card = new RadioButton
+            {
+                GroupName = groupName,
+                Content = new StackPanel
+                {
+                    Children =
+                    {
+                        new TextBlock
+                        {
+                            Text = LocalizationManager.T(titleKey),
+                            FontWeight = FontWeight.SemiBold,
+                            FontSize = 12
+                        },
+                        new TextBlock
+                        {
+                            Text = LocalizationManager.T(hintKey),
+                            FontSize = 11,
+                            Opacity = 0.75,
+                            TextWrapping = TextWrapping.Wrap,
+                            Margin = new Thickness(0, 2, 0, 0)
+                        }
+                    }
+                }
+            };
+            card.Styled(ControlThemes.OptionCard);
+            card.Bind(ToggleButton.IsCheckedProperty, new Binding(path) { Mode = BindingMode.TwoWay });
+            if (enabledPath is not null)
+                card.Bind(InputElement.IsEnabledProperty, new Binding(enabledPath));
+            return card;
+        }
+
+        /// <summary>Мелкое пояснение под группой: кегль 11, второстепенный цвет.</summary>
+        private static TextBlock Hint(string? textKey = null, string? bindingPath = null,
+            Thickness? margin = null)
+        {
+            var block = new TextBlock
+            {
+                FontSize = 11,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = margin ?? new Thickness(2, 6, 0, 0)
+            };
+            if (textKey is not null)
+                block.Text = LocalizationManager.T(textKey);
+            if (bindingPath is not null)
+                block.Bind(TextBlock.TextProperty, new Binding(bindingPath));
+            Themes.ThemeBrushes.Bind(block, TextBlock.ForegroundProperty, "TextSecondaryBrush");
+            return block;
+        }
+
+        private static TabItem Tab(string iconKey, string titleKey, Control content)
+        {
+            var tab = new TabItem
+            {
+                Header = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 8,
+                    Children =
+                    {
+                        IconHelper.MakeIcon(iconKey, 16),
+                        new TextBlock { Text = LocalizationManager.T(titleKey), VerticalAlignment = VerticalAlignment.Center }
+                    }
+                },
+                Content = new ScrollViewer { Content = content, VerticalScrollBarVisibility = ScrollBarVisibility.Auto }
+            };
+            tab.Styled(ControlThemes.ConnTabItem);
+            return tab;
+        }
+
+        // ===================== Раскладка окна =====================
 
         private Control BuildRoot()
         {
-            var grid = new Grid { Margin = new Thickness(16) };
+            var grid = new Grid();
             grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
             grid.RowDefinitions.Add(new RowDefinition(new GridLength(1, GridUnitType.Star)));
             grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
 
-            grid.Children.Add(BuildHeader());
-            Grid.SetRow(grid.Children[^1], 0);
+            var header = BuildHeader();
+            Grid.SetRow(header, 0);
+            grid.Children.Add(header);
 
             var tabs = BuildTabs();
+            tabs.Margin = new Thickness(12, 8, 12, 4);
             Grid.SetRow(tabs, 1);
             grid.Children.Add(tabs);
 
-            var buttons = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8,
-                Margin = new Thickness(0, 12, 0, 0)
-            };
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 100, IsCancel = true };
-            cancel.Click += (_, _) => Close();
-            buttons.Children.Add(cancel);
-            var save = new Button { Content = LocalizationManager.T("Common.Save"), MinWidth = 120, IsDefault = true };
-            save.Click += (_, _) => OnSave_Click();
-            buttons.Children.Add(save);
-            Grid.SetRow(buttons, 2);
-            grid.Children.Add(buttons);
+            var bottom = BuildBottomBar();
+            Grid.SetRow(bottom, 2);
+            grid.Children.Add(bottom);
 
             return grid;
         }
 
-        private Control BuildHeader()
+        /// <summary>Шапка окна: значок базы, заголовок и подзаголовок.</summary>
+        private static Control BuildHeader()
         {
-            var panel = new StackPanel { Margin = new Thickness(0, 0, 0, 12), Spacing = 10 };
+            var iconBox = new Border
+            {
+                Width = 40,
+                Height = 40,
+                CornerRadius = new CornerRadius(10),
+                Margin = new Thickness(0, 0, 12, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+                Child = IconHelper.MakeIcon("IconDatabase", 22, Brushes.White)
+            };
+            Themes.ThemeBrushes.Bind(iconBox, Border.BackgroundProperty, "AccentBrush");
 
-            // Наименование
-            panel.Children.Add(Field(LocalizationManager.T("Connection.NameLabel"), Tb("Name")));
+            var title = new TextBlock
+            {
+                Text = LocalizationManager.T("Connection.HeaderTitle"),
+                FontSize = 18,
+                FontWeight = FontWeight.SemiBold
+            };
+            var subtitle = new TextBlock
+            {
+                Text = LocalizationManager.T("Connection.HeaderSubtitle"),
+                FontSize = 12,
+                Margin = new Thickness(0, 2, 0, 0)
+            };
+            Themes.ThemeBrushes.Bind(subtitle, TextBlock.ForegroundProperty, "TextSecondaryBrush");
 
-            // Группа
-            var groupRow = new Grid();
-            groupRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(160)));
-            groupRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-            groupRow.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-            var groupLabel = new TextBlock { Text = LocalizationManager.T("Connection.GroupLabel"), VerticalAlignment = VerticalAlignment.Center };
-            Grid.SetColumn(groupLabel, 0);
-            groupRow.Children.Add(groupLabel);
-            var groupText = new TextBlock { VerticalAlignment = VerticalAlignment.Center };
-            groupText.Bind(TextBlock.TextProperty, new Binding("GroupDisplayPath"));
-            Grid.SetColumn(groupText, 1);
-            groupRow.Children.Add(groupText);
-            var selectGroup = new Button { Content = LocalizationManager.T("Connection.ChooseGroup"), MinWidth = 90, Margin = new Thickness(8, 0, 0, 0) };
-            selectGroup.Click += (_, _) => OnSelectGroup_Click();
-            Grid.SetColumn(selectGroup, 2);
-            groupRow.Children.Add(selectGroup);
-            panel.Children.Add(groupRow);
+            var band = new Border
+            {
+                Padding = new Thickness(20, 16),
+                BorderThickness = new Thickness(0, 0, 0, 1),
+                Child = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Children =
+                    {
+                        iconBox,
+                        new StackPanel
+                        {
+                            VerticalAlignment = VerticalAlignment.Center,
+                            Children = { title, subtitle }
+                        }
+                    }
+                }
+            };
+            Themes.ThemeBrushes.Bind(band, Border.BackgroundProperty, "CardBackgroundBrush");
+            Themes.ThemeBrushes.Bind(band, Border.BorderBrushProperty, "BorderBrushColor");
+            return band;
+        }
 
-            // Описание
-            panel.Children.Add(Field(LocalizationManager.T("Connection.DescriptionLabel"), Tb("Description", null, true)));
+        /// <summary>Нижняя панель: сохранение доступно, только пока есть изменения.</summary>
+        private Control BuildBottomBar()
+        {
+            // Сохранение доступно, только пока есть несохранённые изменения,
+            // и гаснет прозрачностью, как в разметке (ConnectionSettingsWindow.xaml:1040).
+            var save = BuildConfirmActionButton("Common.Save", "IconSave", 140, OnSave_Click, closeOnClick: false);
+            save.Classes.Add("dimmed");
+            save.Bind(InputElement.IsEnabledProperty, new Binding("HasChanges"));
 
-            // ID
-            var idRow = new Grid();
-            idRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(160)));
-            idRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-            idRow.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-            idRow.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-            var idLabel = new TextBlock { Text = LocalizationManager.T("ConnectionSettings.IdLabel"), VerticalAlignment = VerticalAlignment.Center };
-            Grid.SetColumn(idLabel, 0);
-            idRow.Children.Add(idLabel);
-            var idText = new TextBox { Padding = new Thickness(8, 5), IsReadOnly = true };
-            idText.Bind(TextBox.TextProperty, new Binding("Id") { Mode = BindingMode.TwoWay });
-            Grid.SetColumn(idText, 1);
-            idRow.Children.Add(idText);
-            var copyId = new Button { Content = LocalizationManager.T("Connection.CopyId"), MinWidth = 90, Margin = new Thickness(8, 0, 0, 0) };
-            copyId.Click += (_, _) => OnCopyId_Click();
-            Grid.SetColumn(copyId, 2);
-            idRow.Children.Add(copyId);
-            var genId = new Button { Content = LocalizationManager.T("Connection.GenerateId"), MinWidth = 110, Margin = new Thickness(8, 0, 0, 0) };
-            genId.Click += (_, _) => _viewModel.Id = Guid.NewGuid().ToString("D");
-            Grid.SetColumn(genId, 3);
-            idRow.Children.Add(genId);
-            panel.Children.Add(idRow);
-
-            // Строка подключения
-            var csRow = new Grid();
-            csRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(160)));
-            csRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-            csRow.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-            var csLabel = new TextBlock { Text = LocalizationManager.T("ConnectionSettings.ConnectionStringLabel"), VerticalAlignment = VerticalAlignment.Center };
-            Grid.SetColumn(csLabel, 0);
-            csRow.Children.Add(csLabel);
-            var csText = new TextBox { Padding = new Thickness(8, 5), AcceptsReturn = true, MinHeight = 60 };
-            csText.Bind(TextBox.TextProperty, new Binding("ConnectionString") { Mode = BindingMode.TwoWay });
-            Grid.SetColumn(csText, 1);
-            csRow.Children.Add(csText);
-            var pasteCs = new Button { Content = LocalizationManager.T("ConnectionSettings.PasteButton"), MinWidth = 90, Margin = new Thickness(8, 0, 0, 0), VerticalAlignment = VerticalAlignment.Top };
-            pasteCs.Click += (_, _) => OnPasteConnectionString_Click();
-            Grid.SetColumn(pasteCs, 2);
-            csRow.Children.Add(pasteCs);
-            panel.Children.Add(csRow);
-
-            return panel;
+            var bar = new Border
+            {
+                Padding = new Thickness(16, 12),
+                BorderThickness = new Thickness(0, 1, 0, 0),
+                Child = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    HorizontalAlignment = HorizontalAlignment.Right,
+                    Spacing = 10,
+                    Children = { save, BuildCancelActionButton(140) }
+                }
+            };
+            Themes.ThemeBrushes.Bind(bar, Border.BackgroundProperty, "CardBackgroundBrush");
+            Themes.ThemeBrushes.Bind(bar, Border.BorderBrushProperty, "BorderBrushColor");
+            return bar;
         }
 
         private TabControl BuildTabs()
         {
-            var tabs = new TabControl();
+            var tabs = new TabControl { TabStripPlacement = Dock.Left };
+            tabs.Styled(ControlThemes.ConnTabControl);
 
-            // ===== Подключение =====
-            var conn = new StackPanel();
+            tabs.Items.Add(Tab("IconDatabase", "Connection.Tab.Base", BuildBaseTab()));
+            tabs.Items.Add(Tab("IconNetwork", "Connection.Tab.Connection", BuildConnectionTab()));
+            tabs.Items.Add(Tab("IconMerge", "Connection.Tab.Repository", BuildRepositoryTab()));
+            tabs.Items.Add(Tab("IconAccountKey", "Connection.Tab.Auth", BuildAuthTab()));
+            tabs.Items.Add(Tab("IconPlay", "Connection.Tab.Launch", BuildLaunchTab()));
+            tabs.Items.Add(Tab("IconMonitor", "Connection.Tab.Bitness", BuildBitnessTab()));
+            tabs.Items.Add(Tab("IconPackage", "Connection.Tab.Platform", BuildPlatformTab()));
+            tabs.Items.Add(Tab("IconInfo", "Connection.Tab.Id", BuildIdTab()));
+            return tabs;
+        }
 
-            var connType = RadioGroup(
-                Radio("ConnectionType", "IsClientServer", LocalizationManager.T("Connection.TypeServer")),
-                Radio("ConnectionType", "IsFile", LocalizationManager.T("Connection.TypeFile")),
-                Radio("ConnectionType", "IsWebServer", LocalizationManager.T("Connection.TypeWeb")));
-            conn.Children.Add(Field(LocalizationManager.T("ConnectionSettings.ConnectionTypeLabel"), connType));
+        private Control BuildBaseTab()
+        {
+            var fields = FieldsGrid(3);
+            Place(fields, 0, "Connection.NameLabel", Tb("Name"));
 
-            conn.Children.Add(Field(LocalizationManager.T("Connection.ServerLabel"), Tb("Server", LocalizationManager.T("ConnectionSettings.ServerWatermark"))));
-            conn.Children.Add(Field(LocalizationManager.T("Connection.DatabaseNameLabel"), Tb("DatabaseName", LocalizationManager.T("ConnectionSettings.DatabaseNameWatermark"))));
-            conn.Children.Add(Field(LocalizationManager.T("Connection.PortLabel"), EditableCombo("PortText", "AvailablePorts")));
+            var groupPath = Tb("GroupDisplayPath");
+            groupPath.IsReadOnly = true;
+            groupPath.Padding = new Thickness(8, 6);
+            Place(fields, 1, "Connection.GroupLabel",
+                WithButton(groupPath, SecondaryButton("IconFolderOutline", "Connection.ChooseGroup", OnSelectGroup_Click)));
 
-            var filePathRow = new Grid();
-            filePathRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(160)));
-            filePathRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-            filePathRow.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-            var fileLabel = new TextBlock { Text = LocalizationManager.T("CreateInfobase.DirLabel"), VerticalAlignment = VerticalAlignment.Center };
-            Grid.SetColumn(fileLabel, 0);
-            filePathRow.Children.Add(fileLabel);
-            var fileText = Tb("FilePath", LocalizationManager.T("ConnectionSettings.FilePathWatermark"));
-            Grid.SetColumn(fileText, 1);
-            filePathRow.Children.Add(fileText);
-            var browse = new Button { Content = LocalizationManager.T("Common.Browse"), MinWidth = 90, Margin = new Thickness(8, 0, 0, 0) };
-            browse.Click += (_, _) => OnBrowseFilePath_Click();
-            Grid.SetColumn(browse, 2);
-            filePathRow.Children.Add(browse);
-            conn.Children.Add(Field("", filePathRow));
+            Place(fields, 2, "Connection.DescriptionLabel", Tb("Description"));
+            return Group("IconDatabase", "Connection.GroupBase", fields);
+        }
 
-            conn.Children.Add(Field(LocalizationManager.T("Connection.WebUrlLabel"), Tb("WebUrl", "https://…")));
+        private Control BuildConnectionTab()
+        {
+            var fields = FieldsGrid(4);
 
-            // Аутентификация
-            var auth = RadioGroup(
-                Radio("Auth", "IsAuthPrompt", LocalizationManager.T("ConnectionSettings.AuthPromptShort")),
-                Radio("Auth", "IsAuthCredentials", LocalizationManager.T("ConnectionSettings.AuthAutoShort")),
-                Radio("Auth", "IsAuthWindows", LocalizationManager.T("ConnectionSettings.AuthOsShort")));
-            conn.Children.Add(Field(LocalizationManager.T("ConnectionSettings.AuthLabel"), auth));
-
-            // Имя и пароль показываются только в режиме «вход автоматически»:
-            // в остальных они не участвуют, и в разметке WPF они скрыты
-            // привязкой к IsCredentialsVisible (ConnectionSettingsWindow.xaml:523).
-            var userField = Field(LocalizationManager.T("Connection.UserLabel"), Tb("User"));
-            userField.Bind(Control.IsVisibleProperty, new Binding("IsCredentialsVisible") { Source = _viewModel });
-            conn.Children.Add(userField);
-            _passwordBox.PasswordChanged += (_, _) =>
+            var types = new StackPanel
             {
-                if (_isSyncingPassword) return;
-                _viewModel.Password = _passwordBox.Password;
+                Children =
+                {
+                    OptionCard("ConnType", "IsClientServer", "Connection.TypeServer", "Connection.TypeServerHint"),
+                    OptionCard("ConnType", "IsFile", "Connection.TypeFile", "Connection.TypeFileHint"),
+                    OptionCard("ConnType", "IsWebServer", "Connection.TypeWeb", "Connection.TypeWebHint")
+                }
             };
-            var passwordField = Field(LocalizationManager.T("Connection.PasswordLabel"), _passwordBox);
-            passwordField.Bind(Control.IsVisibleProperty, new Binding("IsCredentialsVisible") { Source = _viewModel });
-            conn.Children.Add(passwordField);
+            Place(fields, 0, "Connection.TypeLabel", types, labelAlignment: VerticalAlignment.Top);
 
-            tabs.Items.Add(new TabItem { Header = LocalizationManager.T("Connection.Tab.Connection"), Content = new ScrollViewer { Content = conn, VerticalScrollBarVisibility = ScrollBarVisibility.Auto } });
+            // Строки серверного, файлового и веб-подключения занимают одни и те же
+            // строки сетки и переключаются признаком типа, как в разметке
+            // (ConnectionSettingsWindow.xaml:324, :346, :363).
+            var server = EditableCombo("Server", "AvailableServers");
+            ToolTip.SetTip(server, LocalizationManager.T("Connection.ServerTooltip"));
+            Place(fields, 1, "Connection.ServerLabel", server, "IsClientServer");
+            Place(fields, 2, "Connection.DatabaseNameLabel", Tb("DatabaseName"), "IsClientServer");
+            var port = EditableCombo("PortText", "AvailablePorts");
+            ToolTip.SetTip(port, LocalizationManager.T("Connection.PortTooltip"));
+            Place(fields, 3, "Connection.PortLabel", port, "IsClientServer");
 
-            // ===== Платформа и запуск =====
-            var platform = new StackPanel();
+            Place(fields, 1, "Connection.FilePathLabel",
+                WithButton(Tb("FilePath"),
+                    SecondaryButton("IconFolderOpen", "Common.Browse", OnBrowseFilePath_Click, "Connection.BrowseFileTooltip")),
+                "IsFile");
 
-            var platRow = new Grid();
-            platRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(160)));
-            platRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-            platRow.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-            var platLabel = new TextBlock { Text = LocalizationManager.T("Connection.VersionLabel"), VerticalAlignment = VerticalAlignment.Center };
-            Grid.SetColumn(platLabel, 0);
-            platform.Children.Add(platRow);
-            platRow.Children.Add(platLabel);
-            var platCombo = new ComboBox();
-            platCombo.Bind(ComboBox.ItemsSourceProperty, new Binding("InstalledPlatformVersions"));
-            platCombo.Bind(ComboBox.SelectedItemProperty, new Binding("PlatformVersion") { Mode = BindingMode.TwoWay });
-            Grid.SetColumn(platCombo, 1);
-            platRow.Children.Add(platCombo);
-            var platBtn = new Button { Content = LocalizationManager.T("Connection.ChoosePlatform"), MinWidth = 90, Margin = new Thickness(8, 0, 0, 0) };
-            platBtn.Click += (_, _) => OnPlatformSettings_Click();
-            Grid.SetColumn(platBtn, 2);
-            platRow.Children.Add(platBtn);
+            Place(fields, 1, "Connection.WebUrlLabel", Tb("WebUrl"), "IsWebServer");
 
-            platform.Children.Add(Field(LocalizationManager.T("ConnectionSettings.ArchLabel"), RadioGroup(
-                Radio("Arch", "IsArchitecture32", "32"),
-                Radio("Arch", "IsArchitecture64", "64"),
-                Radio("Arch", "IsArchitecture32Priority", LocalizationManager.T("ConnectionSettings.Arch32PriorityShort")),
-                Radio("Arch", "IsArchitecture64Priority", LocalizationManager.T("ConnectionSettings.Arch64PriorityShort")))));
-
-            // Две подсказки под выбором разрядности, как в разметке WPF
-            // (ConnectionSettingsWindow.xaml:877): первая объясняет выбранный
-            // режим и меняется вместе с ним, вторая сообщает про саму ОС.
-            var archHint = new TextBlock
+            var paste = new Button
             {
-                FontSize = UiMetrics.ScaledFont(12),
-                TextWrapping = TextWrapping.Wrap,
-                Margin = new Thickness(0, 2, 0, 0)
+                Content = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6,
+                    Children =
+                    {
+                        IconHelper.MakeIcon("IconCopy", 15, "SecondaryButtonTextBrush"),
+                        new TextBlock
+                        {
+                            Text = LocalizationManager.T("Connection.PasteString"),
+                            FontSize = 12,
+                            FontWeight = FontWeight.SemiBold,
+                            VerticalAlignment = VerticalAlignment.Center
+                        }
+                    }
+                },
+                Height = 36,
+                Padding = new Thickness(12, 0),
+                Margin = new Thickness(0, 0, 6, 0)
             };
-            archHint.Bind(TextBlock.TextProperty, new Binding("ArchitectureHint") { Source = _viewModel });
-            Themes.ThemeBrushes.Bind(archHint, TextBlock.ForegroundProperty, "TextSecondaryBrush");
-            platform.Children.Add(archHint);
+            paste.Styled(ControlThemes.SecondaryButton);
+            paste.Click += (_, _) => OnPasteConnectionString_Click();
+            ToolTip.SetTip(paste, LocalizationManager.T("Connection.PasteStringTooltip"));
 
-            // Тексты автора говорят «Windows» в обоих вариантах, поэтому для
-            // Linux заведены свои ключи, а не переиспользованы его.
-            var osHint = new TextBlock
+            return new StackPanel
             {
-                Text = LocalizationManager.T(Environment.Is64BitOperatingSystem
-                    ? "Connection.OsLinux64Text"
-                    : "Connection.OsLinux32Text"),
-                FontSize = UiMetrics.ScaledFont(12),
-                TextWrapping = TextWrapping.Wrap,
-                Margin = new Thickness(0, 2, 0, 8)
+                Children =
+                {
+                    Group("IconServer", "Connection.GroupConnectionType", fields),
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        Margin = new Thickness(4, 8, 4, 0),
+                        Children = { paste, HelpLink("Connection.PasteStringHelp") }
+                    }
+                }
             };
-            Themes.ThemeBrushes.Bind(osHint, TextBlock.ForegroundProperty, "TextSecondaryBrush");
-            platform.Children.Add(osHint);
+        }
 
-            platform.Children.Add(Field(LocalizationManager.T("ConnectionSettings.LaunchModeLabel"), RadioGroup(
-                Radio("LaunchMode", "IsAutoMode", LocalizationManager.T("Main.SessionClientAuto")),
-                Radio("LaunchMode", "IsThinClient", LocalizationManager.T("Main.SessionClientThin")),
-                Radio("LaunchMode", "IsThickClient", LocalizationManager.T("ConnectionSettings.LaunchThickShort")),
-                Radio("LaunchMode", "IsThickOrdinaryClient", LocalizationManager.T("ConnectionSettings.LaunchThickOrdinaryShort")),
-                Radio("LaunchMode", "IsWebClient", LocalizationManager.T("Connection.LaunchWeb")))));
+        private Control BuildRepositoryTab()
+        {
+            var fields = FieldsGrid(4);
+            var server = Tb("RepositoryServer");
+            ToolTip.SetTip(server, LocalizationManager.T("Connection.RepositoryServerTooltip"));
+            Place(fields, 0, "Connection.RepositoryServerLabel", server);
+            var name = Tb("RepositoryName");
+            ToolTip.SetTip(name, LocalizationManager.T("Connection.RepositoryNameTooltip"));
+            Place(fields, 1, "Connection.RepositoryNameLabel", name);
+            var user = Tb("RepositoryUser");
+            ToolTip.SetTip(user, LocalizationManager.T("Connection.RepositoryUserTooltip"));
+            Place(fields, 2, "Connection.RepositoryLoginLabel", user);
 
-            var launchRow = new Grid();
-            launchRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(160)));
-            launchRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-            launchRow.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-            var launchLabel = new TextBlock { Text = LocalizationManager.T("ConnectionSettings.LaunchParametersLabel"), VerticalAlignment = VerticalAlignment.Center };
-            Grid.SetColumn(launchLabel, 0);
-            launchRow.Children.Add(launchLabel);
-            var launchText = new TextBox { Padding = new Thickness(8, 5), AcceptsReturn = true, MinHeight = 60 };
-            launchText.Bind(TextBox.TextProperty, new Binding("LaunchParameters") { Mode = BindingMode.TwoWay });
-            Grid.SetColumn(launchText, 1);
-            launchRow.Children.Add(launchText);
-            var launchBtn = new Button { Content = LocalizationManager.T("ConnectionSettings.ConfigureButton"), MinWidth = 100, Margin = new Thickness(8, 0, 0, 0), VerticalAlignment = VerticalAlignment.Top };
-            launchBtn.Click += (_, _) => OnLaunchParameters_Click();
-            Grid.SetColumn(launchBtn, 2);
-            launchRow.Children.Add(launchBtn);
-            platform.Children.Add(Field("", launchRow));
-
-            platform.Children.Add(Field(LocalizationManager.T("Connection.ConfigurationLabel"), Tb("ConfigurationName")));
-            platform.Children.Add(Field(LocalizationManager.T("ConnectionSettings.ConfigurationVersionLabel"), Tb("ConfigurationVersion")));
-
-            tabs.Items.Add(new TabItem { Header = LocalizationManager.T("ConnectionSettings.TabPlatformAndLaunch"), Content = new ScrollViewer { Content = platform, VerticalScrollBarVisibility = ScrollBarVisibility.Auto } });
-
-            // ===== Репозиторий =====
-            var repo = new StackPanel();
-            repo.Children.Add(Field(LocalizationManager.T("Connection.RepositoryServerLabel"), Tb("RepositoryServer")));
-            repo.Children.Add(Field(LocalizationManager.T("Connection.RepositoryNameLabel"), Tb("RepositoryName")));
-            repo.Children.Add(Field(LocalizationManager.T("Connection.UserLabel"), Tb("RepositoryUser")));
+            _repositoryPasswordBox.Margin = new Thickness(0, 3);
+            _repositoryPasswordBox.Padding = new Thickness(6, 4);
+            _repositoryPasswordBox.VerticalContentAlignment = VerticalAlignment.Center;
+            ToolTip.SetTip(_repositoryPasswordBox, LocalizationManager.T("Connection.RepositoryPasswordTooltip"));
             _repositoryPasswordBox.PasswordChanged += (_, _) =>
             {
                 if (_isSyncingRepositoryPassword) return;
                 _viewModel.RepositoryPassword = _repositoryPasswordBox.Password;
             };
-            repo.Children.Add(Field(LocalizationManager.T("Connection.RepositoryPasswordLabel"), _repositoryPasswordBox));
-            tabs.Items.Add(new TabItem { Header = LocalizationManager.T("Connection.Tab.Repository"), Content = new ScrollViewer { Content = repo, VerticalScrollBarVisibility = ScrollBarVisibility.Auto } });
+            Place(fields, 3, "Connection.RepositoryPasswordLabel", _repositoryPasswordBox);
 
-            // ===== Конфигуратор =====
-            var config = new StackPanel();
-            config.Children.Add(Field(LocalizationManager.T("ConnectionSettings.AuthLabel"), RadioGroup(
-                Radio("ConfigAuth", "IsConfiguratorAuthPrompt", LocalizationManager.T("ConnectionSettings.AuthPromptShort")),
-                Radio("ConfigAuth", "IsConfiguratorAuthCredentials", LocalizationManager.T("ConnectionSettings.AuthAutoShort")),
-                Radio("ConfigAuth", "IsConfiguratorAuthWindows", LocalizationManager.T("ConnectionSettings.AuthOsShort")))));
-            var configUserField = Field(LocalizationManager.T("Connection.UserLabel"), Tb("ConfiguratorUser"));
-            configUserField.Bind(Control.IsVisibleProperty,
-                new Binding("IsConfiguratorCredentialsVisible") { Source = _viewModel });
-            config.Children.Add(configUserField);
+            var content = new StackPanel
+            {
+                Children = { fields, Hint("Connection.RepositoryDescription", margin: new Thickness(0, 8, 0, 0)) }
+            };
+            return Group("IconMerge", "Connection.GroupRepository", content);
+        }
+
+        private Control BuildAuthTab()
+        {
+            var enterprise = FieldsGrid(3);
+            Place(enterprise, 0, "Connection.ModeLabel", new StackPanel
+            {
+                Children =
+                {
+                    OptionCard("Auth", "IsAuthPrompt", "Connection.AuthPrompt", "Connection.AuthPromptHint"),
+                    OptionCard("Auth", "IsAuthCredentials", "Connection.AuthAuto", "Connection.AuthAutoHint"),
+                    OptionCard("Auth", "IsAuthWindows", "Connection.AuthOs", "Connection.AuthOsHint")
+                }
+            }, labelAlignment: VerticalAlignment.Top);
+
+            var user = Tb("User");
+            Place(enterprise, 1, "Connection.UserLabel", user, "IsCredentialsVisible");
+
+            _passwordBox.Margin = new Thickness(0, 3);
+            _passwordBox.Padding = new Thickness(6, 4);
+            _passwordBox.VerticalContentAlignment = VerticalAlignment.Center;
+            _passwordBox.PasswordChanged += (_, _) =>
+            {
+                if (_isSyncingPassword) return;
+                _viewModel.Password = _passwordBox.Password;
+            };
+            Place(enterprise, 2, "Connection.PasswordLabel", _passwordBox, "IsCredentialsVisible");
+
+            var configurator = FieldsGrid(3);
+            Place(configurator, 0, "Connection.ModeLabel", new StackPanel
+            {
+                Children =
+                {
+                    OptionCard("ConfigAuth", "IsConfiguratorAuthPrompt", "Connection.AuthPrompt", "Connection.AuthConfiguratorPromptHint"),
+                    OptionCard("ConfigAuth", "IsConfiguratorAuthCredentials", "Connection.AuthAuto", "Connection.AuthAutoHint"),
+                    OptionCard("ConfigAuth", "IsConfiguratorAuthWindows", "Connection.AuthOs", "Connection.AuthOsHint")
+                }
+            }, labelAlignment: VerticalAlignment.Top);
+
+            Place(configurator, 1, "Connection.UserLabel", Tb("ConfiguratorUser"), "IsConfiguratorCredentialsVisible");
+
+            _configuratorPasswordBox.Margin = new Thickness(0, 3);
+            _configuratorPasswordBox.Padding = new Thickness(6, 4);
+            _configuratorPasswordBox.VerticalContentAlignment = VerticalAlignment.Center;
             _configuratorPasswordBox.PasswordChanged += (_, _) =>
             {
                 if (_isSyncingConfiguratorPassword) return;
                 _viewModel.ConfiguratorPassword = _configuratorPasswordBox.Password;
             };
-            var configPasswordField = Field(LocalizationManager.T("Connection.PasswordLabel"), _configuratorPasswordBox);
-            configPasswordField.Bind(Control.IsVisibleProperty,
-                new Binding("IsConfiguratorCredentialsVisible") { Source = _viewModel });
-            config.Children.Add(configPasswordField);
-            tabs.Items.Add(new TabItem { Header = LocalizationManager.T("ConnectionSettings.TabConfigurator"), Content = new ScrollViewer { Content = config, VerticalScrollBarVisibility = ScrollBarVisibility.Auto } });
+            Place(configurator, 2, "Connection.PasswordLabel", _configuratorPasswordBox, "IsConfiguratorCredentialsVisible");
 
-            return tabs;
+            return new StackPanel
+            {
+                Children =
+                {
+                    Group("IconAccountKey", "Connection.GroupAuthEnterprise", enterprise),
+                    Group("IconApplicationCog", "Connection.GroupAuthConfigurator", configurator)
+                }
+            };
+        }
+
+        private Control BuildLaunchTab()
+        {
+            var content = new StackPanel
+            {
+                Children =
+                {
+                    OptionCard("LaunchMode", "IsAutoMode", "Connection.LaunchAuto", "Connection.LaunchAutoHint"),
+                    OptionCard("LaunchMode", "IsThinClient", "Connection.LaunchThin", "Connection.LaunchThinHint"),
+                    OptionCard("LaunchMode", "IsThickClient", "Connection.LaunchThickManaged", "Connection.LaunchThickManagedHint"),
+                    OptionCard("LaunchMode", "IsThickOrdinaryClient", "Connection.LaunchThickOrdinary", "Connection.LaunchThickOrdinaryHint"),
+                    // Веб-клиент доступен только у веб-подключения, как в разметке
+                    // (ConnectionSettingsWindow.xaml:734).
+                    OptionCard("LaunchMode", "IsWebClient", "Connection.LaunchWeb", "Connection.LaunchWebHint", "IsWebClientAllowed"),
+                    Hint(bindingPath: "LaunchModeHint")
+                }
+            };
+            return Group("IconApplication", "Connection.GroupLaunchMode", content);
+        }
+
+        private Control BuildBitnessTab()
+        {
+            // Тексты автора говорят «Windows» в обоих вариантах, поэтому для
+            // Linux заведены свои ключи, а не переиспользованы его.
+            var osHint = Hint(Environment.Is64BitOperatingSystem
+                ? "Connection.OsLinux64Text"
+                : "Connection.OsLinux32Text", margin: new Thickness(2, 2, 0, 0));
+            if (!Environment.Is64BitOperatingSystem)
+                osHint.Foreground = new SolidColorBrush(Color.Parse("#DC2626"));
+
+            var content = new StackPanel
+            {
+                Children =
+                {
+                    OptionCard("Arch", "IsArchitecture32Priority", "Connection.Arch32Priority", "Connection.Arch32PriorityHint"),
+                    OptionCard("Arch", "IsArchitecture64Priority", "Connection.Arch64Priority", "Connection.Arch64PriorityHint"),
+                    OptionCard("Arch", "IsArchitecture32", "Connection.ArchOnly32", "Connection.ArchOnly32Hint"),
+                    // Только 64 недоступно на 32-битной системе (xaml:852).
+                    OptionCard("Arch", "IsArchitecture64", "Connection.ArchOnly64", "Connection.ArchOnly64Hint", "IsOs64Bit"),
+                    Hint(bindingPath: "ArchitectureHint"),
+                    osHint
+                }
+            };
+            return Group("IconMonitor", "Connection.GroupBitness", content);
+        }
+
+        private Control BuildPlatformTab()
+        {
+            var fields = FieldsGrid(3);
+
+            var version = Tb("PlatformVersion");
+            version.Padding = new Thickness(8, 6);
+            ToolTip.SetTip(version, LocalizationManager.T("Connection.PlatformVersionTooltip"));
+            var pickPlatform = SecondaryButton("IconPackage", "Connection.ChoosePlatform", OnPlatformSettings_Click);
+            pickPlatform.Padding = new Thickness(8, 3);
+            Place(fields, 0, "Connection.VersionLabel", WithButton(version, pickPlatform));
+
+            var configRow = new Grid { Margin = new Thickness(0, 6, 0, 3) };
+            configRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(2, GridUnitType.Star)));
+            configRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(8)));
+            configRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+            var configName = Tb("ConfigurationName");
+            configName.Margin = new Thickness(0);
+            configName.Padding = new Thickness(8, 6);
+            ToolTip.SetTip(configName, LocalizationManager.T("Connection.ConfigurationNameTooltip"));
+            Grid.SetColumn(configName, 0);
+            configRow.Children.Add(configName);
+            var configVersion = Tb("ConfigurationVersion");
+            configVersion.Margin = new Thickness(0);
+            configVersion.Padding = new Thickness(8, 6);
+            ToolTip.SetTip(configVersion, LocalizationManager.T("Connection.ConfigurationVersionTooltip"));
+            Grid.SetColumn(configVersion, 2);
+            configRow.Children.Add(configVersion);
+            Place(fields, 1, "Connection.ConfigurationLabel", configRow);
+
+            var parameters = Tb("LaunchParameters");
+            parameters.Padding = new Thickness(8, 6);
+            var pickParameters = SecondaryButton("IconTune", "Connection.Parameters", OnLaunchParameters_Click);
+            pickParameters.Padding = new Thickness(8, 3);
+            Place(fields, 2, "Connection.ParametersLabel", WithButton(parameters, pickParameters));
+
+            return Group("IconPackage", "Connection.GroupPlatform", fields);
+        }
+
+        private Control BuildIdTab()
+        {
+            var id = Tb("Id");
+            id.Margin = new Thickness(0);
+            ToolTip.SetTip(id, LocalizationManager.T("Connection.IdTooltip"));
+
+            var label = new TextBlock
+            {
+                Text = LocalizationManager.T("Connection.IdLabel"),
+                FontSize = 11,
+                FontWeight = FontWeight.SemiBold,
+                Margin = new Thickness(0, 0, 0, 4)
+            };
+            Themes.ThemeBrushes.Bind(label, TextBlock.ForegroundProperty, "TextSecondaryBrush");
+
+            var generate = SecondaryButton("IconRefresh", "Connection.GenerateId",
+                () => _viewModel.Id = Guid.NewGuid().ToString("D"), "Connection.GenerateIdTooltip");
+            generate.Padding = new Thickness(10, 5);
+            generate.Margin = new Thickness(0, 0, 8, 0);
+            var copy = SecondaryButton("IconCopy", "Connection.CopyId", OnCopyId_Click, "Connection.CopyIdTooltip");
+            copy.Padding = new Thickness(10, 5);
+
+            return new StackPanel
+            {
+                Margin = new Thickness(8, 12, 8, 8),
+                VerticalAlignment = VerticalAlignment.Top,
+                Children =
+                {
+                    Hint("Connection.IdDescription", margin: new Thickness(0, 0, 0, 10)),
+                    label,
+                    id,
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        Margin = new Thickness(0, 8, 0, 0),
+                        Children = { generate, copy }
+                    }
+                }
+            };
         }
 
         // ===================== Обработчики =====================

--- a/Configuration Management/Views/ConnectionSettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/ConnectionSettingsWindow.Avalonia.cs
@@ -107,7 +107,7 @@ namespace Configuration_Management
         /// <summary>Ширина колонки подписей, как в разметке (ConnectionSettingsWindow.xaml:203).</summary>
         private const double LabelColumn = 120;
 
-        private static TextBox Tb(string path, string? watermark = null, bool multiline = false)
+        private static TextBox Tb(string path, bool readOnly = false)
         {
             var tb = new TextBox
             {
@@ -116,12 +116,13 @@ namespace Configuration_Management
                 FontSize = 12,
                 Margin = new Thickness(0, 3),
                 VerticalContentAlignment = VerticalAlignment.Center,
-                Watermark = watermark,
-                AcceptsReturn = multiline
+                IsReadOnly = readOnly
             };
-            if (multiline)
-                tb.MinHeight = 70;
-            tb.Bind(TextBox.TextProperty, new Binding(path) { Mode = BindingMode.TwoWay });
+            // Свойство только для чтения привязывается односторонне, как в разметке
+            // (ConnectionSettingsWindow.xaml:219): двусторонняя привязка к свойству
+            // без сеттера пишет ошибку в журнал при каждом обновлении.
+            tb.Bind(TextBox.TextProperty,
+                new Binding(path) { Mode = readOnly ? BindingMode.OneWay : BindingMode.TwoWay });
             return tb;
         }
 
@@ -197,7 +198,7 @@ namespace Configuration_Management
 
         /// <summary>Вторичная кнопка со значком и подписью, как в разметке окна.</summary>
         private static Button SecondaryButton(string iconKey, string textKey, Action onClick,
-            string? tooltipKey = null, double iconSize = 14)
+            string? tooltipKey = null, double iconSize = 14, IBrush? iconBrush = null)
         {
             var button = new Button
             {
@@ -207,7 +208,9 @@ namespace Configuration_Management
                     Spacing = 4,
                     Children =
                     {
-                        IconHelper.MakeIcon(iconKey, iconSize, "SecondaryButtonTextBrush"),
+                        iconBrush is null
+                            ? IconHelper.MakeIcon(iconKey, iconSize, "SecondaryButtonTextBrush")
+                            : IconHelper.MakeIcon(iconKey, iconSize, iconBrush),
                         new TextBlock
                         {
                             Text = LocalizationManager.T(textKey),
@@ -279,7 +282,7 @@ namespace Configuration_Management
         /// Карточка варианта выбора: переключатель в рамке с подписью и пояснением.
         /// </summary>
         private static RadioButton OptionCard(string groupName, string path, string titleKey, string hintKey,
-            string? enabledPath = null)
+            string? enabledPath = null, bool wrapHint = false)
         {
             var card = new RadioButton
             {
@@ -294,13 +297,17 @@ namespace Configuration_Management
                             FontWeight = FontWeight.SemiBold,
                             FontSize = 12
                         },
+                        // Перенос строк и отступ пояснения у автора разные: на
+                        // вкладках выбора типа и авторизации это одна строка
+                        // с отступом 1 (xaml:279), на запуске и разрядности
+                        // перенос и отступ 2 (xaml:657).
                         new TextBlock
                         {
                             Text = LocalizationManager.T(hintKey),
                             FontSize = 11,
                             Opacity = 0.75,
-                            TextWrapping = TextWrapping.Wrap,
-                            Margin = new Thickness(0, 2, 0, 0)
+                            TextWrapping = wrapHint ? TextWrapping.Wrap : TextWrapping.NoWrap,
+                            Margin = new Thickness(0, wrapHint ? 2 : 1, 0, 0)
                         }
                     }
                 }
@@ -314,11 +321,11 @@ namespace Configuration_Management
 
         /// <summary>Мелкое пояснение под группой: кегль 11, второстепенный цвет.</summary>
         private static TextBlock Hint(string? textKey = null, string? bindingPath = null,
-            Thickness? margin = null)
+            Thickness? margin = null, double fontSize = 11)
         {
             var block = new TextBlock
             {
-                FontSize = 11,
+                FontSize = fontSize,
                 TextWrapping = TextWrapping.Wrap,
                 Margin = margin ?? new Thickness(2, 6, 0, 0)
             };
@@ -334,19 +341,27 @@ namespace Configuration_Management
         {
             var tab = new TabItem
             {
-                Header = new StackPanel
-                {
-                    Orientation = Orientation.Horizontal,
-                    Spacing = 8,
-                    Children =
-                    {
-                        IconHelper.MakeIcon(iconKey, 16),
-                        new TextBlock { Text = LocalizationManager.T(titleKey), VerticalAlignment = VerticalAlignment.Center }
-                    }
-                },
                 Content = new ScrollViewer { Content = content, VerticalScrollBarVisibility = ScrollBarVisibility.Auto }
             };
             tab.Styled(ControlThemes.ConnTabItem);
+
+            // Значок берёт цвет подписи: у выбранной вкладки тема меняет Foreground,
+            // а заливка контура сама по себе не наследуется, и значок остался бы
+            // светлым на тёмно-оранжевом.
+            var icon = IconHelper.MakeIcon(iconKey, 16, out var path);
+            path.Bind(Avalonia.Controls.Shapes.Shape.FillProperty,
+                new Binding(nameof(TabItem.Foreground)) { Source = tab });
+
+            tab.Header = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 8,
+                Children =
+                {
+                    icon,
+                    new TextBlock { Text = LocalizationManager.T(titleKey), VerticalAlignment = VerticalAlignment.Center }
+                }
+            };
             return tab;
         }
 
@@ -454,9 +469,15 @@ namespace Configuration_Management
 
         private TabControl BuildTabs()
         {
-            var tabs = new TabControl { TabStripPlacement = Dock.Left };
+            // Колонку вкладок слева задаёт сам шаблон темы, поэтому
+            // TabStripPlacement здесь не нужен: шаблон его не читает.
+            var tabs = new TabControl();
             tabs.Styled(ControlThemes.ConnTabControl);
 
+            // Значков MaterialDesign в Linux-сборке нет, поэтому взяты ближайшие
+            // из словаря автора: LanConnect это IconNetwork, SourceBranch это
+            // IconMerge, PlayCircleOutline это IconPlay, Chip это IconMonitor,
+            // CubeOutline это IconPackage, Identifier это IconInfo.
             tabs.Items.Add(Tab("IconDatabase", "Connection.Tab.Base", BuildBaseTab()));
             tabs.Items.Add(Tab("IconNetwork", "Connection.Tab.Connection", BuildConnectionTab()));
             tabs.Items.Add(Tab("IconMerge", "Connection.Tab.Repository", BuildRepositoryTab()));
@@ -473,8 +494,7 @@ namespace Configuration_Management
             var fields = FieldsGrid(3);
             Place(fields, 0, "Connection.NameLabel", Tb("Name"));
 
-            var groupPath = Tb("GroupDisplayPath");
-            groupPath.IsReadOnly = true;
+            var groupPath = Tb("GroupDisplayPath", readOnly: true);
             groupPath.Padding = new Thickness(8, 6);
             Place(fields, 1, "Connection.GroupLabel",
                 WithButton(groupPath, SecondaryButton("IconFolderOutline", "Connection.ChooseGroup", OnSelectGroup_Click)));
@@ -551,7 +571,15 @@ namespace Configuration_Management
                     {
                         Orientation = Orientation.Horizontal,
                         Margin = new Thickness(4, 8, 4, 0),
-                        Children = { paste, HelpLink("Connection.PasteStringHelp") }
+                        Children =
+                        {
+                            paste,
+                            new Configuration_Management.Controls.HelpLink
+                            {
+                                HelpText = LocalizationManager.T("Connection.PasteStringHelp"),
+                                VerticalAlignment = VerticalAlignment.Center
+                            }
+                        }
                     }
                 }
             };
@@ -653,13 +681,13 @@ namespace Configuration_Management
             {
                 Children =
                 {
-                    OptionCard("LaunchMode", "IsAutoMode", "Connection.LaunchAuto", "Connection.LaunchAutoHint"),
-                    OptionCard("LaunchMode", "IsThinClient", "Connection.LaunchThin", "Connection.LaunchThinHint"),
-                    OptionCard("LaunchMode", "IsThickClient", "Connection.LaunchThickManaged", "Connection.LaunchThickManagedHint"),
-                    OptionCard("LaunchMode", "IsThickOrdinaryClient", "Connection.LaunchThickOrdinary", "Connection.LaunchThickOrdinaryHint"),
+                    OptionCard("LaunchMode", "IsAutoMode", "Connection.LaunchAuto", "Connection.LaunchAutoHint", wrapHint: true),
+                    OptionCard("LaunchMode", "IsThinClient", "Connection.LaunchThin", "Connection.LaunchThinHint", wrapHint: true),
+                    OptionCard("LaunchMode", "IsThickClient", "Connection.LaunchThickManaged", "Connection.LaunchThickManagedHint", wrapHint: true),
+                    OptionCard("LaunchMode", "IsThickOrdinaryClient", "Connection.LaunchThickOrdinary", "Connection.LaunchThickOrdinaryHint", wrapHint: true),
                     // Веб-клиент доступен только у веб-подключения, как в разметке
                     // (ConnectionSettingsWindow.xaml:734).
-                    OptionCard("LaunchMode", "IsWebClient", "Connection.LaunchWeb", "Connection.LaunchWebHint", "IsWebClientAllowed"),
+                    OptionCard("LaunchMode", "IsWebClient", "Connection.LaunchWeb", "Connection.LaunchWebHint", "IsWebClientAllowed", wrapHint: true),
                     Hint(bindingPath: "LaunchModeHint")
                 }
             };
@@ -680,11 +708,11 @@ namespace Configuration_Management
             {
                 Children =
                 {
-                    OptionCard("Arch", "IsArchitecture32Priority", "Connection.Arch32Priority", "Connection.Arch32PriorityHint"),
-                    OptionCard("Arch", "IsArchitecture64Priority", "Connection.Arch64Priority", "Connection.Arch64PriorityHint"),
-                    OptionCard("Arch", "IsArchitecture32", "Connection.ArchOnly32", "Connection.ArchOnly32Hint"),
+                    OptionCard("Arch", "IsArchitecture32Priority", "Connection.Arch32Priority", "Connection.Arch32PriorityHint", wrapHint: true),
+                    OptionCard("Arch", "IsArchitecture64Priority", "Connection.Arch64Priority", "Connection.Arch64PriorityHint", wrapHint: true),
+                    OptionCard("Arch", "IsArchitecture32", "Connection.ArchOnly32", "Connection.ArchOnly32Hint", wrapHint: true),
                     // Только 64 недоступно на 32-битной системе (xaml:852).
-                    OptionCard("Arch", "IsArchitecture64", "Connection.ArchOnly64", "Connection.ArchOnly64Hint", "IsOs64Bit"),
+                    OptionCard("Arch", "IsArchitecture64", "Connection.ArchOnly64", "Connection.ArchOnly64Hint", "IsOs64Bit", wrapHint: true),
                     Hint(bindingPath: "ArchitectureHint"),
                     osHint
                 }
@@ -733,7 +761,6 @@ namespace Configuration_Management
         private Control BuildIdTab()
         {
             var id = Tb("Id");
-            id.Margin = new Thickness(0);
             ToolTip.SetTip(id, LocalizationManager.T("Connection.IdTooltip"));
 
             var label = new TextBlock
@@ -745,8 +772,10 @@ namespace Configuration_Management
             };
             Themes.ThemeBrushes.Bind(label, TextBlock.ForegroundProperty, "TextSecondaryBrush");
 
+            // Значок обновления зелёный, как в разметке (xaml:996).
             var generate = SecondaryButton("IconRefresh", "Connection.GenerateId",
-                () => _viewModel.Id = Guid.NewGuid().ToString("D"), "Connection.GenerateIdTooltip");
+                () => _viewModel.Id = Guid.NewGuid().ToString("D"), "Connection.GenerateIdTooltip",
+                iconBrush: new SolidColorBrush(Color.Parse("#22C55E")));
             generate.Padding = new Thickness(10, 5);
             generate.Margin = new Thickness(0, 0, 8, 0);
             var copy = SecondaryButton("IconCopy", "Connection.CopyId", OnCopyId_Click, "Connection.CopyIdTooltip");
@@ -758,7 +787,7 @@ namespace Configuration_Management
                 VerticalAlignment = VerticalAlignment.Top,
                 Children =
                 {
-                    Hint("Connection.IdDescription", margin: new Thickness(0, 0, 0, 10)),
+                    Hint("Connection.IdDescription", margin: new Thickness(0, 0, 0, 10), fontSize: 12),
                     label,
                     id,
                     new StackPanel

--- a/Configuration Management/Views/ConnectionStringInputWindow.Avalonia.cs
+++ b/Configuration Management/Views/ConnectionStringInputWindow.Avalonia.cs
@@ -7,6 +7,7 @@ using Avalonia.Input.Platform;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 using Configuration_Management.Services;
 
 namespace Configuration_Management
@@ -36,7 +37,14 @@ namespace Configuration_Management
 
             _dialogs = AppServices.GetRequiredService<IDialogService>();
 
-            _inputBox = new TextBox { Padding = new Thickness(8, 6), AcceptsReturn = true, MinHeight = 80 };
+            // Поле однострочное и во всю ширину, как в разметке
+            // (ConnectionStringInputWindow.xaml:44).
+            _inputBox = new TextBox
+            {
+                Padding = new Thickness(8, 6),
+                MinHeight = 34,
+                VerticalContentAlignment = VerticalAlignment.Center
+            };
             _inputBox.TextChanged += (_, _) => UpdateOkEnabled();
             _inputBox.KeyDown += OnInputBox_KeyDown;
 
@@ -48,55 +56,72 @@ namespace Configuration_Management
 
             var title = new TextBlock
             {
-                Text = LocalizationManager.T("ConnectionStringInput.Header"),
-                FontSize = 15,
-                FontWeight = FontWeight.SemiBold,
-                Margin = new Thickness(0, 0, 0, 8)
+                Text = LocalizationManager.T("ConnectionStringInput.Label"),
+                Margin = new Thickness(0, 0, 0, 6)
             };
             Grid.SetRow(title, 0);
             grid.Children.Add(title);
 
             var hint = new TextBlock
             {
-                Text = LocalizationManager.T("ConnectionStringInput.HintText"),
+                Text = LocalizationManager.T("ConnectionStringInput.Hint"),
                 TextWrapping = TextWrapping.Wrap,
-                FontSize = 12,
+                FontSize = 11,
                 Margin = new Thickness(0, 0, 0, 8)
             };
+            Themes.ThemeBrushes.Bind(hint, TextBlock.ForegroundProperty, "TextSecondaryBrush");
             Grid.SetRow(hint, 1);
             grid.Children.Add(hint);
 
-            var inputArea = new Grid();
-            inputArea.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-            inputArea.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-            Grid.SetColumn(_inputBox, 0);
-            _inputBox.HorizontalAlignment = HorizontalAlignment.Stretch;
-            inputArea.Children.Add(_inputBox);
+            Grid.SetRow(_inputBox, 2);
+            grid.Children.Add(_inputBox);
 
-            var pasteButton = new Button { Content = LocalizationManager.T("ConnectionStringInput.Paste"), MinWidth = 130, Margin = new Thickness(8, 0, 0, 0), VerticalAlignment = VerticalAlignment.Top };
+            // Нижняя строка: вставка из буфера слева, применение и отмена справа
+            // (ConnectionStringInputWindow.xaml:50).
+            var bottom = new Grid { Margin = new Thickness(0, 14, 0, 0) };
+            bottom.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+            bottom.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+            bottom.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+
+            var pasteCaption = new TextBlock
+            {
+                Text = LocalizationManager.T("ConnectionStringInput.Paste"),
+                FontSize = 12,
+                FontWeight = FontWeight.SemiBold,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            var pasteButton = new Button
+            {
+                Content = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6,
+                    Children = { IconHelper.MakeIcon("IconCopy", 15, "SecondaryButtonTextBrush"), pasteCaption }
+                },
+                Height = 38,
+                Padding = new Thickness(12, 0)
+            };
+            pasteButton.Styled(ControlThemes.SecondaryButton);
             ToolTip.SetTip(pasteButton, LocalizationManager.T("ConnectionStringInput.PasteTooltip"));
             pasteButton.Click += (_, _) => OnPasteClipboard_Click();
-            Grid.SetColumn(pasteButton, 1);
-            inputArea.Children.Add(pasteButton);
+            Grid.SetColumn(pasteButton, 0);
+            bottom.Children.Add(pasteButton);
 
-            Grid.SetRow(inputArea, 2);
-            grid.Children.Add(inputArea);
+            _okButton = BuildConfirmActionButton("Common.Apply", "IconCheck", 150, OnOk_Click, height: 38);
+            _okButton.Classes.Add("greyed");
 
             var buttons = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8,
-                Margin = new Thickness(0, 16, 0, 0)
+                Spacing = 10,
+                Children = { _okButton, BuildCancelActionButton(140, height: 38) }
             };
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 100, IsCancel = true };
-            cancel.Click += (_, _) => Close();
-            buttons.Children.Add(cancel);
-            _okButton = new Button { Content = LocalizationManager.T("Common.Apply"), MinWidth = 120, IsDefault = true };
-            _okButton.Click += (_, _) => OnOk_Click();
-            buttons.Children.Add(_okButton);
-            Grid.SetRow(buttons, 3);
-            grid.Children.Add(buttons);
+            Grid.SetColumn(buttons, 2);
+            bottom.Children.Add(buttons);
+
+            Grid.SetRow(bottom, 3);
+            grid.Children.Add(bottom);
 
             Content = grid;
             UpdateOkEnabled();
@@ -208,8 +233,6 @@ namespace Configuration_Management
         private void OnOk_Click()
         {
             Result = _inputBox.Text?.Trim();
-            DialogResult = true;
-            Close();
         }
 
         private void OnInputBox_KeyDown(object? sender, KeyEventArgs e)
@@ -217,6 +240,8 @@ namespace Configuration_Management
             if (e.Key == Key.Enter && _okButton.IsEnabled)
             {
                 OnOk_Click();
+                DialogResult = true;
+                Close();
                 e.Handled = true;
             }
         }

--- a/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
+++ b/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
@@ -368,26 +368,38 @@ namespace Configuration_Management
             {
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8,
+                Spacing = 10,
                 Margin = new Thickness(0, 16, 0, 0)
             };
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 100, IsCancel = true };
-            cancel.Click += (_, _) => Close();
-            buttons.Children.Add(cancel);
+            // Оформление и порядок по разметке (CreateInfobaseWindow.xaml:184):
+            // зелёное создание шириной 140 слева, красная отмена шириной 130 справа.
+            // Кнопка создания закрывает окно сама, только если проверки прошли,
+            // поэтому она собирается здесь, а не общим методом базового класса.
             var create = new Button
             {
-                Content = new TextBlock
+                Content = new StackPanel
                 {
-                    Text = LocalizationManager.T("CreateInfobase.Create"),
-                    Foreground = Brushes.White
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 8,
+                    Children =
+                    {
+                        IconHelper.MakeIcon("IconDatabase", 16, Brushes.White),
+                        new TextBlock
+                        {
+                            Text = LocalizationManager.T("CreateInfobase.Create"),
+                            VerticalAlignment = VerticalAlignment.Center
+                        }
+                    }
                 },
-                MinWidth = 120,
-                IsDefault = true,
-                Background = new SolidColorBrush(Color.Parse("#16A34A")),
-                Foreground = Brushes.White
+                Width = 140,
+                Height = 36,
+                IsDefault = true
             };
+            create.Styled(ControlThemes.DialogConfirmButton);
             create.Click += (_, _) => OnCreate_Click();
             buttons.Children.Add(create);
+            buttons.Children.Add(BuildCancelActionButton(130));
+
             Grid.SetRow(buttons, 5);
             grid.Children.Add(buttons);
 

--- a/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
+++ b/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
@@ -198,6 +198,8 @@ namespace Configuration_Management
             Grid.SetColumn(_groupPathBox, 1);
             groupRow.Children.Add(_groupPathBox);
             var pickGroup = new Button { Content = LocalizationManager.T("CreateInfobase.ChooseGroup"), MinWidth = 90, Margin = new Thickness(8, 0, 0, 0) };
+            pickGroup.Styled(ControlThemes.SecondaryButton);
+            pickGroup.Padding = new Thickness(10, 4);
             ToolTip.SetTip(pickGroup, LocalizationManager.T("CreateInfobase.ChooseGroupTooltip"));
             pickGroup.Click += (_, _) => OnPickGroup_Click();
             Grid.SetColumn(pickGroup, 2);
@@ -217,10 +219,14 @@ namespace Configuration_Management
             platRow.Children.Add(_platformBox);
             var platButtons = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6, Margin = new Thickness(8, 0, 0, 0) };
             var pickPlatform = new Button { Content = LocalizationManager.T("CreateInfobase.List"), MinWidth = 90 };
+            pickPlatform.Styled(ControlThemes.SecondaryButton);
+            pickPlatform.Padding = new Thickness(10, 4);
             ToolTip.SetTip(pickPlatform, LocalizationManager.T("CreateInfobase.ListTooltip"));
             pickPlatform.Click += (_, _) => OnPickPlatform_Click();
             platButtons.Children.Add(pickPlatform);
             var editPaths = new Button { Content = LocalizationManager.T("CreateInfobase.Paths"), MinWidth = 70 };
+            editPaths.Styled(ControlThemes.SecondaryButton);
+            editPaths.Padding = new Thickness(10, 4);
             ToolTip.SetTip(editPaths, LocalizationManager.T("CreateInfobase.PathsTooltip"));
             editPaths.Click += (_, _) => OnEditPlatformPaths_Click();
             platButtons.Children.Add(editPaths);
@@ -230,6 +236,8 @@ namespace Configuration_Management
 
             // Файловая база: путь к каталогу.
             var browseFile = new Button { Content = LocalizationManager.T("Common.Browse"), MinWidth = 90 };
+            browseFile.Styled(ControlThemes.SecondaryButton);
+            browseFile.Padding = new Thickness(10, 4);
             browseFile.Click += (_, _) => OnBrowseFolder_Click();
             var fileRow = new Grid();
             fileRow.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
@@ -340,10 +348,14 @@ namespace Configuration_Management
                 tplRow.Children.Add(_templateBox);
                 var tplButtons = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6, Margin = new Thickness(8, 0, 0, 0) };
                 var refreshTemplates = new Button { Content = LocalizationManager.T("CreateInfobase.Refresh"), MinWidth = 90 };
+                refreshTemplates.Styled(ControlThemes.SecondaryButton);
+                refreshTemplates.Padding = new Thickness(10, 4);
                 ToolTip.SetTip(refreshTemplates, LocalizationManager.T("CreateInfobase.RefreshTooltip"));
                 refreshTemplates.Click += (_, _) => LoadInstalledTemplates();
                 tplButtons.Children.Add(refreshTemplates);
                 var browseTemplate = new Button { Content = LocalizationManager.T("CreateInfobase.File"), MinWidth = 90 };
+                browseTemplate.Styled(ControlThemes.SecondaryButton);
+                browseTemplate.Padding = new Thickness(10, 4);
                 ToolTip.SetTip(browseTemplate, LocalizationManager.T("CreateInfobase.FileTooltip"));
                 browseTemplate.Click += (_, _) => OnBrowseTemplate_Click();
                 tplButtons.Children.Add(browseTemplate);
@@ -375,27 +387,25 @@ namespace Configuration_Management
             // зелёное создание шириной 140 слева, красная отмена шириной 130 справа.
             // Кнопка создания закрывает окно сама, только если проверки прошли,
             // поэтому она собирается здесь, а не общим методом базового класса.
+            var createCaption = new TextBlock
+            {
+                Text = LocalizationManager.T("CreateInfobase.Create"),
+                VerticalAlignment = VerticalAlignment.Center
+            };
             var create = new Button
             {
                 Content = new StackPanel
                 {
                     Orientation = Orientation.Horizontal,
                     Spacing = 8,
-                    Children =
-                    {
-                        IconHelper.MakeIcon("IconDatabase", 16, Brushes.White),
-                        new TextBlock
-                        {
-                            Text = LocalizationManager.T("CreateInfobase.Create"),
-                            VerticalAlignment = VerticalAlignment.Center
-                        }
-                    }
+                    Children = { IconHelper.MakeIcon("IconDatabase", 16, Brushes.White), createCaption }
                 },
                 Width = 140,
                 Height = 36,
                 IsDefault = true
             };
             create.Styled(ControlThemes.DialogConfirmButton);
+            RegisterConfirmCaption(createCaption, "CreateInfobase.Create");
             create.Click += (_, _) => OnCreate_Click();
             buttons.Children.Add(create);
             buttons.Children.Add(BuildCancelActionButton(130));

--- a/Configuration Management/Views/GroupEditWindow.Avalonia.cs
+++ b/Configuration Management/Views/GroupEditWindow.Avalonia.cs
@@ -151,8 +151,10 @@ namespace Configuration_Management
 
         private Control BuildRoot()
         {
-            var grid = new Grid { Margin = new Thickness(16) };
-            grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+            // Раскладка по разметке (GroupEditWindow.xaml:154): вкладки тянутся
+            // на всю высоту, кнопки прижаты к низу отдельной полосой с отбивкой.
+            var grid = new Grid();
+            grid.RowDefinitions.Add(new RowDefinition(new GridLength(1, GridUnitType.Star)));
             grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
 
             var tabs = new TabControl();
@@ -231,12 +233,35 @@ namespace Configuration_Management
             iconTab.Children.Add(iconScroll);
             tabs.Items.Add(new TabItem { Header = LocalizationManager.T("GroupEdit.TabIcon"), Content = iconTab });
 
+            tabs.Margin = new Thickness(16, 16, 16, 0);
             Grid.SetRow(tabs, 0);
             grid.Children.Add(tabs);
 
-            var buttons = BuildButtons(LocalizationManager.T("Common.Save"), 140, OnSave_Click);
-            Grid.SetRow(buttons, 1);
-            grid.Children.Add(buttons);
+            // Нижняя панель по разметке (GroupEditWindow.xaml:293): зелёное
+            // сохранение шириной 130 слева, красная отмена шириной 120 справа.
+            // Значок отмены в разметке взят из ключа IconClear, у нас тот же
+            // контур лежит под именем IconClose.
+            var buttons = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Spacing = 10,
+                Children =
+                {
+                    BuildConfirmActionButton("Common.Save", "IconSave", 130, OnSave_Click),
+                    BuildCancelActionButton(120, iconSize: 14)
+                }
+            };
+            var buttonsBar = new Border
+            {
+                Padding = new Thickness(16, 10, 16, 16),
+                BorderThickness = new Thickness(0, 1, 0, 0),
+                Child = buttons
+            };
+            Themes.ThemeBrushes.Bind(buttonsBar, Border.BorderBrushProperty, "BorderBrushColor");
+            Themes.ThemeBrushes.Bind(buttonsBar, Border.BackgroundProperty, "CardBackgroundBrush");
+            Grid.SetRow(buttonsBar, 1);
+            grid.Children.Add(buttonsBar);
 
             return grid;
         }

--- a/Configuration Management/Views/GroupEditWindow.Avalonia.cs
+++ b/Configuration Management/Views/GroupEditWindow.Avalonia.cs
@@ -10,6 +10,7 @@ using Avalonia.Media;
 using Path = Avalonia.Controls.Shapes.Path;
 using Configuration_Management.Controls;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 using Configuration_Management.Models;
 using Configuration_Management.ViewModels;
 
@@ -188,7 +189,14 @@ namespace Configuration_Management
                 Margin = new Thickness(8, 0, 0, 0),
                 VerticalAlignment = VerticalAlignment.Center
             };
-            var selectParent = new Button { Content = LocalizationManager.T("GroupEdit.SelectParent"), MinWidth = 90 };
+            var selectParent = new Button
+            {
+                Content = IconHelper.IconAndText("IconFolder", LocalizationManager.T("GroupEdit.SelectParent"), 14,
+                    "SecondaryButtonTextBrush"),
+                MinWidth = 90,
+                Padding = new Thickness(10, 4)
+            };
+            selectParent.Styled(Themes.ControlThemes.SecondaryButton);
             selectParent.IsEnabled = !_noGroupMode;
             selectParent.Click += (_, _) => OnSelectParent_Click();
             ToolTip.SetTip(selectParent, LocalizationManager.T("GroupEdit.SelectParentTooltip"));
@@ -248,8 +256,8 @@ namespace Configuration_Management
                 Spacing = 10,
                 Children =
                 {
-                    BuildConfirmActionButton("Common.Save", "IconSave", 130, OnSave_Click),
-                    BuildCancelActionButton(120, iconSize: 14)
+                    BuildConfirmActionButton("Common.Save", "IconSave", 130, OnSave_Click, iconGap: 8),
+                    BuildCancelActionButton(120, iconSize: 14, iconGap: 8)
                 }
             };
             var buttonsBar = new Border

--- a/Configuration Management/Views/GroupSettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/GroupSettingsWindow.Avalonia.cs
@@ -10,6 +10,7 @@ using Avalonia.Controls.Templates;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 using Configuration_Management.Models;
 using Configuration_Management.Services;
 using Configuration_Management.ViewModels;
@@ -26,7 +27,7 @@ namespace Configuration_Management
         private readonly ObservableCollection<Group> _groups;
         private readonly IDialogService _dialogs;
         private readonly TreeView _tree = new();
-        private readonly Button _doneButton = new() { Content = LocalizationManager.T("GroupSettings.Done"), MinWidth = 110, IsDefault = true };
+        private readonly Button _doneButton = new() { IsDefault = true };
 
         /// <summary>
         /// Создаёт диалог управления группами.
@@ -99,22 +100,48 @@ namespace Configuration_Management
             Grid.SetRow(treeBorder, 1);
             grid.Children.Add(treeBorder);
 
-            // Кнопки управления
+            // Кнопки управления по разметке (GroupSettingsWindow.xaml:67):
+            // добавление корневой группы основной кнопкой, остальные вторичными,
+            // все шириной 120.
             var actions = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 12, 0, 0), Spacing = 8 };
-            actions.Children.Add(MakeButton(LocalizationManager.T("GroupSettings.AddRoot"), "IconAdd", OnAddRoot_Click));
-            actions.Children.Add(MakeButton(LocalizationManager.T("GroupSettings.AddSubgroup"), "IconAdd", OnAddSubgroup_Click));
-            actions.Children.Add(MakeButton(LocalizationManager.T("Common.Edit"), "IconEdit", OnEdit_Click));
-            actions.Children.Add(MakeButton(LocalizationManager.T("Common.Delete"), "IconDelete", OnDelete_Click));
+            actions.Children.Add(MakeButton(LocalizationManager.T("Common.Add"), "IconAdd", OnAddRoot_Click, ControlThemes.ModernButton));
+            actions.Children.Add(MakeButton(LocalizationManager.T("GroupSettings.AddSubgroup"), "IconAdd", OnAddSubgroup_Click, ControlThemes.SecondaryButton));
+            actions.Children.Add(MakeButton(LocalizationManager.T("Common.Edit"), "IconEdit", OnEdit_Click, ControlThemes.SecondaryButton));
+            actions.Children.Add(MakeButton(LocalizationManager.T("Common.Delete"), "IconDelete", OnDelete_Click, ControlThemes.SecondaryButton));
             Grid.SetRow(actions, 2);
             grid.Children.Add(actions);
 
             // Нижняя панель
-            var bottom = new Grid { Margin = new Thickness(0, 12, 0, 0) };
-            bottom.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-            bottom.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+            // Нижняя панель по разметке (GroupSettingsWindow.xaml:101): готово
+            // основной кнопкой, отмена вторичной, обе 120 на 34, зазор 10.
+            var doneCaption = new TextBlock
+            {
+                Text = LocalizationManager.T("GroupSettings.Done"),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            _doneButton.Content = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 6,
+                Children = { IconHelper.MakeIcon("IconOk", 14, "ButtonTextBrush"), doneCaption }
+            };
+            _doneButton.Styled(ControlThemes.ModernButton);
+            _doneButton.Width = 120;
+            _doneButton.Height = 34;
             _doneButton.Click += (_, _) => { DialogResult = true; Close(); };
-            Grid.SetColumn(_doneButton, 1);
-            bottom.Children.Add(_doneButton);
+            RegisterConfirmCaption(doneCaption, "GroupSettings.Done");
+
+            var cancel = BuildCancelButton(120, secondary: true);
+            cancel.Height = 34;
+
+            var bottom = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Spacing = 10,
+                Margin = new Thickness(0, 12, 0, 0),
+                Children = { _doneButton, cancel }
+            };
             Grid.SetRow(bottom, 3);
             grid.Children.Add(bottom);
 
@@ -123,9 +150,17 @@ namespace Configuration_Management
             return grid;
         }
 
-        private Button MakeButton(string text, string iconKey, Action onClick)
+        private Button MakeButton(string text, string iconKey, Action onClick, string themeKey)
         {
-            var button = new Button { Content = IconHelper.IconAndText(iconKey, text) };
+            // Значок красится под тему кнопки: у основной подпись и значок идут
+            // цветом текста на акценте, у вторичной своим.
+            var button = new Button
+            {
+                Content = IconHelper.IconAndText(iconKey, text, 16,
+                    themeKey == ControlThemes.ModernButton ? "ButtonTextBrush" : "SecondaryButtonTextBrush"),
+                Width = 120
+            };
+            button.Styled(themeKey);
             button.Click += (_, _) => onClick();
             return button;
         }

--- a/Configuration Management/Views/LaunchParametersWindow.Avalonia.cs
+++ b/Configuration Management/Views/LaunchParametersWindow.Avalonia.cs
@@ -202,6 +202,7 @@ namespace Configuration_Management
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
                 Spacing = 10,
+                Margin = new Thickness(0, 8, 0, 0),
                 Children =
                 {
                     BuildConfirmActionButton("Common.Ok", "IconCheck", 140, OnOk_Click),

--- a/Configuration Management/Views/LaunchParametersWindow.Avalonia.cs
+++ b/Configuration Management/Views/LaunchParametersWindow.Avalonia.cs
@@ -196,18 +196,18 @@ namespace Configuration_Management
             grid.Children.Add(listBorder);
 
             // Кнопки
+            // Оформление и порядок по разметке (LaunchParametersWindow.xaml:77).
             var buttons = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8
+                Spacing = 10,
+                Children =
+                {
+                    BuildConfirmActionButton("Common.Ok", "IconCheck", 140, OnOk_Click),
+                    BuildCancelActionButton(140)
+                }
             };
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 100, IsCancel = true };
-            cancel.Click += (_, _) => Close();
-            buttons.Children.Add(cancel);
-            var ok = new Button { Content = LocalizationManager.T("Common.Ok"), MinWidth = 110, IsDefault = true };
-            ok.Click += (_, _) => OnOk_Click();
-            buttons.Children.Add(ok);
             Grid.SetRow(buttons, 6);
             grid.Children.Add(buttons);
 
@@ -235,8 +235,6 @@ namespace Configuration_Management
         private void OnOk_Click()
         {
             Result = (_txtCustom.Text ?? string.Empty).Trim();
-            DialogResult = true;
-            Close();
         }
 
         /// <summary>Строит каталог ключей командной строки 1С для справочника.</summary>

--- a/Configuration Management/Views/LinkInputWindow.axaml
+++ b/Configuration Management/Views/LinkInputWindow.axaml
@@ -27,22 +27,33 @@
                        Foreground="{DynamicResource TextSecondaryBrush}"/>
         </StackPanel>
 
+        <!-- Порядок, размеры и цвета по разметке WPF (LinkInputWindow.xaml:50):
+             зелёный переход слева, красная отмена справа, зазор 10. -->
         <StackPanel Grid.Row="2" Orientation="Horizontal"
-                    HorizontalAlignment="Right" Spacing="8" Margin="0,16,0,0">
-            <Button x:Name="CancelButton" MinWidth="110" IsCancel="True">
+                    HorizontalAlignment="Right" Spacing="10" Margin="0,16,0,0">
+            <Button x:Name="OkButton" Width="150" Height="38" IsDefault="True"
+                    Classes="greyed"
+                    Theme="{DynamicResource DialogConfirmButton}">
                 <StackPanel Orientation="Horizontal" Spacing="6">
-                    <Path Data="{DynamicResource IconClose}" Width="14" Height="14"
-                          Stretch="Uniform" Fill="{DynamicResource TextPrimaryBrush}"
-                          VerticalAlignment="Center"/>
-                    <TextBlock Text="{loc:Loc Common.Cancel}" VerticalAlignment="Center"/>
+                    <!-- Контур кладётся в холст 24 на 24 и масштабируется целиком,
+                         как это делает IconHelper.MakeIcon и PackIcon в WPF. -->
+                    <Viewbox Width="16" Height="16" Stretch="Uniform" VerticalAlignment="Center">
+                        <Canvas Width="24" Height="24">
+                            <Path Data="{DynamicResource IconArrowRight}" Fill="White"/>
+                        </Canvas>
+                    </Viewbox>
+                    <TextBlock Text="{loc:Loc LinkInput.Go}" VerticalAlignment="Center"/>
                 </StackPanel>
             </Button>
-            <Button x:Name="OkButton" MinWidth="130" IsDefault="True">
+            <Button x:Name="CancelButton" Width="140" Height="38" IsCancel="True"
+                    Theme="{DynamicResource DialogCancelButton}">
                 <StackPanel Orientation="Horizontal" Spacing="6">
-                    <Path Data="{DynamicResource IconOk}" Width="14" Height="14"
-                          Stretch="Uniform" Fill="{DynamicResource TextPrimaryBrush}"
-                          VerticalAlignment="Center"/>
-                    <TextBlock Text="{loc:Loc LinkInput.Go}" VerticalAlignment="Center"/>
+                    <Viewbox Width="16" Height="16" Stretch="Uniform" VerticalAlignment="Center">
+                        <Canvas Width="24" Height="24">
+                            <Path Data="{DynamicResource IconClose}" Fill="#EF4444"/>
+                        </Canvas>
+                    </Viewbox>
+                    <TextBlock Text="{loc:Loc Common.Cancel}" VerticalAlignment="Center"/>
                 </StackPanel>
             </Button>
         </StackPanel>

--- a/Configuration Management/Views/LinkInputWindow.axaml
+++ b/Configuration Management/Views/LinkInputWindow.axaml
@@ -12,24 +12,27 @@
                        SizeToContent="Height"
                        CanResize="False"
                        SystemDecorations="Full">
-    <Grid Margin="16" RowDefinitions="Auto,Auto,Auto">
+    <Grid Margin="16" RowDefinitions="Auto,Auto,Auto,Auto">
 
+        <!-- Порядок по разметке (LinkInputWindow.xaml:35): подпись, примеры
+             допустимых ссылок, затем поле ввода. -->
         <TextBlock Grid.Row="0"
                    Text="{loc:Loc LinkInput.Label}"
                    TextWrapping="Wrap"
-                   Margin="0,0,0,8"/>
+                   Margin="0,0,0,6"/>
 
-        <StackPanel Grid.Row="1" Spacing="4">
-            <TextBox x:Name="LinkBox" Padding="8,6"/>
-            <!-- Примеры допустимых ссылок, как под полем в разметке WPF. -->
-            <TextBlock Text="{loc:Loc LinkInput.Hint}" FontSize="11"
-                       TextWrapping="Wrap"
-                       Foreground="{DynamicResource TextSecondaryBrush}"/>
-        </StackPanel>
+        <TextBlock Grid.Row="1"
+                   Text="{loc:Loc LinkInput.Hint}"
+                   FontSize="11"
+                   TextWrapping="Wrap"
+                   Margin="0,0,0,8"
+                   Foreground="{DynamicResource TextSecondaryBrush}"/>
+
+        <TextBox Grid.Row="2" x:Name="LinkBox" Padding="8,6"/>
 
         <!-- Порядок, размеры и цвета по разметке WPF (LinkInputWindow.xaml:50):
              зелёный переход слева, красная отмена справа, зазор 10. -->
-        <StackPanel Grid.Row="2" Orientation="Horizontal"
+        <StackPanel Grid.Row="3" Orientation="Horizontal"
                     HorizontalAlignment="Right" Spacing="10" Margin="0,16,0,0">
             <Button x:Name="OkButton" Width="150" Height="38" IsDefault="True"
                     Classes="greyed"

--- a/Configuration Management/Views/LoginWindow.Avalonia.cs
+++ b/Configuration Management/Views/LoginWindow.Avalonia.cs
@@ -160,26 +160,24 @@ namespace Configuration_Management
             var cancel = BuildCancelButton(110);
             panel.Children.Add(cancel);
 
+            var loginCaption = new TextBlock
+            {
+                Text = LocalizationManager.T("Auth.Login"),
+                VerticalAlignment = VerticalAlignment.Center
+            };
             var login = new Button
             {
                 Content = new StackPanel
                 {
                     Orientation = Orientation.Horizontal,
                     Spacing = 6,
-                    Children =
-                    {
-                        IconHelper.MakeIcon("IconOk", 14, "ButtonTextBrush"),
-                        new TextBlock
-                        {
-                            Text = LocalizationManager.T("Auth.Login"),
-                            VerticalAlignment = VerticalAlignment.Center
-                        }
-                    }
+                    Children = { IconHelper.MakeIcon("IconOk", 14, "ButtonTextBrush"), loginCaption }
                 },
                 Width = 130,
                 IsDefault = true
             };
             login.Styled(ControlThemes.ModernButton);
+            RegisterConfirmCaption(loginCaption, "Auth.Login");
             login.Click += (_, _) => TryLogin();
             panel.Children.Add(login);
 

--- a/Configuration Management/Views/LoginWindow.Avalonia.cs
+++ b/Configuration Management/Views/LoginWindow.Avalonia.cs
@@ -8,6 +8,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Controls;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 using Configuration_Management.Models;
 using Configuration_Management.Services;
 
@@ -154,11 +155,31 @@ namespace Configuration_Management
                 Spacing = 8
             };
 
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 110 };
-            cancel.Click += (_, _) => Close();
+            // Оформление по разметке (LoginWindow.xaml:62): обе кнопки в стиле
+            // основной, у отмены заливка мягкая, у входа акцентная.
+            var cancel = BuildCancelButton(110);
             panel.Children.Add(cancel);
 
-            var login = new Button { Content = LocalizationManager.T("Auth.Login"), MinWidth = 130 };
+            var login = new Button
+            {
+                Content = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6,
+                    Children =
+                    {
+                        IconHelper.MakeIcon("IconOk", 14, "ButtonTextBrush"),
+                        new TextBlock
+                        {
+                            Text = LocalizationManager.T("Auth.Login"),
+                            VerticalAlignment = VerticalAlignment.Center
+                        }
+                    }
+                },
+                Width = 130,
+                IsDefault = true
+            };
+            login.Styled(ControlThemes.ModernButton);
             login.Click += (_, _) => TryLogin();
             panel.Children.Add(login);
 

--- a/Configuration Management/Views/ModalWindowBase.cs
+++ b/Configuration Management/Views/ModalWindowBase.cs
@@ -23,8 +23,10 @@ namespace Configuration_Management
         /// <summary>
         /// Задаёт окну фон темы. В разметке WPF его ставит каждое окно
         /// (<c>Background="{DynamicResource ContentBackgroundBrush}"</c>),
-        /// здесь это одно место на все диалоги. Окно, которому нужен свой фон,
-        /// присваивает его после базового конструктора, и его значение старше.
+        /// здесь это одно место на все диалоги. Окну, которому нужен свой фон,
+        /// присвоения мало: привязка держит то же местное значение и вернёт своё
+        /// при следующей смене темы или схемы, поэтому её надо снимать
+        /// (<c>ClearValue(BackgroundProperty)</c>) до присвоения.
         /// </summary>
         protected ModalWindowBase()
         {
@@ -139,8 +141,12 @@ namespace Configuration_Management
         /// <param name="onOk">Что выполнить перед закрытием с положительным результатом.</param>
         /// <param name="cancelWidth">Ширина кнопки отмены.</param>
         /// <param name="okIconKey">Ключ значка кнопки подтверждения.</param>
+        /// <param name="okTextKey">
+        /// Ключ подписи подтверждения вместо готовой строки: только так подпись
+        /// переводится при смене языка.
+        /// </param>
         protected StackPanel BuildButtons(string? okText = null, double okWidth = 130, Action? onOk = null,
-            double cancelWidth = 110, string okIconKey = "IconOk")
+            double cancelWidth = 110, string okIconKey = "IconOk", string? okTextKey = null)
         {
             var panel = new StackPanel
             {
@@ -150,7 +156,7 @@ namespace Configuration_Management
             };
 
             panel.Children.Add(BuildCancelButton(cancelWidth));
-            panel.Children.Add(BuildConfirmButton(okText, okWidth, onOk, okIconKey: okIconKey));
+            panel.Children.Add(BuildConfirmButton(okText, okWidth, onOk, okIconKey: okIconKey, okTextKey: okTextKey));
             return panel;
         }
 
@@ -209,12 +215,15 @@ namespace Configuration_Management
         /// <param name="onOk">Что выполнить перед закрытием.</param>
         /// <param name="minimumWidth">Ширина задаётся как минимальная, а не жёсткая.</param>
         /// <param name="okIconKey">Ключ значка.</param>
+        /// <param name="okTextKey">Ключ подписи вместо готовой строки.</param>
         protected Button BuildConfirmButton(string? okText, double width = 130, Action? onOk = null,
-            bool minimumWidth = false, string okIconKey = "IconOk")
+            bool minimumWidth = false, string okIconKey = "IconOk", string? okTextKey = null)
         {
             var caption = new TextBlock
             {
-                Text = ResolveOkText(okText),
+                Text = okTextKey is { Length: > 0 } captionKey
+                    ? LocalizationManager.T(captionKey)
+                    : ResolveOkText(okText),
                 VerticalAlignment = VerticalAlignment.Center
             };
 
@@ -244,14 +253,14 @@ namespace Configuration_Management
 
             _lastOkText = caption;
             _lastOkRaw = okText ?? "";
-            _lastOkKey = null;
+            _lastOkKey = okTextKey;
             EnsureLanguageSubscription();
             return button;
         }
 
         /// <summary>
         /// Кнопка подтверждения нижней панели диалога: зелёная заливка, белые
-        /// значок и подпись. Так эта кнопка задана в разметке WPF у девяти окон.
+        /// значок и подпись. Так эта кнопка задана в разметке WPF у десяти окон.
         /// </summary>
         /// <param name="textKey">Ключ локализации подписи.</param>
         /// <param name="iconKey">Ключ значка.</param>
@@ -259,8 +268,14 @@ namespace Configuration_Management
         /// <param name="onOk">Что выполнить перед закрытием с положительным результатом.</param>
         /// <param name="height">Высота кнопки.</param>
         /// <param name="iconSize">Размер значка.</param>
+        /// <param name="iconGap">Зазор между значком и подписью.</param>
+        /// <param name="closeOnClick">
+        /// Закрывать окно по нажатию. Ложь нужна окнам, где кнопка сначала
+        /// проверяет введённое и закрывает окно сама.
+        /// </param>
         protected Button BuildConfirmActionButton(string textKey, string iconKey, double width,
-            Action? onOk = null, double height = 36, double iconSize = 16)
+            Action? onOk = null, double height = 36, double iconSize = 16, double iconGap = 6,
+            bool closeOnClick = true)
         {
             var caption = new TextBlock
             {
@@ -273,7 +288,7 @@ namespace Configuration_Management
                 Content = new StackPanel
                 {
                     Orientation = Orientation.Horizontal,
-                    Spacing = 6,
+                    Spacing = iconGap,
                     Children =
                     {
                         IconHelper.MakeIcon(iconKey, iconSize, Brushes.White),
@@ -286,12 +301,19 @@ namespace Configuration_Management
             };
 
             button.Styled(ControlThemes.DialogConfirmButton);
-            button.Click += (_, _) =>
+            if (closeOnClick)
             {
-                onOk?.Invoke();
-                DialogResult = true;
-                Close();
-            };
+                button.Click += (_, _) =>
+                {
+                    onOk?.Invoke();
+                    DialogResult = true;
+                    Close();
+                };
+            }
+            else if (onOk is not null)
+            {
+                button.Click += (_, _) => onOk();
+            }
 
             _lastOkText = caption;
             _lastOkKey = textKey;
@@ -306,7 +328,9 @@ namespace Configuration_Management
         /// <param name="width">Ширина кнопки.</param>
         /// <param name="height">Высота кнопки.</param>
         /// <param name="iconSize">Размер значка.</param>
-        protected Button BuildCancelActionButton(double width = 140, double height = 36, double iconSize = 16)
+        /// <param name="iconGap">Зазор между значком и подписью.</param>
+        protected Button BuildCancelActionButton(double width = 140, double height = 36,
+            double iconSize = 16, double iconGap = 6)
         {
             var caption = new TextBlock
             {
@@ -319,7 +343,7 @@ namespace Configuration_Management
                 Content = new StackPanel
                 {
                     Orientation = Orientation.Horizontal,
-                    Spacing = 6,
+                    Spacing = iconGap,
                     Children =
                     {
                         IconHelper.MakeIcon("IconClose", iconSize, DangerBrush),
@@ -341,6 +365,20 @@ namespace Configuration_Management
 
         /// <summary>Красный цвет отмены и удаления: в разметке WPF он задан числом.</summary>
         protected static readonly IBrush DangerBrush = new SolidColorBrush(Color.Parse("#EF4444"));
+
+        /// <summary>
+        /// Берёт на себя перевод подписи кнопки, которую окно собрало само.
+        /// Без этого при смене языка переводится только «Отмена», и панель
+        /// остаётся двуязычной.
+        /// </summary>
+        /// <param name="caption">Подпись кнопки подтверждения.</param>
+        /// <param name="textKey">Ключ локализации этой подписи.</param>
+        protected void RegisterConfirmCaption(TextBlock caption, string textKey)
+        {
+            _lastOkText = caption;
+            _lastOkKey = textKey;
+            EnsureLanguageSubscription();
+        }
 
         private static void SetButtonWidth(Button button, double width, bool minimumWidth)
         {

--- a/Configuration Management/Views/ModalWindowBase.cs
+++ b/Configuration Management/Views/ModalWindowBase.cs
@@ -4,8 +4,10 @@ using System.Threading;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Avalonia.Threading;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 
 namespace Configuration_Management
 {
@@ -19,6 +21,17 @@ namespace Configuration_Management
     public abstract class ModalWindowBase : Window
     {
         /// <summary>
+        /// Задаёт окну фон темы. В разметке WPF его ставит каждое окно
+        /// (<c>Background="{DynamicResource ContentBackgroundBrush}"</c>),
+        /// здесь это одно место на все диалоги. Окно, которому нужен свой фон,
+        /// присваивает его после базового конструктора, и его значение старше.
+        /// </summary>
+        protected ModalWindowBase()
+        {
+            Themes.ThemeBrushes.Bind(this, BackgroundProperty, "ContentBackgroundBrush");
+        }
+
+        /// <summary>
         /// Источник локализации для привязок XAML: <c>{Binding Loc[Key]}</c>.
         /// При смене языка открытые окна автоматически обновляют текст.
         /// </summary>
@@ -28,6 +41,9 @@ namespace Configuration_Management
         private TextBlock? _lastCancelText;
         private TextBlock? _lastOkText;
         private string _lastOkRaw = "";
+        // Ключ подписи подтверждения, когда кнопку строили по ключу, а не по
+        // готовой строке: только так подпись переводится при смене языка.
+        private string? _lastOkKey;
         private bool _languageSubscribed;
 
         /// <summary>Результат диалога: true — подтверждён (ОК), false — отменён.</summary>
@@ -114,7 +130,17 @@ namespace Configuration_Management
             return mark;
         }
 
-        protected StackPanel BuildButtons(string? okText = null, double okWidth = 130, Action? onOk = null)
+        /// <summary>
+        /// Строит правую панель кнопок «Отмена» и подтверждение, как в разметке WPF:
+        /// отмена мягкой заливкой, подтверждение акцентом, зазор 8.
+        /// </summary>
+        /// <param name="okText">Подпись кнопки подтверждения; пусто означает «ОК».</param>
+        /// <param name="okWidth">Ширина кнопки подтверждения.</param>
+        /// <param name="onOk">Что выполнить перед закрытием с положительным результатом.</param>
+        /// <param name="cancelWidth">Ширина кнопки отмены.</param>
+        /// <param name="okIconKey">Ключ значка кнопки подтверждения.</param>
+        protected StackPanel BuildButtons(string? okText = null, double okWidth = 130, Action? onOk = null,
+            double cancelWidth = 110, string okIconKey = "IconOk")
         {
             var panel = new StackPanel
             {
@@ -123,10 +149,28 @@ namespace Configuration_Management
                 Spacing = 8
             };
 
-            var cancelText = new TextBlock { Text = LocalizationManager.T("Common.Cancel"), VerticalAlignment = VerticalAlignment.Center };
-            var okTextBlock = new TextBlock { Text = ResolveOkText(okText), VerticalAlignment = VerticalAlignment.Center };
+            panel.Children.Add(BuildCancelButton(cancelWidth));
+            panel.Children.Add(BuildConfirmButton(okText, okWidth, onOk, okIconKey: okIconKey));
+            return panel;
+        }
 
-            var cancel = new Button
+        /// <summary>
+        /// Кнопка отмены. По умолчанию это основная кнопка с мягкой заливкой и
+        /// основным цветом текста, как её задаёт разметка WPF в диалогах ввода;
+        /// <paramref name="secondary"/> переключает её на стиль вторичной кнопки.
+        /// </summary>
+        /// <param name="width">Ширина кнопки.</param>
+        /// <param name="secondary">Оформлять стилем вторичной кнопки.</param>
+        /// <param name="minimumWidth">Ширина задаётся как минимальная, а не жёсткая.</param>
+        protected Button BuildCancelButton(double width = 110, bool secondary = false, bool minimumWidth = false)
+        {
+            var caption = new TextBlock
+            {
+                Text = LocalizationManager.T("Common.Cancel"),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            var button = new Button
             {
                 Content = new StackPanel
                 {
@@ -134,17 +178,47 @@ namespace Configuration_Management
                     Spacing = 6,
                     Children =
                     {
-                        IconHelper.MakeIcon("IconClose", 14),
-                        cancelText
+                        IconHelper.MakeIcon("IconClose", 14, secondary ? "SecondaryButtonTextBrush" : "TextPrimaryBrush"),
+                        caption
                     }
                 },
-                MinWidth = 110,
                 IsCancel = true
             };
-            cancel.Click += (_, _) => Close();
-            panel.Children.Add(cancel);
 
-            var ok = new Button
+            button.Styled(secondary ? ControlThemes.SecondaryButton : ControlThemes.ModernButton);
+            if (!secondary)
+            {
+                Themes.ThemeBrushes.Bind(button, BackgroundProperty, "ItemHoverBrush");
+                Themes.ThemeBrushes.Bind(button, ForegroundProperty, "TextPrimaryBrush");
+            }
+
+            SetButtonWidth(button, width, minimumWidth);
+            button.Click += (_, _) => Close();
+
+            _lastCancelText = caption;
+            EnsureLanguageSubscription();
+            return button;
+        }
+
+        /// <summary>
+        /// Кнопка подтверждения: акцентная заливка, значок и подпись, закрытие
+        /// с положительным результатом.
+        /// </summary>
+        /// <param name="okText">Подпись; пусто означает «ОК».</param>
+        /// <param name="width">Ширина кнопки.</param>
+        /// <param name="onOk">Что выполнить перед закрытием.</param>
+        /// <param name="minimumWidth">Ширина задаётся как минимальная, а не жёсткая.</param>
+        /// <param name="okIconKey">Ключ значка.</param>
+        protected Button BuildConfirmButton(string? okText, double width = 130, Action? onOk = null,
+            bool minimumWidth = false, string okIconKey = "IconOk")
+        {
+            var caption = new TextBlock
+            {
+                Text = ResolveOkText(okText),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            var button = new Button
             {
                 Content = new StackPanel
                 {
@@ -152,28 +226,128 @@ namespace Configuration_Management
                     Spacing = 6,
                     Children =
                     {
-                        IconHelper.MakeIcon("IconOk", 14),
-                        okTextBlock
+                        IconHelper.MakeIcon(okIconKey, 14, "ButtonTextBrush"),
+                        caption
                     }
                 },
-                MinWidth = okWidth,
                 IsDefault = true
             };
-            ok.Click += (_, _) =>
+
+            button.Styled(ControlThemes.ModernButton);
+            SetButtonWidth(button, width, minimumWidth);
+            button.Click += (_, _) =>
             {
                 onOk?.Invoke();
                 DialogResult = true;
                 Close();
             };
-            panel.Children.Add(ok);
 
-            // Живое обновление кнопок при смене языка.
-            _lastCancelText = cancelText;
-            _lastOkText = okTextBlock;
+            _lastOkText = caption;
             _lastOkRaw = okText ?? "";
+            _lastOkKey = null;
             EnsureLanguageSubscription();
+            return button;
+        }
 
-            return panel;
+        /// <summary>
+        /// Кнопка подтверждения нижней панели диалога: зелёная заливка, белые
+        /// значок и подпись. Так эта кнопка задана в разметке WPF у девяти окон.
+        /// </summary>
+        /// <param name="textKey">Ключ локализации подписи.</param>
+        /// <param name="iconKey">Ключ значка.</param>
+        /// <param name="width">Ширина кнопки.</param>
+        /// <param name="onOk">Что выполнить перед закрытием с положительным результатом.</param>
+        /// <param name="height">Высота кнопки.</param>
+        /// <param name="iconSize">Размер значка.</param>
+        protected Button BuildConfirmActionButton(string textKey, string iconKey, double width,
+            Action? onOk = null, double height = 36, double iconSize = 16)
+        {
+            var caption = new TextBlock
+            {
+                Text = LocalizationManager.T(textKey),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            var button = new Button
+            {
+                Content = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6,
+                    Children =
+                    {
+                        IconHelper.MakeIcon(iconKey, iconSize, Brushes.White),
+                        caption
+                    }
+                },
+                Width = width,
+                Height = height,
+                IsDefault = true
+            };
+
+            button.Styled(ControlThemes.DialogConfirmButton);
+            button.Click += (_, _) =>
+            {
+                onOk?.Invoke();
+                DialogResult = true;
+                Close();
+            };
+
+            _lastOkText = caption;
+            _lastOkKey = textKey;
+            EnsureLanguageSubscription();
+            return button;
+        }
+
+        /// <summary>
+        /// Кнопка отмены нижней панели диалога: прозрачная заливка, красный контур,
+        /// красные значок и подпись, как в разметке WPF.
+        /// </summary>
+        /// <param name="width">Ширина кнопки.</param>
+        /// <param name="height">Высота кнопки.</param>
+        /// <param name="iconSize">Размер значка.</param>
+        protected Button BuildCancelActionButton(double width = 140, double height = 36, double iconSize = 16)
+        {
+            var caption = new TextBlock
+            {
+                Text = LocalizationManager.T("Common.Cancel"),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            var button = new Button
+            {
+                Content = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6,
+                    Children =
+                    {
+                        IconHelper.MakeIcon("IconClose", iconSize, DangerBrush),
+                        caption
+                    }
+                },
+                Width = width,
+                Height = height,
+                IsCancel = true
+            };
+
+            button.Styled(ControlThemes.DialogCancelButton);
+            button.Click += (_, _) => Close();
+
+            _lastCancelText = caption;
+            EnsureLanguageSubscription();
+            return button;
+        }
+
+        /// <summary>Красный цвет отмены и удаления: в разметке WPF он задан числом.</summary>
+        protected static readonly IBrush DangerBrush = new SolidColorBrush(Color.Parse("#EF4444"));
+
+        private static void SetButtonWidth(Button button, double width, bool minimumWidth)
+        {
+            if (minimumWidth)
+                button.MinWidth = width;
+            else
+                button.Width = width;
         }
 
         /// <summary>
@@ -201,7 +375,9 @@ namespace Configuration_Management
             if (_lastCancelText is not null)
                 _lastCancelText.Text = LocalizationManager.T("Common.Cancel");
             if (_lastOkText is not null)
-                _lastOkText.Text = ResolveOkText(_lastOkRaw);
+                _lastOkText.Text = _lastOkKey is { Length: > 0 } key
+                    ? LocalizationManager.T(key)
+                    : ResolveOkText(_lastOkRaw);
         }
     }
 }

--- a/Configuration Management/Views/NameInputWindow.axaml
+++ b/Configuration Management/Views/NameInputWindow.axaml
@@ -13,6 +13,7 @@
     <Grid Margin="16" RowDefinitions="Auto,Auto,Auto">
         <TextBlock Grid.Row="0" x:Name="Prompt" Margin="0,0,0,8"/>
         <TextBox Grid.Row="1" x:Name="NameBox" Padding="8,6"/>
-        <ContentControl Grid.Row="2" x:Name="ButtonsHost"/>
+        <!-- Отступ панели кнопок сверху взят из разметки WPF. -->
+        <ContentControl Grid.Row="2" x:Name="ButtonsHost" Margin="0,16,0,0"/>
     </Grid>
 </local:ModalWindowBase>

--- a/Configuration Management/Views/PlatformVersionPickerWindow.Avalonia.cs
+++ b/Configuration Management/Views/PlatformVersionPickerWindow.Avalonia.cs
@@ -34,7 +34,7 @@ namespace Configuration_Management
         private HashSet<PlatformVersionGroup>? _initialAncestors;
 
         private readonly TreeView _tree = new();
-        private readonly Button _selectButton = new() { Content = LocalizationManager.T("Common.Select"), MinWidth = 110, IsDefault = true };
+        private Button _selectButton = null!;
         private readonly RadioButton _filterAll = new() { Content = LocalizationManager.T("Common.All"), IsChecked = true, GroupName = "Arch" };
         private readonly RadioButton _filterX32 = new() { Content = LocalizationManager.T("PlatformVersionPicker.FilterX32"), GroupName = "Arch" };
         private readonly RadioButton _filterX64 = new() { Content = LocalizationManager.T("PlatformVersionPicker.FilterX64"), GroupName = "Arch" };
@@ -78,6 +78,13 @@ namespace Configuration_Management
 
         private Control BuildRoot()
         {
+            // Кнопка выбора создаётся до дерева: её доступность меняет обработчик
+            // выделения, а выделение дерево умеет выставить само при подготовке
+            // контейнеров.
+            _selectButton = BuildConfirmActionButton("Common.Select", "IconCheck", 140);
+            _selectButton.Classes.Add("dimmed");
+            _selectButton.IsEnabled = false;
+
             var grid = new Grid { Margin = new Thickness(16) };
             grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
             grid.RowDefinitions.Add(new RowDefinition(new GridLength(1, GridUnitType.Star)));
@@ -185,14 +192,13 @@ namespace Configuration_Management
             {
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8,
+                Spacing = 10,
                 Margin = new Thickness(0, 12, 0, 0)
             };
-            var cancel = new Button { Content = LocalizationManager.T("Common.Cancel"), MinWidth = 100, IsCancel = true };
-            cancel.Click += (_, _) => Close();
-            buttons.Children.Add(cancel);
-            _selectButton.Click += (_, _) => OnSelect_Click();
+            // Оформление и порядок по разметке (PlatformVersionPickerWindow.xaml:257):
+            // зелёный «Выбрать» слева, красная «Отмена» справа, зазор 10.
             buttons.Children.Add(_selectButton);
+            buttons.Children.Add(BuildCancelActionButton(140));
             Grid.SetRow(buttons, 2);
             grid.Children.Add(buttons);
 

--- a/Configuration Management/Views/PlatformVersionPickerWindow.Avalonia.cs
+++ b/Configuration Management/Views/PlatformVersionPickerWindow.Avalonia.cs
@@ -81,7 +81,10 @@ namespace Configuration_Management
             // Кнопка выбора создаётся до дерева: её доступность меняет обработчик
             // выделения, а выделение дерево умеет выставить само при подготовке
             // контейнеров.
-            _selectButton = BuildConfirmActionButton("Common.Select", "IconCheck", 140);
+            // Закрывает окно сам обработчик: у него есть проверка на пустой выбор,
+            // и терять её нельзя (PlatformVersionPickerWindow.xaml:259).
+            _selectButton = BuildConfirmActionButton("Common.Select", "IconCheck", 140,
+                OnSelect_Click, closeOnClick: false);
             _selectButton.Classes.Add("dimmed");
             _selectButton.IsEnabled = false;
 
@@ -150,6 +153,7 @@ namespace Configuration_Management
                 }
                 else
                 {
+                    _selectedVersion = string.Empty;
                     _selectButton.IsEnabled = false;
                 }
             };

--- a/Configuration Management/Views/ProfilesWindow.Avalonia.cs
+++ b/Configuration Management/Views/ProfilesWindow.Avalonia.cs
@@ -7,6 +7,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Controls;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 using Configuration_Management.Models;
 using Configuration_Management.Services;
 
@@ -96,11 +97,14 @@ namespace Configuration_Management
             return panel;
         }
 
-        private StackPanel BuildButtons()
+        private Control BuildButtons()
         {
+            // Раскладка по разметке (ProfilesWindow.xaml:161): отмена прижата
+            // влево, остальные кнопки вправо. Удаление, как и отмена, идёт мягкой
+            // заливкой, три остальные акцентом.
             var panel = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right, Spacing = 8 };
 
-            var delete = new Button { Content = LocalizationManager.T("Profiles.Delete"), MinWidth = 110 };
+            var delete = SoftButton("Profiles.Delete", "IconDelete", 120);
             delete.Click += (_, _) => OnDelete();
             panel.Children.Add(delete);
 
@@ -108,19 +112,55 @@ namespace Configuration_Management
             // (ProfilesWindow.xaml:183). Без неё сменить активный профиль
             // из интерфейса было нельзя вовсе: команда живёт в ProfilesViewModel,
             // а тот в Linux-сборку не входит.
-            var activate = new Button { Content = LocalizationManager.T("Profiles.Activate"), MinWidth = 150 };
+            var activate = AccentButton("Profiles.Activate", "IconStar", 150);
             activate.Click += (_, _) => OnActivate();
             panel.Children.Add(activate);
 
-            var save = new Button { Content = LocalizationManager.T("Profiles.Save"), MinWidth = 130 };
+            var save = AccentButton("Profiles.Save", "IconOk", 130);
             save.Click += (_, _) => OnSave();
             panel.Children.Add(save);
 
-            var create = new Button { Content = LocalizationManager.T("Profiles.Create"), MinWidth = 130 };
+            var create = AccentButton("Profiles.Create", "IconAdd", 130);
             create.Click += (_, _) => OnCreate();
             panel.Children.Add(create);
 
-            return panel;
+            var row = new Grid();
+            row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+            row.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+
+            var cancel = BuildCancelButton(110);
+            Grid.SetColumn(cancel, 0);
+            row.Children.Add(cancel);
+
+            Grid.SetColumn(panel, 1);
+            row.Children.Add(panel);
+            return row;
+        }
+
+        /// <summary>Кнопка акцентной заливки со значком и подписью.</summary>
+        private static Button AccentButton(string textKey, string iconKey, double width)
+        {
+            var button = new Button
+            {
+                Content = IconHelper.IconAndText(iconKey, LocalizationManager.T(textKey), 14, "ButtonTextBrush"),
+                Width = width
+            };
+            button.Styled(Themes.ControlThemes.ModernButton);
+            return button;
+        }
+
+        /// <summary>Кнопка мягкой заливки: в разметке ей задан фон ItemHoverBrush.</summary>
+        private static Button SoftButton(string textKey, string iconKey, double width)
+        {
+            var button = new Button
+            {
+                Content = IconHelper.IconAndText(iconKey, LocalizationManager.T(textKey), 14, "TextPrimaryBrush"),
+                Width = width
+            };
+            button.Styled(Themes.ControlThemes.ModernButton);
+            Themes.ThemeBrushes.Bind(button, Button.BackgroundProperty, "ItemHoverBrush");
+            Themes.ThemeBrushes.Bind(button, Button.ForegroundProperty, "TextPrimaryBrush");
+            return button;
         }
 
         private UserProfile? SelectedProfile => _profilesList.SelectedItem as UserProfile;

--- a/Configuration Management/Views/TagInputWindow.Avalonia.cs
+++ b/Configuration Management/Views/TagInputWindow.Avalonia.cs
@@ -26,7 +26,8 @@ namespace Configuration_Management
             // Кнопки строит базовый класс: у них общий вид и поведение
             // на все модальные окна, поэтому в разметке стоит только место.
             var buttonsHost = this.FindControl<ContentControl>("ButtonsHost")!;
-            buttonsHost.Content = BuildButtons(null, 130, OnOk_Click);
+            buttonsHost.Content = BuildButtons(Localization.LocalizationManager.T("Common.Add"), 110, OnOk_Click,
+                cancelWidth: 90, okIconKey: "IconAdd");
 
             Opened += (_, _) =>
             {

--- a/Configuration Management/Views/TagInputWindow.Avalonia.cs
+++ b/Configuration Management/Views/TagInputWindow.Avalonia.cs
@@ -26,8 +26,8 @@ namespace Configuration_Management
             // Кнопки строит базовый класс: у них общий вид и поведение
             // на все модальные окна, поэтому в разметке стоит только место.
             var buttonsHost = this.FindControl<ContentControl>("ButtonsHost")!;
-            buttonsHost.Content = BuildButtons(Localization.LocalizationManager.T("Common.Add"), 110, OnOk_Click,
-                cancelWidth: 90, okIconKey: "IconAdd");
+            buttonsHost.Content = BuildButtons(null, 110, OnOk_Click,
+                cancelWidth: 90, okIconKey: "IconAdd", okTextKey: "Common.Add");
 
             Opened += (_, _) =>
             {

--- a/Configuration Management/Views/TagInputWindow.axaml
+++ b/Configuration Management/Views/TagInputWindow.axaml
@@ -16,6 +16,7 @@
                    Text="{loc:Loc TagInput.Prompt}"
                    Margin="0,0,0,8"/>
         <TextBox Grid.Row="1" x:Name="TagBox" Padding="8,6"/>
-        <ContentControl Grid.Row="2" x:Name="ButtonsHost"/>
+        <!-- Отступ панели кнопок сверху взят из разметки WPF. -->
+        <ContentControl Grid.Row="2" x:Name="ButtonsHost" Margin="0,16,0,0"/>
     </Grid>
 </local:ModalWindowBase>


### PR DESCRIPTION
# Linux/Avalonia: окно настройки подключения перестроено по разметке WPF

> **Зависимость: этот PR идёт после #105.** Он опирается на общие построители
> кнопок диалога и словарь тем контролов из #105, поэтому ветка нарезана от неё.
> Пока #105 не влит, в дифф этого PR попадают и его коммиты; после мержа
> останутся только два верхних.

## Зачем

Из девятнадцати окон это отставало сильнее всех. Разбор по разметке
(`Views/ConnectionSettingsWindow.xaml`, 1075 строк) против Linux-двойника дал:
68 ключей локализации из 96 не использовались вовсе, восьми вертикальных вкладок
не было (стояли четыре обычные), шапки не было, восьми групп не было, из 26
значков не было ни одного, отсутствовали 14 всплывающих подсказок и около двадцати
пояснений. Отдельно были потеряны пять привязок поведения, и это уже не косметика.

## Что сделано

**Каркас.** Размеры окна и базовый кегль по разметке (760 на 780, минимум 680
на 680, кегль 13). Появилась шапка: значок базы в акцентном квадрате 40 на 40,
заголовок кеглем 18 и подзаголовок кеглем 12. Появилась нижняя панель с отбивкой
сверху и фоном карточки, кнопки в ней 140 на 36 с зазором 10.

**Восемь вкладок вместо четырёх**, вертикальной колонкой слева, со значками
и в порядке разметки: База, Подключение, Хранилище, Авторизация, Запуск,
Разрядность, Платформа, Идентификатор. Прежняя раскладка склеивала их иначе:
поля базы и идентификатор стояли над вкладками, авторизация 1С была внутри
подключения, а платформа, разрядность и запуск были одной вкладкой.

**Восемь групп** в рамках с заголовком и значком, как задаёт шаблон `GroupBox`
разметки.

**Карточки вариантов.** Пятнадцать переключателей (тип подключения, две
авторизации, режим запуска, разрядность) стали карточками в рамке с подписью
и пояснением, как в разметке; выбранная карточка получает акцентный контур
и подложку. Прежде это были голые переключатели в строку, без пояснений.

**Вернулись потерянные привязки поведения**, все пять:

* список серверов из соседних баз (`AvailableServers`) вместо простого поля ввода;
* доступность сохранения по наличию несохранённых изменений (`HasChanges`),
  с гашением прозрачностью;
* недоступность варианта «Веб-клиент» вне веб-подключения (`IsWebClientAllowed`);
* недоступность варианта «Только 64» на 32-битной системе (`IsOs64Bit`);
* показ полей сервера, файла и адреса по типу подключения: в разметке они лежат
  в одних и тех же строках сетки и переключаются, а не показываются все сразу.

**Числа** взяты из разметки: колонка подписей 120 вместо 160, поля с отступом
6 на 4, минимальной высотой 28 и кеглем 12, карточки с отступом 8 на 6,
скруглением 6 и контуром 1.5, вкладки шириной 180 с отступом 14 на 12
и акцентной полосой 3 справа у выбранной.

**Подсказки.** Добавлены четырнадцать всплывающих подсказок и пояснения под
каждым вариантом выбора, плюс динамические пояснения режима запуска
и разрядности, которые модель уже отдавала, но никто не показывал.

## Что изменилось в общем словаре тем

`Themes/Controls.axaml` пополнился тремя темами: `ConnTabControl` и `ConnTabItem`
(в разметке они объявлены в самом окне) и `OptionCard` для карточки варианта.
Последняя в разметке сделана иначе: там `Border` с собственным `DataTrigger`
вокруг штатного переключателя. Здесь это тема самого переключателя, потому что
в Avalonia состояние выбора выражается псевдоклассом и красит рамку и кружок
без привязок и без кода.

## Отличия от разметки, сделанные сознательно

1. **Значки.** В разметке они из пакета MaterialDesign, которого в Linux-сборке
   нет. Взяты ближайшие из собственного словаря автора `Themes/Icons.axaml`:
   `LanConnect` → `IconNetwork`, `ServerNetwork` → `IconServer`, `SourceBranch` →
   `IconMerge`, `ApplicationEditOutline` → `IconApplicationCog`,
   `PlayCircleOutline` → `IconPlay`, `Chip` → `IconMonitor`, `CubeOutline` →
   `IconPackage`, `Identifier` → `IconInfo`, `ContentPaste` → `IconCopy`.
2. **Пояснение про разрядность операционной системы.** У автора оба варианта
   текста говорят «Windows», поэтому в Linux-ветке для него свои ключи. Это
   расхождение было и раньше, здесь оно сохранено, а не введено.

## Что осталось названным, но не сделанным

* Тексты авторских подсказок про аутентификацию говорят «учётная запись Windows»
  (`Connection.AuthOsHint`). Это его строки, они перенесены как есть; для Linux
  у нас заведены свои ключи только там, где расхождение уже мешало (пояснение
  про разрядность системы).
* Содержимое каждой вкладки завёрнуто в прокрутку, которой в разметке нет:
  без неё при уменьшении окна нижние поля обрезаются, а `SizeToContent` здесь
  не годится.
* 22 ключа локализации вида `ConnectionSettings.*Short` остались без
  потребителей: их завёл автор, его же разметка ими не пользуется, и трогать
  их без нужды не стоит.

## Как проверено

Сборка Linux-цели без ошибок, публикация, прогон приложения в отдельном каталоге
данных. Сняты и осмотрены вкладки «База», «Подключение», «Запуск»,
«Авторизация» и «Идентификатор» в светлой и тёмной теме: карточки выбора, переключение полей по типу подключения,
недоступный вариант веб-клиента у серверной базы и погасшая кнопка сохранения
до первого изменения.
