### PR TITLE
Linux/Avalonia: поля ввода, списки и флажки по стилям разметки

### DIFF
--- a/Configuration Management/App.axaml
+++ b/Configuration Management/App.axaml
@@ -6,6 +6,7 @@
              RequestedThemeVariant="Default">
     <Application.Styles>
         <FluentTheme />
+        <StyleInclude Source="avares://ConfigurationManagement/Themes/ControlDefaults.axaml" />
     </Application.Styles>
 
     <Application.Resources>

--- a/Configuration Management/Themes/ControlDefaults.axaml
+++ b/Configuration Management/Themes/ControlDefaults.axaml
@@ -9,17 +9,6 @@
     <Style Selector="ComboBox">
         <Setter Property="Theme" Value="{DynamicResource ModernComboBox}"/>
     </Style>
-    <!-- Рамка выпадающего списка живёт в отдельном окне (PopupRoot), и селектор
-         части шаблона из темы ComboBox до неё не достаёт: проверено прогоном,
-         тема применялась, а рамка оставалась штатной. Поэтому она задаётся
-         отдельным стилем по имени части Fluent. -->
-    <Style Selector="Border#PopupBorder">
-        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushColor}"/>
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="CornerRadius" Value="8"/>
-        <Setter Property="Padding" Value="4"/>
-    </Style>
     <Style Selector="ComboBoxItem">
         <Setter Property="Theme" Value="{DynamicResource ModernComboBoxItem}"/>
     </Style>

--- a/Configuration Management/Themes/ControlDefaults.axaml
+++ b/Configuration Management/Themes/ControlDefaults.axaml
@@ -1,0 +1,29 @@
+<!-- Умолчания оформления контролов (Linux). В разметке WPF словари тем
+     объявляют неявные стили ComboBox и CheckBox (LightTheme.xaml:413 и :477),
+     то есть эти два контрола выглядят одинаково во всём приложении без явного
+     указания стиля. Здесь это те же две строки: тема ставится селектором по типу.
+     Поле ввода в неявный стиль не входит: у автора оно объявляется отдельно
+     в каждом окне, и в главном окне у поиска своё оформление. -->
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style Selector="ComboBox">
+        <Setter Property="Theme" Value="{DynamicResource ModernComboBox}"/>
+    </Style>
+    <!-- Рамка выпадающего списка живёт в отдельном окне (PopupRoot), и селектор
+         части шаблона из темы ComboBox до неё не достаёт: проверено прогоном,
+         тема применялась, а рамка оставалась штатной. Поэтому она задаётся
+         отдельным стилем по имени части Fluent. -->
+    <Style Selector="Border#PopupBorder">
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushColor}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="Padding" Value="4"/>
+    </Style>
+    <Style Selector="ComboBoxItem">
+        <Setter Property="Theme" Value="{DynamicResource ModernComboBoxItem}"/>
+    </Style>
+    <Style Selector="CheckBox">
+        <Setter Property="Theme" Value="{DynamicResource ModernMaterialCheckBox}"/>
+    </Style>
+</Styles>

--- a/Configuration Management/Themes/ControlThemes.Avalonia.cs
+++ b/Configuration Management/Themes/ControlThemes.Avalonia.cs
@@ -36,11 +36,8 @@ namespace Configuration_Management.Themes
         /// <summary>Поле ввода: карточный фон, скругление 6, акцентный контур при наведении и фокусе.</summary>
         public const string ModernTextBox = "ModernTextBox";
 
-        /// <summary>Выпадающий список: карточный фон, скругление 8, акцентный контур.</summary>
-        public const string ModernComboBox = "ModernComboBox";
-
-        /// <summary>Флажок в стиле Material Design: квадрат 18 со скруглением 3.</summary>
-        public const string ModernMaterialCheckBox = "ModernMaterialCheckBox";
+        /// <summary>Поле пароля: то же поле, но с контуром 1.5, скруглением 8 и отступом 10 на 6.</summary>
+        public const string ModernPasswordBox = "ModernPasswordBox";
 
         /// <summary>
         /// Ставит элементу тему контрола по ключу словаря и возвращает сам элемент,

--- a/Configuration Management/Themes/ControlThemes.Avalonia.cs
+++ b/Configuration Management/Themes/ControlThemes.Avalonia.cs
@@ -33,6 +33,15 @@ namespace Configuration_Management.Themes
         /// <summary>Карточка варианта выбора: рамка вокруг переключателя с подписью и пояснением.</summary>
         public const string OptionCard = "OptionCard";
 
