### PR TITLE
fix: preserve platform selection when switching infobase type

### DIFF
--- a/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
+++ b/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
@@ -71,6 +71,9 @@ namespace Configuration_Management
         private int _templateLoadGeneration;
         private bool _closed;
         private List<OneCTemplateService.TemplateInfo> _flatTemplates = new();
+        private bool _platformSelectionIsFile = true;
+        private string? _filePlatformSelection;
+        private string? _clientServerPlatformSelection;
 
         /// <summary>Доступные значения СУБД для клиент-серверного создания.</summary>
         private static readonly string[] DbmsValues =
@@ -120,6 +123,7 @@ namespace Configuration_Management
 
             Content = BuildRoot();
             RefreshPlatformList();
+            RememberPlatformSelection(true, _platformBox.Text);
             if (_fromTemplate)
                 LoadInstalledTemplates();
         }
@@ -421,10 +425,14 @@ namespace Configuration_Management
             var isFile = _typeBox.SelectedIndex != 1;
             _filePanel.IsVisible = isFile;
             _serverPanel.IsVisible = !isFile;
-            // Для двух типов базы хранятся разные последние успешные версии. Окно всегда
-            // открывается с файловым типом, поэтому при смене типа нужно заменить значение
-            // read-only поля, а не оставлять выбранную для файловой базы версию.
-            RefreshPlatformList(replaceSelection: true);
+            // В пределах открытого окна ручной выбор хранится отдельно для каждого типа.
+            // При первом переходе используется последняя успешная версия из настроек.
+            RememberPlatformSelection(_platformSelectionIsFile, _platformBox.Text);
+            _platformSelectionIsFile = isFile;
+            RefreshPlatformList(
+                replaceSelection: true,
+                preferredSelection: GetPlatformSelection(isFile));
+            RememberPlatformSelection(isFile, _platformBox.Text);
         }
 
         private static Control BuildTemplateRow(object? item)
@@ -625,7 +633,7 @@ namespace Configuration_Management
             }
         }
 
-        private void RefreshPlatformList(bool replaceSelection = false)
+        private void RefreshPlatformList(bool replaceSelection = false, string? preferredSelection = null)
         {
             var extras = PlatformVersionService.GetAdditionalSearchPaths();
             var platforms = PlatformVersionService.FindInstalledVersions(extras);
@@ -633,28 +641,58 @@ namespace Configuration_Management
                 platforms = _platformVersions.ToList();
 
             if (platforms.Count == 0)
+            {
+                if (replaceSelection)
+                    _platformBox.Text = string.Empty;
                 return;
+            }
+
+            if (string.IsNullOrWhiteSpace(preferredSelection))
+                preferredSelection = GetPlatformSelection(_typeBox.SelectedIndex != 1);
 
             // По умолчанию подставляем последнюю успешно использованную версию для текущего
             // типа базы (файловая/клиент-серверная), если она всё ещё установлена. Иначе — самую новую.
             string selected = platforms[0];
-            var saved = GetSavedPlatformVersion();
-            if (!string.IsNullOrWhiteSpace(saved))
+            var preferred = platforms.FirstOrDefault(p =>
+                string.Equals(p, preferredSelection, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrWhiteSpace(preferred))
             {
-                foreach (var p in platforms)
+                selected = preferred;
+            }
+            else
+            {
+                var saved = GetSavedPlatformVersion();
+                if (!string.IsNullOrWhiteSpace(saved))
                 {
-                    PlatformVersionService.ParseVariant(p, out var clean, out _);
-                    var candidate = string.IsNullOrWhiteSpace(clean) ? p : clean;
-                    if (string.Equals(candidate, saved, StringComparison.OrdinalIgnoreCase))
+                    foreach (var p in platforms)
                     {
-                        selected = p;
-                        break;
+                        PlatformVersionService.ParseVariant(p, out var clean, out _);
+                        var candidate = string.IsNullOrWhiteSpace(clean) ? p : clean;
+                        if (string.Equals(candidate, saved, StringComparison.OrdinalIgnoreCase))
+                        {
+                            selected = p;
+                            break;
+                        }
                     }
                 }
             }
 
             if (replaceSelection || string.IsNullOrWhiteSpace(_platformBox.Text))
                 _platformBox.Text = selected;
+        }
+
+        private string? GetPlatformSelection(bool isFile) =>
+            isFile ? _filePlatformSelection : _clientServerPlatformSelection;
+
+        private void RememberPlatformSelection(bool isFile, string? platform)
+        {
+            if (string.IsNullOrWhiteSpace(platform))
+                return;
+
+            if (isFile)
+                _filePlatformSelection = platform;
+            else
+                _clientServerPlatformSelection = platform;
         }
 
         /// <summary>
@@ -756,7 +794,10 @@ namespace Configuration_Management
 
             var dlg = new PlatformVersionPickerWindow(platforms, _platformBox.Text ?? "");
             if (dlg.ShowDialogSync(this) && !string.IsNullOrWhiteSpace(dlg.Result))
+            {
                 _platformBox.Text = dlg.Result;
+                RememberPlatformSelection(_typeBox.SelectedIndex != 1, dlg.Result);
+            }
         }
 
         private void OnBrowseFolder_Click()

