### PR TITLE
CREATEINFOBASE: маскирование DBPwd и восстановление SchJobDn

### DIFF
--- a/Configuration Management/Services/OneCLauncher.Arguments.cs
+++ b/Configuration Management/Services/OneCLauncher.Arguments.cs
@@ -378,6 +378,10 @@ public static partial class OneCLauncher
             // к несуществующей. Проверено запуском на PostgreSQL и на MS SQL.
             if (createSqlDatabase)
                 csb.Append(";CrSQLDB=\"Y\"");
+            // SchJobDn действует только в CREATEINFOBASE: он задаёт состояние создаваемой
+            // клиент-серверной базы и не должен попадать в обычную строку подключения.
+            if (blockScheduledJobs)
+                csb.Append(";SchJobDn=\"Y\"");
             connectionString = csb.ToString();
         }
 
@@ -432,8 +436,13 @@ public static partial class OneCLauncher
                 var err = "";
                 try { err = process.StandardError.ReadToEnd(); } catch { /* ignore */ }
                 CleanupCreatedDir(createdDirPath);
-                return (false,
-                    string.Format(LocalizationManager.T("Launcher.CreateExitCodeFormat"), process.ExitCode, err, exePath, arguments));
+                var message = string.Format(
+                    LocalizationManager.T("Launcher.CreateExitCodeFormat"),
+                    process.ExitCode,
+                    err,
+                    exePath,
+                    arguments);
+                return (false, SensitiveDataMasker.MaskDbPassword(message));
             }
 
             return (true, null);
@@ -441,7 +450,12 @@ public static partial class OneCLauncher
         catch (Exception ex)
         {
             CleanupCreatedDir(createdDirPath);
-            return (false, string.Format(LocalizationManager.T("Launcher.CreateCommandErrorFormat"), ex.Message, exePath, arguments));
+            var message = string.Format(
+                LocalizationManager.T("Launcher.CreateCommandErrorFormat"),
+                ex.Message,
+                exePath,
+                arguments);
+            return (false, SensitiveDataMasker.MaskDbPassword(message));
         }
     }
 

--- a/Configuration Management/Services/OneCLauncher.Linux.cs
+++ b/Configuration Management/Services/OneCLauncher.Linux.cs
@@ -1057,6 +1057,10 @@ namespace Configuration_Management.Services
                 // к несуществующей. Проверено запуском на PostgreSQL 8.3.27.
                 if (createSqlDatabase)
                     cs += ";CrSQLDB=\"Y\"";
+                // SchJobDn действует только в CREATEINFOBASE: он задаёт состояние создаваемой
+                // клиент-серверной базы и не должен попадать в обычную строку подключения.
+                if (blockScheduledJobs)
+                    cs += ";SchJobDn=\"Y\"";
                 connectionString = cs;
             }
 
@@ -1114,7 +1118,13 @@ namespace Configuration_Management.Services
                     var err = "";
                     try { err = proc.StandardError.ReadToEnd(); } catch { }
                     CleanupCreatedDir(createdDirPath);
-                    return (false, string.Format(LocalizationManager.T("Launcher.CreateExitCodeFormat"), proc.ExitCode, err, exe, string.Join(" ", args)));
+                    var message = string.Format(
+                        LocalizationManager.T("Launcher.CreateExitCodeFormat"),
+                        proc.ExitCode,
+                        err,
+                        exe,
+                        string.Join(" ", args));
+                    return (false, SensitiveDataMasker.MaskDbPassword(message));
                 }
 
                 return (true, null);
@@ -1122,7 +1132,12 @@ namespace Configuration_Management.Services
             catch (Exception ex)
             {
                 CleanupCreatedDir(createdDirPath);
-                return (false, string.Format(LocalizationManager.T("Launcher.CreateCommandErrorFormat"), ex.Message, exe, string.Join(" ", args)));
+                var message = string.Format(
+                    LocalizationManager.T("Launcher.CreateCommandErrorFormat"),
+                    ex.Message,
+                    exe,
+                    string.Join(" ", args));
+                return (false, SensitiveDataMasker.MaskDbPassword(message));
             }
         }
 

--- a/Configuration Management/Services/SensitiveDataMasker.cs
+++ b/Configuration Management/Services/SensitiveDataMasker.cs
@@ -1,0 +1,27 @@
+using System.Text.RegularExpressions;
+
+namespace Configuration_Management.Services;
+
+/// <summary>Маскирует секреты перед показом диагностического текста пользователю.</summary>
+internal static class SensitiveDataMasker
+{
+    /// <summary>
+    /// Значение DBPwd в строке подключения 1С. Внутренняя кавычка кодируется парой кавычек,
+    /// поэтому пара должна поглощаться целиком, прежде чем одиночная кавычка закроет значение.
+    /// </summary>
+    private static readonly Regex DbPasswordRegex = new(
+        @"(\bDBPwd\s*=\s*"")(?:(?:"""")|[^""])*""",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Скрывает пароль СУБД во всём тексте — как в показанной команде CREATEINFOBASE,
+    /// так и в диагностике платформы, если она повторила строку подключения.
+    /// </summary>
+    internal static string MaskDbPassword(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text;
+
+        return DbPasswordRegex.Replace(text, match => match.Groups[1].Value + "********\"");
+    }
+}


### PR DESCRIPTION
Исправляет два связанных дефекта команды CREATEINFOBASE на Windows/WPF и Linux/Avalonia.

- весь возвращаемый пользователю текст ошибки проходит через общий маскировщик DBPwd; закрывается и показанная команда, и возможное повторение строки подключения в stderr платформы;
- при включённой блокировке фоновых заданий снова добавляется SchJobDn=Y рядом с CrSQLDB=Y;
- восстановление SchJobDn отдельно важно после merge a6eacb8: параметр метода сохранился, а его использование при разрешении параллельных изменений потерялось.

Проверка:
- git diff --check — успешно;
- локальная сборка недоступна: установлен runtime .NET 10 без SDK; обе цели проверит обязательный GitHub Actions CI.

Closes #90
Closes #94