### PR TITLE
Создание ИБ: подстановка версии при смене типа базы

### DIFF
--- a/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
+++ b/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
@@ -421,6 +421,10 @@ namespace Configuration_Management
             var isFile = _typeBox.SelectedIndex != 1;
             _filePanel.IsVisible = isFile;
             _serverPanel.IsVisible = !isFile;
+            // Для двух типов базы хранятся разные последние успешные версии. Окно всегда
+            // открывается с файловым типом, поэтому при смене типа нужно заменить значение
+            // read-only поля, а не оставлять выбранную для файловой базы версию.
+            RefreshPlatformList(replaceSelection: true);
         }
 
         private static Control BuildTemplateRow(object? item)
@@ -621,7 +625,7 @@ namespace Configuration_Management
             }
         }
 
-        private void RefreshPlatformList()
+        private void RefreshPlatformList(bool replaceSelection = false)
         {
             var extras = PlatformVersionService.GetAdditionalSearchPaths();
             var platforms = PlatformVersionService.FindInstalledVersions(extras);
@@ -649,7 +653,7 @@ namespace Configuration_Management
                 }
             }
 
-            if (string.IsNullOrWhiteSpace(_platformBox.Text))
+            if (replaceSelection || string.IsNullOrWhiteSpace(_platformBox.Text))
                 _platformBox.Text = selected;
         }
 

--- a/Configuration Management/Views/CreateInfobaseWindow.xaml.cs
+++ b/Configuration Management/Views/CreateInfobaseWindow.xaml.cs
@@ -84,7 +84,7 @@ namespace Configuration_Management
             }
         }
 
-        private void RefreshPlatformList()
+        private void RefreshPlatformList(bool replaceSelection = false)
         {
             var extras = PlatformVersionService.GetAdditionalSearchPaths();
             _platforms = PlatformVersionService.FindInstalledVersions(extras);
@@ -112,7 +112,7 @@ namespace Configuration_Management
                 }
             }
 
-            if (string.IsNullOrWhiteSpace(PlatformBox.Text))
+            if (replaceSelection || string.IsNullOrWhiteSpace(PlatformBox.Text))
                 PlatformBox.Text = selected;
         }
 
@@ -214,6 +214,11 @@ namespace Configuration_Management
                 FilePanel.Visibility = isFile ? Visibility.Visible : Visibility.Collapsed;
             if (ServerPanel != null)
                 ServerPanel.Visibility = isFile ? Visibility.Collapsed : Visibility.Visible;
+            // Для двух типов базы хранятся разные последние успешные версии. Окно всегда
+            // открывается с файловым типом, поэтому без пересчёта здесь серверная версия
+            // никогда не попадала в read-only поле при переключении на клиент-серверную базу.
+            if (PlatformBox != null)
+                RefreshPlatformList(replaceSelection: true);
         }
 
         private void OnPickPlatform_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Поле версии в окне создания ИБ read-only, а окно всегда открывается с файловым типом. До этой правки переключение на клиент-серверный тип меняло только видимость панелей: сохранённая LastClientServerCreatePlatformVersion не читалась, и в поле оставалась файловая версия (или самая новая).

Теперь при каждом переключении типа список платформ пересчитывает выбранное значение принудительно:

- для файловой базы подставляется LastFileCreatePlatformVersion;
- для клиент-серверной — LastClientServerCreatePlatformVersion;
- если сохранённая версия не установлена, остаётся прежний fallback на самую новую.

Правка симметрична для Windows/WPF и Linux/Avalonia.

Проверка: git diff --check — успешно. Локальная компиляция недоступна из-за отсутствующего .NET SDK; обе цели проверит обязательный CI.

Closes #91