--- a/Configuration Management/Views/CreateInfobaseWindow.xaml.cs
+++ b/Configuration Management/Views/CreateInfobaseWindow.xaml.cs
@@ -34,11 +34,11 @@ namespace Configuration_Management
             string defaultGroupPath = "",
             IEnumerable<Group>? groups = null)
         {
-            InitializeComponent();
             _fromTemplate = fromTemplate;
             _platformVersions = platformVersions?.ToList() ?? new List<string>();
             _groups = groups?.ToList() ?? new List<Group>();
             _selectedGroupPath = defaultGroupPath ?? string.Empty;
+            InitializeComponent();
 
             Title = fromTemplate
                 ? LocalizationManager.T("CreateInfobase.TitleFromTemplate")
@@ -54,12 +54,16 @@ namespace Configuration_Management
                 : LocalizationManager.T("CreateInfobase.HintEmpty");
 
             RefreshPlatformList();
+            RememberPlatformSelection(true, PlatformBox.Text);
 
             if (fromTemplate)
                 LoadInstalledTemplates();
         }
 
         private List<string> _platforms = new();
+        private bool _platformSelectionIsFile = true;
+        private string? _filePlatformSelection;
+        private string? _clientServerPlatformSelection;
 
         
         private void OnPickGroup_Click(object sender, RoutedEventArgs e)
@@ -84,7 +88,7 @@ namespace Configuration_Management
             }
         }
 