+        /// <summary>Поле ввода: карточный фон, скругление 6, акцентный контур при наведении и фокусе.</summary>
+        public const string ModernTextBox = "ModernTextBox";
+
+        /// <summary>Выпадающий список: карточный фон, скругление 8, акцентный контур.</summary>
+        public const string ModernComboBox = "ModernComboBox";
+
+        /// <summary>Флажок в стиле Material Design: квадрат 18 со скруглением 3.</summary>
+        public const string ModernMaterialCheckBox = "ModernMaterialCheckBox";
+
         /// <summary>
         /// Ставит элементу тему контрола по ключу словаря и возвращает сам элемент,
         /// чтобы вызов можно было встроить в инициализацию.

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -32,6 +32,18 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
+    <!-- Ресурсы штатной темы Fluent, которыми она красит выпадающий список.
+         Рамка списка живёт в отдельном окне, и селектор части шаблона до неё
+         не достаёт (проверено прогоном), поэтому вид задаётся через ресурсы,
+         на которые её шаблон и ссылается. Значения из разметки WPF
+         (ConnectionSettingsWindow.xaml:365: фон карточки, контур, скругление 8,
+         внутренний отступ 4). -->
+    <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{DynamicResource CardBackgroundColor}"/>
+    <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{DynamicResource BorderColor}"/>
+    <Thickness x:Key="ComboBoxDropdownBorderThickness">1</Thickness>
+    <Thickness x:Key="ComboBoxDropdownBorderPadding">4</Thickness>
+    <CornerRadius x:Key="OverlayCornerRadius">8</CornerRadius>
+
     <!-- ===================== Основная кнопка ===================== -->
     <ControlTheme x:Key="ModernButton" TargetType="Button">
         <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
@@ -329,6 +341,164 @@
              (ConnectionSettingsWindow.xaml:744 и :862). -->
         <Style Selector="^:disabled /template/ Border#PART_Surface">
             <Setter Property="Opacity" Value="0.45"/>
+        </Style>
+    </ControlTheme>
+    <!-- ===================== Поля ввода и списки =====================
+         Стили ModernTextBox, ModernComboBox, ModernComboBoxItem и
+         ModernMaterialCheckBox из словарей WPF (LightTheme.xaml:211, :277, :341,
+         :415; в тёмной теме они дословно те же). Поле ввода и список наследуют
+         штатную тему Fluent и переопределяют её части: свой шаблон здесь опасен,
+         у TextBox обязательна часть PART_TextPresenter, у ComboBox PART_Popup.
+         У флажка обязательных частей нет, поэтому его шаблон повторяет авторский
+         целиком. -->
+    <ControlTheme x:Key="ModernTextBox" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushColor}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Padding" Value="8,6"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="CaretBrush" Value="{DynamicResource TextPrimaryBrush}"/>
+
+        <Style Selector="^ /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushColor}"/>
+        </Style>
+        <Style Selector="^:pointerover /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        </Style>
+        <Style Selector="^:focus /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="ModernComboBoxItem" TargetType="ComboBoxItem" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="Padding" Value="10,8"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+
+        <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        </Style>
+        <Style Selector="^:selected /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+        </Style>
+        <Style Selector="^:selected:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
+        </Style>
+        <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}"/>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="ModernComboBox" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushColor}"/>
+        <Setter Property="BorderThickness" Value="1.5"/>
+        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="Padding" Value="10,6"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="MinHeight" Value="36"/>
+        <Setter Property="MinWidth" Value="120"/>
+        <Setter Property="MaxDropDownHeight" Value="280"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="ItemContainerTheme" Value="{StaticResource ModernComboBoxItem}"/>
+
+        <Style Selector="^ /template/ Border#Background">
+            <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushColor}"/>
+        </Style>
+        <Style Selector="^:pointerover /template/ Border#Background">
+            <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        </Style>
+        <Style Selector="^:pressed /template/ Border#Background">
+            <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        </Style>
+        <Style Selector="^:focus /template/ Border#Background">
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        </Style>
+        <Style Selector="^ /template/ PathIcon#DropDownGlyph">
+            <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}"/>
+        </Style>
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value="0.5"/>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="ModernMaterialCheckBox" TargetType="CheckBox">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="CheckBox">
+                <Grid Background="{TemplateBinding Background}" ColumnDefinitions="Auto,*">
+                    <Border Name="PART_Box"
+                            Width="18" Height="18"
+                            CornerRadius="3"
+                            BorderThickness="2"
+                            VerticalAlignment="Center"
+                            Background="{DynamicResource CardBackgroundBrush}"
+                            BorderBrush="{DynamicResource BorderBrushColor}">
+                        <Panel>
+                            <Path Name="PART_Check"
+                                  Data="M 3.2,8.2 L 6.8,11.8 L 14.6,4.2"
+                                  Stroke="White" StrokeThickness="2.2"
+                                  StrokeLineCap="Round" StrokeJoin="Round"
+                                  Stretch="None"
+                                  HorizontalAlignment="Center" VerticalAlignment="Center"
+                                  IsVisible="False"/>
+                            <Path Name="PART_Dash"
+                                  Data="M 4.2,9 L 13.8,9"
+                                  Stroke="White" StrokeThickness="2.2"
+                                  StrokeLineCap="Round"
+                                  Stretch="None"
+                                  HorizontalAlignment="Center" VerticalAlignment="Center"
+                                  IsVisible="False"/>
+                        </Panel>
+                    </Border>
+                    <ContentPresenter Grid.Column="1"
+                                      Name="PART_ContentPresenter"
+                                      Margin="9,0,0,0"
+                                      VerticalAlignment="Center"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"/>
+                </Grid>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Box">
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        </Style>
+        <Style Selector="^:checked /template/ Border#PART_Box">
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        </Style>
+        <Style Selector="^:checked /template/ Path#PART_Check">
+            <Setter Property="IsVisible" Value="True"/>
+        </Style>
+        <Style Selector="^:indeterminate /template/ Border#PART_Box">
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        </Style>
+        <Style Selector="^:indeterminate /template/ Path#PART_Dash">
+            <Setter Property="IsVisible" Value="True"/>
+        </Style>
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value="0.5"/>
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -32,17 +32,23 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <!-- Ресурсы штатной темы Fluent, которыми она красит выпадающий список.
-         Рамка списка живёт в отдельном окне, и селектор части шаблона до неё
-         не достаёт (проверено прогоном), поэтому вид задаётся через ресурсы,
-         на которые её шаблон и ссылается. Значения из разметки WPF
-         (ConnectionSettingsWindow.xaml:365: фон карточки, контур, скругление 8,
-         внутренний отступ 4). -->
+    <!-- Ресурсы штатной темы Fluent, которыми она красит выпадающий список
+         и стрелку. Через ресурсы, а не селектором: рамка списка и стрелка
+         получают значения прямо из шаблона, а у значения из шаблона приоритет
+         выше, чем у именованного стиля, поэтому селектор части ничего не меняет.
+         Значения из разметки WPF (ConnectionSettingsWindow.xaml:365: фон
+         карточки, контур темы, толщина 1, внутренний отступ 4; стрелка
+         второстепенным цветом, LightTheme.xaml:352).
+         Скругление списка остаётся штатным: у Fluent за него отвечает общий
+         OverlayCornerRadius, и подъём его до авторских 8 заодно скруглил бы
+         подсказки и меню, у которых в разметке WPF свои значения. -->
     <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{DynamicResource CardBackgroundColor}"/>
     <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{DynamicResource BorderColor}"/>
-    <Thickness x:Key="ComboBoxDropdownBorderThickness">1</Thickness>
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{DynamicResource TextSecondaryColor}"/>
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundPointerOver" Color="{DynamicResource TextSecondaryColor}"/>
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundPressed" Color="{DynamicResource TextSecondaryColor}"/>
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundDisabled" Color="{DynamicResource TextSecondaryColor}"/>
     <Thickness x:Key="ComboBoxDropdownBorderPadding">4</Thickness>
-    <CornerRadius x:Key="OverlayCornerRadius">8</CornerRadius>
 
     <!-- ===================== Основная кнопка ===================== -->
     <ControlTheme x:Key="ModernButton" TargetType="Button">
@@ -344,9 +350,9 @@
         </Style>
     </ControlTheme>
     <!-- ===================== Поля ввода и списки =====================
-         Стили ModernTextBox, ModernComboBox, ModernComboBoxItem и
-         ModernMaterialCheckBox из словарей WPF (LightTheme.xaml:211, :277, :341,
-         :415; в тёмной теме они дословно те же). Поле ввода и список наследуют
+         Стили ModernTextBox (LightTheme.xaml:211), ModernComboBoxItem (:242),
+         ModernComboBox (:277), ModernMaterialCheckBox (:417) и PasswordBox
+         (:1121); в тёмной теме все они дословно те же. Поле ввода и список наследуют
          штатную тему Fluent и переопределяют её части: свой шаблон здесь опасен,
          у TextBox обязательна часть PART_TextPresenter, у ComboBox PART_Popup.
          У флажка обязательных частей нет, поэтому его шаблон повторяет авторский
@@ -360,6 +366,10 @@
         <Setter Property="Padding" Value="8,6"/>
         <Setter Property="FontSize" Value="13"/>
         <Setter Property="CaretBrush" Value="{DynamicResource TextPrimaryBrush}"/>
+        <!-- Штатная тема задаёт полю минимум 32 на 64; в разметке WPF габаритов
+             нет, высоту определяют отступы и кегль. -->
+        <Setter Property="MinHeight" Value="0"/>
+        <Setter Property="MinWidth" Value="0"/>
 
         <Style Selector="^ /template/ Border#PART_BorderElement">
             <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
@@ -373,6 +383,23 @@
             <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
+        </Style>
+        <!-- Штатная тема на наведении, фокусе и в недоступном состоянии красит
+             и текст, и фон своими системными кистями; в разметке WPF у поля
+             таких правил нет вовсе, цвет там всегда один. -->
+        <Style Selector="^:pointerover">
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        </Style>
+        <Style Selector="^:focus">
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        </Style>
+        <Style Selector="^:disabled">
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+            <Setter Property="Opacity" Value="0.5"/>
+        </Style>
+        <Style Selector="^:disabled /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushColor}"/>
         </Style>
     </ControlTheme>
 
@@ -412,6 +439,8 @@
         <Setter Property="MaxDropDownHeight" Value="280"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="ItemContainerTheme" Value="{StaticResource ModernComboBoxItem}"/>
+        <!-- Штатная тема прижимает список влево, в WPF он растягивается по месту. -->
+        <Setter Property="HorizontalAlignment" Value="Stretch"/>
 
         <Style Selector="^ /template/ Border#Background">
             <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
@@ -425,15 +454,31 @@
             <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         </Style>
+        <!-- У редактируемого списка фокус живёт во вложенном поле ввода,
+             поэтому одного :focus мало: разметка WPF смотрит IsKeyboardFocusWithin
+             (LightTheme.xaml:397). -->
         <Style Selector="^:focus /template/ Border#Background">
             <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         </Style>