-        private void RefreshPlatformList(bool replaceSelection = false)
+        private void RefreshPlatformList(bool replaceSelection = false, string? preferredSelection = null)
         {
             var extras = PlatformVersionService.GetAdditionalSearchPaths();
             _platforms = PlatformVersionService.FindInstalledVersions(extras);
@@ -92,28 +96,58 @@ namespace Configuration_Management
                 _platforms = _platformVersions.ToList();
 
             if (_platforms.Count == 0)
+            {
+                if (replaceSelection)
+                    PlatformBox.Text = string.Empty;
                 return;
+            }
+
+            if (string.IsNullOrWhiteSpace(preferredSelection))
+                preferredSelection = GetPlatformSelection(TypeBox.SelectedIndex != 1);
 
             // По умолчанию подставляем последнюю успешно использованную версию для текущего
             // типа базы (файловая/клиент-серверная), если она всё ещё установлена. Иначе — самую новую.
             string selected = _platforms[0];
-            var saved = GetSavedPlatformVersion();
-            if (!string.IsNullOrWhiteSpace(saved))
+            var preferred = _platforms.FirstOrDefault(p =>
+                string.Equals(p, preferredSelection, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrWhiteSpace(preferred))
             {
-                foreach (var p in _platforms)
+                selected = preferred;
+            }
+            else
+            {
+                var saved = GetSavedPlatformVersion();
+                if (!string.IsNullOrWhiteSpace(saved))
                 {
-                    PlatformVersionService.ParseVariant(p, out var clean, out _);
-                    var candidate = string.IsNullOrWhiteSpace(clean) ? p : clean;
-                    if (string.Equals(candidate, saved, StringComparison.OrdinalIgnoreCase))
+                    foreach (var p in _platforms)
                     {
-                        selected = p;
-                        break;
+                        PlatformVersionService.ParseVariant(p, out var clean, out _);
+                        var candidate = string.IsNullOrWhiteSpace(clean) ? p : clean;
+                        if (string.Equals(candidate, saved, StringComparison.OrdinalIgnoreCase))
+                        {
+                            selected = p;
+                            break;
+                        }
                     }
                 }
             }
 
             if (replaceSelection || string.IsNullOrWhiteSpace(PlatformBox.Text))
                 PlatformBox.Text = selected;
+        }
+
+        private string? GetPlatformSelection(bool isFile) =>
+            isFile ? _filePlatformSelection : _clientServerPlatformSelection;
+
+        private void RememberPlatformSelection(bool isFile, string? platform)
+        {
+            if (string.IsNullOrWhiteSpace(platform))
+                return;
+
+            if (isFile)
+                _filePlatformSelection = platform;
+            else
+                _clientServerPlatformSelection = platform;
         }
 
         /// <summary>
@@ -214,11 +248,17 @@ namespace Configuration_Management
                 FilePanel.Visibility = isFile ? Visibility.Visible : Visibility.Collapsed;
             if (ServerPanel != null)
                 ServerPanel.Visibility = isFile ? Visibility.Collapsed : Visibility.Visible;
-            // Для двух типов базы хранятся разные последние успешные версии. Окно всегда
-            // открывается с файловым типом, поэтому без пересчёта здесь серверная версия
-            // никогда не попадала в read-only поле при переключении на клиент-серверную базу.
+            // В пределах открытого окна ручной выбор хранится отдельно для каждого типа.
+            // При первом переходе используется последняя успешная версия из настроек.
             if (PlatformBox != null)
-                RefreshPlatformList(replaceSelection: true);
+            {
+                RememberPlatformSelection(_platformSelectionIsFile, PlatformBox.Text);
+                _platformSelectionIsFile = isFile;
+                RefreshPlatformList(
+                    replaceSelection: true,
+                    preferredSelection: GetPlatformSelection(isFile));
+                RememberPlatformSelection(isFile, PlatformBox.Text);
+            }
         }
 
         private void OnPickPlatform_Click(object sender, RoutedEventArgs e)
@@ -229,7 +269,10 @@ namespace Configuration_Management
                 Owner = this
             };
             if (dlg.ShowDialog() == true && !string.IsNullOrWhiteSpace(dlg.Result))
+            {
                 PlatformBox.Text = dlg.Result;
+                RememberPlatformSelection(TypeBox.SelectedIndex != 1, dlg.Result);
+            }
         }
 
         private void OnEditPlatformPaths_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Что исправлено

Follow-up к #109 / #91 после независимого аудита.

- ручной выбор версии платформы хранится отдельно для файловой и клиент-серверной базы в пределах открытого окна;
- при первом переходе по-прежнему используется последняя успешно применённая версия соответствующего типа;
- выбор восстанавливается после переключений типа и после временно пустого списка платформ;
- WPF и Avalonia реализуют одинаковое поведение;
- входные данные WPF инициализируются до `InitializeComponent`, чтобы ранний `SelectionChanged` был безопасен.

## Проверка

- сценарии file A → server B → file A и обратный переход: PASS;
- восстановление выбора после пустого списка: PASS;
- `git diff --check`: PASS;
- независимый read-only аудит моделями GPT-5.6 Sol, GPT-5.6 Terra, GPT-5.6 Luna, GPT-5.5 и GPT-5.4: findings нет после исправления найденного edge case.

Локальную сборку не запускал: в окружении установлены .NET runtimes, но отсутствует .NET SDK. Поэтому PR оставлен draft до результата CI.