-        <Style Selector="^ /template/ PathIcon#DropDownGlyph">
-            <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}"/>
+        <Style Selector="^:focus-within /template/ Border#Background">
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         </Style>
         <Style Selector="^:disabled">
             <Setter Property="Opacity" Value="0.5"/>
         </Style>
+        <Style Selector="^:disabled /template/ Border#Background">
+            <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushColor}"/>
+        </Style>
+    </ControlTheme>
+
+    <!-- Поле пароля: свой стиль словаря WPF (LightTheme.xaml:1121), отличается
+         от поля ввода толщиной контура, скруглением и отступом. -->
+    <ControlTheme x:Key="ModernPasswordBox" TargetType="TextBox" BasedOn="{StaticResource ModernTextBox}">
+        <Setter Property="BorderThickness" Value="1.5"/>
+        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="Padding" Value="10,6"/>
+        <Setter Property="SelectionBrush" Value="{DynamicResource AccentBrush}"/>
     </ControlTheme>
 
     <ControlTheme x:Key="ModernMaterialCheckBox" TargetType="CheckBox">

--- a/Configuration Management/Views/ConnectionSettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/ConnectionSettingsWindow.Avalonia.cs
@@ -28,9 +28,9 @@ namespace Configuration_Management
         private readonly ConnectionSettingsViewModel _viewModel;
         private readonly IDialogService _dialogs;
 
-        private readonly PasswordBox _passwordBox = new();
-        private readonly PasswordBox _repositoryPasswordBox = new();
-        private readonly PasswordBox _configuratorPasswordBox = new();
+        private readonly PasswordBox _passwordBox = new PasswordBox().Styled(ControlThemes.ModernPasswordBox);
+        private readonly PasswordBox _repositoryPasswordBox = new PasswordBox().Styled(ControlThemes.ModernPasswordBox);
+        private readonly PasswordBox _configuratorPasswordBox = new PasswordBox().Styled(ControlThemes.ModernPasswordBox);
 
         private bool _isSyncingPassword;
         private bool _isSyncingRepositoryPassword;
@@ -129,12 +129,12 @@ namespace Configuration_Management
 
         private static ComboBox EditableCombo(string textPath, string itemsPath)
         {
+            // Высоту и кегль списку задаёт тема: в разметке у этих двух списков
+            // местных значений нет (ConnectionSettingsWindow.xaml:325 и :338).
             var combo = new ComboBox
             {
                 IsEditable = true,
                 Margin = new Thickness(0, 3),
-                MinHeight = 28,
-                FontSize = 12,
                 HorizontalAlignment = HorizontalAlignment.Stretch
             };
             combo.Bind(ComboBox.TextProperty, new Binding(textPath) { Mode = BindingMode.TwoWay });

--- a/Configuration Management/Views/ConnectionSettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/ConnectionSettingsWindow.Avalonia.cs
@@ -118,6 +118,7 @@ namespace Configuration_Management
                 VerticalContentAlignment = VerticalAlignment.Center,
                 IsReadOnly = readOnly
             };
+            tb.Styled(ControlThemes.ModernTextBox);
             // Свойство только для чтения привязывается односторонне, как в разметке
             // (ConnectionSettingsWindow.xaml:219): двусторонняя привязка к свойству
             // без сеттера пишет ошибку в журнал при каждом обновлении.

--- a/Configuration Management/Views/ConnectionStringInputWindow.Avalonia.cs
+++ b/Configuration Management/Views/ConnectionStringInputWindow.Avalonia.cs
@@ -41,10 +41,10 @@ namespace Configuration_Management
             // (ConnectionStringInputWindow.xaml:44).
             _inputBox = new TextBox
             {
-                Padding = new Thickness(8, 6),
                 MinHeight = 34,
                 VerticalContentAlignment = VerticalAlignment.Center
             };
+            _inputBox.Styled(ControlThemes.ModernTextBox);
             _inputBox.TextChanged += (_, _) => UpdateOkEnabled();
             _inputBox.KeyDown += OnInputBox_KeyDown;
 

--- a/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
+++ b/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
@@ -35,21 +35,21 @@ namespace Configuration_Management
             AppServices.GetRequiredService<IInfobaseRepository>();
 
         private readonly ComboBox _typeBox = new() { Padding = new Thickness(8, 5) };
-        private readonly TextBox _nameBox = new() { Padding = new Thickness(8, 5) };
+        private readonly TextBox _nameBox = new TextBox().Styled(ControlThemes.ModernTextBox);
         private readonly TextBlock _groupPathBox = new() { VerticalAlignment = VerticalAlignment.Center };
-        private readonly TextBox _platformBox = new() { Padding = new Thickness(8, 5), IsReadOnly = true };
-        private readonly TextBox _filePathBox = new() { Padding = new Thickness(8, 5) };
-        private readonly TextBox _templateBox = new() { Padding = new Thickness(8, 5) };
+        private readonly TextBox _platformBox = new TextBox { Padding = new Thickness(6, 4), IsReadOnly = true }.Styled(ControlThemes.ModernTextBox);
+        private readonly TextBox _filePathBox = new TextBox { Padding = new Thickness(6, 4) }.Styled(ControlThemes.ModernTextBox);
+        private readonly TextBox _templateBox = new TextBox { Padding = new Thickness(6, 4) }.Styled(ControlThemes.ModernTextBox);
         private readonly StackPanel _filePanel = new() { Spacing = 8 };
 
         // Поля клиент-серверного варианта.
         private readonly StackPanel _serverPanel = new() { Spacing = 8 };
-        private readonly TextBox _serverBox = new() { Padding = new Thickness(8, 5) };
-        private readonly TextBox _refBox = new() { Padding = new Thickness(8, 5) };
+        private readonly TextBox _serverBox = new TextBox().Styled(ControlThemes.ModernTextBox);
+        private readonly TextBox _refBox = new TextBox().Styled(ControlThemes.ModernTextBox);
         private readonly ComboBox _dbmsBox = new() { Padding = new Thickness(8, 5), IsEditable = true };
-        private readonly TextBox _dbServerBox = new() { Padding = new Thickness(8, 5) };
-        private readonly TextBox _dbNameBox = new() { Padding = new Thickness(8, 5) };
-        private readonly TextBox _dbUserBox = new() { Padding = new Thickness(8, 5) };
+        private readonly TextBox _dbServerBox = new TextBox().Styled(ControlThemes.ModernTextBox);
+        private readonly TextBox _dbNameBox = new TextBox().Styled(ControlThemes.ModernTextBox);
+        private readonly TextBox _dbUserBox = new TextBox().Styled(ControlThemes.ModernTextBox);
         private readonly PasswordBox _dbPwdBox = new() { Padding = new Thickness(8, 5) };
         private readonly CheckBox _createDbCheck = new();
         private readonly CheckBox _blockJobsCheck = new();

--- a/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
+++ b/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
@@ -34,7 +34,7 @@ namespace Configuration_Management
         private readonly IInfobaseRepository _repository =
             AppServices.GetRequiredService<IInfobaseRepository>();
 
-        private readonly ComboBox _typeBox = new() { Padding = new Thickness(8, 5) };
+        private readonly ComboBox _typeBox = new();
         private readonly TextBox _nameBox = new TextBox().Styled(ControlThemes.ModernTextBox);
         private readonly TextBlock _groupPathBox = new() { VerticalAlignment = VerticalAlignment.Center };
         private readonly TextBox _platformBox = new TextBox { Padding = new Thickness(6, 4), IsReadOnly = true }.Styled(ControlThemes.ModernTextBox);
@@ -46,11 +46,11 @@ namespace Configuration_Management
         private readonly StackPanel _serverPanel = new() { Spacing = 8 };
         private readonly TextBox _serverBox = new TextBox().Styled(ControlThemes.ModernTextBox);
         private readonly TextBox _refBox = new TextBox().Styled(ControlThemes.ModernTextBox);
-        private readonly ComboBox _dbmsBox = new() { Padding = new Thickness(8, 5), IsEditable = true };
+        private readonly ComboBox _dbmsBox = new() { Padding = new Thickness(6, 2), IsEditable = true };
         private readonly TextBox _dbServerBox = new TextBox().Styled(ControlThemes.ModernTextBox);
         private readonly TextBox _dbNameBox = new TextBox().Styled(ControlThemes.ModernTextBox);
         private readonly TextBox _dbUserBox = new TextBox().Styled(ControlThemes.ModernTextBox);
-        private readonly PasswordBox _dbPwdBox = new() { Padding = new Thickness(8, 5) };
+        private readonly PasswordBox _dbPwdBox = new PasswordBox().Styled(ControlThemes.ModernPasswordBox);
         private readonly CheckBox _createDbCheck = new();
         private readonly CheckBox _blockJobsCheck = new();
 

--- a/Configuration Management/Views/GroupEditWindow.Avalonia.cs
+++ b/Configuration Management/Views/GroupEditWindow.Avalonia.cs
@@ -30,8 +30,12 @@ namespace Configuration_Management
         private string _icon = string.Empty;
         private string _parentId = string.Empty;
 
-        private readonly TextBox _nameBox = new() { Padding = new Thickness(8, 6) };
-        private readonly TextBox _descriptionBox = new() { Padding = new Thickness(8, 6), AcceptsReturn = true, MinHeight = 70 };
+        private readonly TextBox _nameBox =
+            new TextBox { Padding = new Thickness(4, 3) }.Styled(ControlThemes.ModernTextBox);
+
+        private readonly TextBox _descriptionBox =
+            new TextBox { Padding = new Thickness(4, 3), AcceptsReturn = true, MinHeight = 70 }
+                .Styled(ControlThemes.ModernTextBox);
         private readonly TextBlock _parentPathBox = new();
         private readonly ColorPickerControl _colorControl = new();
         private readonly ColorPickerControl _iconColorControl = new();

--- a/Configuration Management/Views/LaunchParametersWindow.Avalonia.cs
+++ b/Configuration Management/Views/LaunchParametersWindow.Avalonia.cs
@@ -9,6 +9,7 @@ using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Configuration_Management.Localization;
+using Configuration_Management.Themes;
 
 namespace Configuration_Management
 {
@@ -34,14 +35,17 @@ namespace Configuration_Management
             MinWidth = 720;
             MinHeight = 480;
 
+            // Высота и выравнивание из разметки (LaunchParametersWindow.xaml:28 и :48).
             _txtCustom = new TextBox
             {
                 Text = currentParameters ?? string.Empty,
-                Padding = new Thickness(8, 6),
                 AcceptsReturn = true,
-                MinHeight = 90,
+                TextWrapping = TextWrapping.Wrap,
+                MinHeight = 110,
+                VerticalContentAlignment = VerticalAlignment.Top,
                 Watermark = LocalizationManager.T("LaunchParams.InputWatermark")
             };
+            _txtCustom.Styled(Themes.ControlThemes.ModernTextBox);
             ToolTip.SetTip(_txtCustom, LocalizationManager.T("LaunchParams.InputTooltip"));
 
             Content = BuildRoot();

--- a/Configuration Management/Views/LaunchParametersWindow.Avalonia.cs
+++ b/Configuration Management/Views/LaunchParametersWindow.Avalonia.cs
@@ -42,6 +42,7 @@ namespace Configuration_Management
                 AcceptsReturn = true,
                 TextWrapping = TextWrapping.Wrap,
                 MinHeight = 110,
+                Padding = new Thickness(6, 6),
                 VerticalContentAlignment = VerticalAlignment.Top,
                 Watermark = LocalizationManager.T("LaunchParams.InputWatermark")
             };

--- a/Configuration Management/Views/LinkInputWindow.axaml
+++ b/Configuration Management/Views/LinkInputWindow.axaml
@@ -28,7 +28,7 @@
                    Margin="0,0,0,8"
                    Foreground="{DynamicResource TextSecondaryBrush}"/>
 
-        <TextBox Grid.Row="2" x:Name="LinkBox" Padding="8,6"/>
+        <TextBox Grid.Row="2" x:Name="LinkBox" Theme="{DynamicResource ModernTextBox}"/>
 
         <!-- Порядок, размеры и цвета по разметке WPF (LinkInputWindow.xaml:50):
              зелёный переход слева, красная отмена справа, зазор 10. -->

--- a/Configuration Management/Views/LoginWindow.Avalonia.cs
+++ b/Configuration Management/Views/LoginWindow.Avalonia.cs
@@ -84,7 +84,8 @@ namespace Configuration_Management
                 IsVisible = false
             };
             _passwordPanel.Children.Add(new TextBlock { Text = LocalizationManager.T("Auth.Password") });
-            _passwordInput = new PasswordBox { Padding = new Thickness(8, 6) };
+            _passwordInput = new PasswordBox();
+            _passwordInput.Styled(ControlThemes.ModernPasswordBox);
             _passwordInput.KeyDown += OnPasswordInput_KeyDown;
             _passwordPanel.Children.Add(_passwordInput);
             Grid.SetRow(_passwordPanel, 2);

--- a/Configuration Management/Views/NameInputWindow.axaml
+++ b/Configuration Management/Views/NameInputWindow.axaml
@@ -12,7 +12,7 @@
                        SystemDecorations="Full">
     <Grid Margin="16" RowDefinitions="Auto,Auto,Auto">
         <TextBlock Grid.Row="0" x:Name="Prompt" Margin="0,0,0,8"/>
-        <TextBox Grid.Row="1" x:Name="NameBox" Padding="8,6"/>
+        <TextBox Grid.Row="1" x:Name="NameBox" Theme="{DynamicResource ModernTextBox}"/>
         <!-- Отступ панели кнопок сверху взят из разметки WPF. -->
         <ContentControl Grid.Row="2" x:Name="ButtonsHost" Margin="0,16,0,0"/>
     </Grid>

--- a/Configuration Management/Views/ProfilesWindow.Avalonia.cs
+++ b/Configuration Management/Views/ProfilesWindow.Avalonia.cs
@@ -22,7 +22,7 @@ namespace Configuration_Management
         private readonly IProfileService _profileService;
         private readonly TextBlock _currentAccountLabel;
         private readonly ListBox _profilesList;
-        private readonly TextBox _nameBox = new() { Padding = new Thickness(8, 6), MinWidth = 280 };
+        private readonly TextBox _nameBox = new TextBox { Width = 260 }.Styled(Themes.ControlThemes.ModernTextBox);
         private readonly PasswordBox _passwordInput = new() { Padding = new Thickness(8, 6), MinWidth = 280 };
         private readonly CheckBox _protectCheck = new() { Content = LocalizationManager.T("Profiles.ProtectWithPassword"), Margin = new Thickness(108, 0, 0, 0) };
         private readonly TextBlock _errorLabel;

--- a/Configuration Management/Views/ProfilesWindow.Avalonia.cs
+++ b/Configuration Management/Views/ProfilesWindow.Avalonia.cs
@@ -23,7 +23,8 @@ namespace Configuration_Management
         private readonly TextBlock _currentAccountLabel;
         private readonly ListBox _profilesList;
         private readonly TextBox _nameBox = new TextBox { Width = 260 }.Styled(Themes.ControlThemes.ModernTextBox);
-        private readonly PasswordBox _passwordInput = new() { Padding = new Thickness(8, 6), MinWidth = 280 };
+        private readonly PasswordBox _passwordInput =
+            new PasswordBox { Width = 260 }.Styled(Themes.ControlThemes.ModernPasswordBox);
         private readonly CheckBox _protectCheck = new() { Content = LocalizationManager.T("Profiles.ProtectWithPassword"), Margin = new Thickness(108, 0, 0, 0) };
         private readonly TextBlock _errorLabel;
         private bool _suppressSelection;

--- a/Configuration Management/Views/SettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/SettingsWindow.Avalonia.cs
@@ -1418,7 +1418,7 @@ namespace Configuration_Management
             var fileGrid = new Grid();
             fileGrid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
             fileGrid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-            var fileBox = new TextBox { Text = _viewModel.IbasesSyncFilePath, HorizontalAlignment = HorizontalAlignment.Stretch };
+            var fileBox = new TextBox { Text = _viewModel.IbasesSyncFilePath, HorizontalAlignment = HorizontalAlignment.Stretch }.Styled(ControlThemes.ModernTextBox);
             var browse = new Button { Content = "...", Margin = new Thickness(8, 0, 0, 0) };
             ToolTip.SetTip(browse, LocalizationManager.T("Settings.Ibases.BrowseTooltip"));
             browse.Click += (_, _) =>
@@ -1453,11 +1453,11 @@ namespace Configuration_Management
             // иначе рядом с погашенным полем стоит подпись в полную яркость.
             var intervalLabel = new TextBlock { Text = LocalizationManager.T("Settings.Ibases.Interval"), VerticalAlignment = VerticalAlignment.Center };
             intervalRow.Children.Add(intervalLabel);
-            var intervalBox = new TextBox { Text = _viewModel.IbasesSyncIntervalMinutes.ToString(), Width = 80 };
+            var intervalBox = new TextBox { Text = _viewModel.IbasesSyncIntervalMinutes.ToString(), Width = 80 }.Styled(ControlThemes.ModernTextBox);
             intervalRow.Children.Add(intervalBox);
             var scheduleLabel = new TextBlock { Text = LocalizationManager.T("Settings.Ibases.ScheduleTime"), VerticalAlignment = VerticalAlignment.Center };
             intervalRow.Children.Add(scheduleLabel);
-            var scheduleBox = new TextBox { Text = _viewModel.IbasesSyncScheduleTime, Width = 80 };
+            var scheduleBox = new TextBox { Text = _viewModel.IbasesSyncScheduleTime, Width = 80 }.Styled(ControlThemes.ModernTextBox);
             intervalRow.Children.Add(scheduleBox);
             bases.Children.Add(intervalRow);
 
@@ -1523,7 +1523,7 @@ namespace Configuration_Management
             bases.Children.Add(backupCheck);
             var keepRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
             keepRow.Children.Add(new TextBlock { Text = LocalizationManager.T("Settings.Ibases.BackupKeepCount"), VerticalAlignment = VerticalAlignment.Center });
-            var keepBox = new TextBox { Text = _viewModel.IbasesBackupKeepCount.ToString(), Width = 80 };
+            var keepBox = new TextBox { Text = _viewModel.IbasesBackupKeepCount.ToString(), Width = 80 }.Styled(ControlThemes.ModernTextBox);
             keepRow.Children.Add(keepBox);
             bases.Children.Add(keepRow);
             bases.Children.Add(Hint(LocalizationManager.T("Settings.Ibases.BackupNote")));
@@ -1567,6 +1567,7 @@ namespace Configuration_Management
                 Text = _viewModel.ProfileBackupDirectory,
                 HorizontalAlignment = HorizontalAlignment.Stretch
             };
+            profileDirBox.Styled(ControlThemes.ModernTextBox);
             var profileBrowse = new Button { Content = LocalizationManager.T("Settings.Profile.Browse"), Margin = new Thickness(8, 0, 0, 0) };
             ToolTip.SetTip(profileBrowse, LocalizationManager.T("Settings.Profile.BrowseTooltip"));
             profileBrowse.Click += (_, _) =>

--- a/Configuration Management/Views/SettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/SettingsWindow.Avalonia.cs
@@ -2387,7 +2387,10 @@ namespace Configuration_Management
             var label = new TextBlock { Text = action, VerticalAlignment = VerticalAlignment.Center };
             grid.Children.Add(label);
 
+            // Поле сочетания в разметке идёт тем же стилем, что и обычное поле
+            // ввода (SettingsWindow.xaml:977 и далее).
             var box = new Controls.HotkeyBox { Value = value ?? string.Empty, HorizontalAlignment = HorizontalAlignment.Stretch, Height = 34 };
+            box.Styled(ControlThemes.ModernTextBox);
             Grid.SetColumn(box, 1);
             grid.Children.Add(box);
 

--- a/Configuration Management/Views/TagInputWindow.axaml
+++ b/Configuration Management/Views/TagInputWindow.axaml
@@ -15,7 +15,7 @@
         <TextBlock Grid.Row="0"
                    Text="{loc:Loc TagInput.Prompt}"
                    Margin="0,0,0,8"/>
-        <TextBox Grid.Row="1" x:Name="TagBox" Padding="8,6"/>
+        <TextBox Grid.Row="1" x:Name="TagBox" Theme="{DynamicResource ModernTextBox}"/>
         <!-- Отступ панели кнопок сверху взят из разметки WPF. -->
         <ContentControl Grid.Row="2" x:Name="ButtonsHost" Margin="0,16,0,0"/>
     </Grid>


### PR DESCRIPTION
# Linux/Avalonia: поля ввода, списки и флажки по стилям разметки

> **Зависимость: этот PR идёт после #105 и #106.** Он дописывает тот же словарь
> тем контролов, поэтому ветка нарезана от ветки #106. Пока те не влиты, в дифф
> попадают и их коммиты; после мержа останется только верхний.

## Зачем

Три именованных стиля разметки не были перенесены вовсе, а применяются они шире
всех остальных: `ModernTextBox` в девяти окнах (плюс десять полей окна создания
базы напрямую), `ModernComboBox` и `ModernMaterialCheckBox` вообще неявными
стилями словарей, то есть на всё приложение (`Themes/LightTheme.xaml:413` и `:477`).
В Linux-ветке поля ввода, списки и флажки оставались штатными контролами Fluent:
чужое скругление, чужие цвета наведения и фокуса, синий флажок вместо янтарного
квадрата.

## Что сделано

**Четыре темы контролов** в `Themes/Controls.axaml`: `ModernTextBox`,
`ModernComboBox`, `ModernComboBoxItem`, `ModernMaterialCheckBox`. Значения взяты
из словарей WPF; для этих четырёх стилей светлый и тёмный словари совпадают
дословно, поэтому тема одна.

**Устройство выбрано по обязательным частям шаблона, а не по вкусу.** У `TextBox`
обязательна часть `PART_TextPresenter`, у `ComboBox` обязательна `PART_Popup`:
свой шаблон для них означает повторить обязательную обвязку и сломаться на любом
её изменении. Поэтому обе темы наследуют штатную тему Fluent
(`BasedOn="{StaticResource {x:Type TextBox}}"`) и переопределяют её части по
именам: `Border#PART_BorderElement` у поля, `Border#Background` и
`PathIcon#DropDownGlyph` у списка. У `CheckBox` обязательных частей нет, поэтому
его шаблон повторяет авторский целиком: квадрат 18 со скруглением 3, контур 2,
белая галочка, акцентная заливка при отметке.

**Где применяется.** Список и флажок получают тему по умолчанию во всём
приложении (`Themes/ControlDefaults.axaml`), как это делают неявные стили
словарей WPF. Поле ввода применяется по окнам, где его применяет автор:
настройки подключения, строка подключения, создание базы, параметры запуска,
профили, настройки, ввод имени, ввод тега, ввод ссылки. В главном окне и в окне
выбора группы автор его не применяет, и здесь тоже не применяется.

**Оконные правки поверх стиля сохранены**: свой отступ у окна строки подключения,
свои отступ, высота и кегль у окна подключения, верхнее выравнивание и высота 110
у окна параметров запуска, отступ 6 на 4 у трёх полей окна создания базы.

## Отдельная механика: рамка выпадающего списка

Она живёт в отдельном окне (`PopupRoot`), и селектор части шаблона из темы
`ComboBox` до неё не достаёт. Это проверено прогоном: тема применялась (закрытый
список менял вид), а рамка оставалась штатной. Поэтому её вид задан через
ресурсы, на которые ссылается шаблон Fluent: `ComboBoxDropDownBackground`,
`ComboBoxDropDownBorderBrush` и соседние. Значения те же, что в разметке: фон
карточки, контур темы, внутренний отступ 4.

## Что нашли аудиты и что из этого закрыто

Три встречных аудита дали шесть находок, все закрыты в этом же PR:

* штатная тема перекрашивала поле и список в своих состояниях (наведение, фокус,
  недоступность) системными кистями мимо схемы приложения; в разметке цвет текста
  поля не меняется никогда, а недоступный список гаснет прозрачностью;
* редактируемый список не подсвечивался при вводе: фокус живёт во вложенном поле,
  и одного `:focus` мало, нужен `:focus-within` (в разметке это
  `IsKeyboardFocusWithin`);
* цвет стрелки списка селектором не менялся: значение из шаблона старше значения
  из именованного стиля, поэтому цвет задан ресурсом, а не селектором;
* переопределение общего `OverlayCornerRadius` скругляло заодно подсказки и меню,
  у которых в разметке свои значения; убрано, скругление списка осталось штатным;
* тема поля была пропущена в окне правки группы и у одиннадцати полей сочетаний
  клавиш; поле пароля осталось без своего стиля разметки (`LightTheme.xaml:1121`);
* местные значения заслоняли тему: отступы двух списков окна создания базы,
  высота и кегль списков окна подключения, отступ поля параметров запуска.

## Как проверено

Сборка Linux-цели без ошибок, публикация, прогон в отдельном каталоге данных.
Осмотрены: поля и списки окна подключения (общий фон и скругление, акцентный
контур при фокусе), выпадающий список языка в настройках вместе с раскрытым
списком (рамка, внутренний отступ, скруглённая подсветка выбранного элемента)
и флажки вкладки «Настройки» (янтарный квадрат с белой галочкой).
