### PR TITLE
Linux/Avalonia: меню, значковые кнопки и меню трея главного окна

### DIFF
--- a/Configuration Management/Themes/ControlThemes.Avalonia.cs
+++ b/Configuration Management/Themes/ControlThemes.Avalonia.cs
@@ -45,6 +45,12 @@ namespace Configuration_Management.Themes
         /// <summary>Переключатель настроек: дорожка 40 на 22 с кружком 16.</summary>
         public const string SettingsToggle = "SettingsToggle";
 
+        /// <summary>Всплывающее меню: карточный фон, контур, минимальная ширина 280.</summary>
+        public const string ModernContextMenu = "ModernContextMenu";
+
+        /// <summary>Пункт меню: отступ 12 на 6, скругление 4, подсветка выделенного.</summary>
+        public const string ModernMenuItem = "ModernMenuItem";
+
         /// <summary>Значковая кнопка: прозрачный фон, скругление 8, подсветка при наведении.</summary>
         public const string IconButton = "IconButton";
 

--- a/Configuration Management/Themes/ControlThemes.Avalonia.cs
+++ b/Configuration Management/Themes/ControlThemes.Avalonia.cs
@@ -45,6 +45,15 @@ namespace Configuration_Management.Themes
         /// <summary>Переключатель настроек: дорожка 40 на 22 с кружком 16.</summary>
         public const string SettingsToggle = "SettingsToggle";
 
+        /// <summary>Значковая кнопка: прозрачный фон, скругление 8, подсветка при наведении.</summary>
+        public const string IconButton = "IconButton";
+
+        /// <summary>Значковая кнопка заголовка: скругление 6, своё нажатие и гашение.</summary>
+        public const string HeaderIconButton = "HeaderIconButton";
+
+        /// <summary>Значковая кнопка строки состояния: отступ 6 на 4, подсветка боковой панели.</summary>
+        public const string StatusBarIconButton = "StatusBarIconButton";
+
         /// <summary>Плитка выбора значка группы: тёмная в обеих темах, как у автора.</summary>
         public const string IconPickButton = "IconPickButton";
 

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -20,6 +20,9 @@
             <SolidColorBrush x:Key="SecondaryButtonPressedSurfaceBrush" Color="{DynamicResource SecondaryButtonPressedColor}"/>
             <Thickness x:Key="SecondaryButtonOutlineThickness">0</Thickness>
             <SolidColorBrush x:Key="SettingsToggleTrackBrush">#CBD5E1</SolidColorBrush>
+            <SolidColorBrush x:Key="IconButtonHoverBrush">#F1F5F9</SolidColorBrush>
+            <SolidColorBrush x:Key="StatusBarIconPressedBrush">#0F172A</SolidColorBrush>
+            <x:Double x:Key="StatusBarIconPressedOpacity">1</x:Double>
         </ResourceDictionary>
         <!-- Тёмная: вторичная кнопка это карточка в контуре, при наведении контур акцентный. -->
         <ResourceDictionary x:Key="Dark">
@@ -31,6 +34,9 @@
             <SolidColorBrush x:Key="SecondaryButtonPressedSurfaceBrush" Color="{DynamicResource SidebarHoverColor}"/>
             <Thickness x:Key="SecondaryButtonOutlineThickness">1</Thickness>
             <SolidColorBrush x:Key="SettingsToggleTrackBrush">#475569</SolidColorBrush>
+            <SolidColorBrush x:Key="IconButtonHoverBrush" Color="{DynamicResource ItemHoverColor}"/>
+            <SolidColorBrush x:Key="StatusBarIconPressedBrush" Color="{DynamicResource SidebarHoverColor}"/>
+            <x:Double x:Key="StatusBarIconPressedOpacity">0.85</x:Double>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
@@ -754,6 +760,103 @@
         <Style Selector="^:pointerover /template/ Border#PART_Surface">
             <Setter Property="Background" Value="#4B5563"/>
             <Setter Property="BorderBrush" Value="#9CA3AF"/>
+        </Style>
+    </ControlTheme>
+    <!-- ===================== Значковые кнопки =====================
+         Стили IconButton (LightTheme.xaml:561, DarkTheme.xaml:1105),
+         HeaderIconButton (:586 и :1130) и StatusBarIconButton (:616 и :1160).
+         Различие тем у первой одно: в светлой наведение задано числом #F1F5F9,
+         в тёмной берётся ItemHoverBrush, поэтому кисть вынесена в словари темы.
+         Триггера недоступности у IconButton в разметке нет вовсе. -->
+    <ControlTheme x:Key="IconButton" TargetType="Button">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="8"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        BorderThickness="0"
+                        CornerRadius="8"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource IconButtonHoverBrush}"/>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="HeaderIconButton" TargetType="Button" BasedOn="{StaticResource IconButton}">
+        <Setter Property="Padding" Value="5"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        BorderThickness="0"
+                        CornerRadius="6"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+        </Style>
+        <Style Selector="^:pressed /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource SecondaryButtonHoverBrush}"/>
+        </Style>
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value="0.4"/>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="StatusBarIconButton" TargetType="Button" BasedOn="{StaticResource IconButton}">
+        <Setter Property="Padding" Value="6,4"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        BorderThickness="0"
+                        CornerRadius="6"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource SidebarHoverBrush}"/>
+        </Style>
+        <!-- Нажатие у автора различается темами: в светлой это заливка числом,
+             в тёмной прозрачность 0.85 (LightTheme.xaml:634, DarkTheme.xaml:1178). -->
+        <Style Selector="^:pressed /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource StatusBarIconPressedBrush}"/>
+        </Style>
+        <Style Selector="^:pressed">
+            <Setter Property="Opacity" Value="{DynamicResource StatusBarIconPressedOpacity}"/>
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -859,4 +859,53 @@
             <Setter Property="Opacity" Value="{DynamicResource StatusBarIconPressedOpacity}"/>
         </Style>
     </ControlTheme>
+    <!-- Ресурсы штатной темы, которыми она красит всплывающее меню и колонку
+         значка. Через ресурсы, а не селектором: подменю живёт в своём Popup,
+         и его рамка получает значения прямо из шаблона. Числа из разметки
+         (LightTheme.xaml:817 и :742): фон карточки, контур темы, толщина 1,
+         внутренний отступ 4, зазор после значка 8 вместо штатных 12. -->
+    <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="{DynamicResource CardBackgroundColor}"/>
+    <SolidColorBrush x:Key="MenuFlyoutPresenterBorderBrush" Color="{DynamicResource BorderColor}"/>
+    <Thickness x:Key="MenuFlyoutPresenterBorderThemeThickness">1</Thickness>
+    <Thickness x:Key="MenuFlyoutPresenterThemePadding">4</Thickness>
+    <Thickness x:Key="MenuIconPresenterMargin">0,0,8,0</Thickness>
+
+    <!-- ===================== Меню =====================
+         Стили ModernContextMenu (LightTheme.xaml:817) и ModernMenuItem (:742);
+         в тёмной теме оба дословно те же. Темы наследуют штатные: у MenuItem
+         обязательна часть PART_Popup, без неё не открывается подменю, а у
+         ContextMenu нужен ItemsPresenter, иначе пункты не показываются.
+         Подсветка пункта идёт по :selected, а не по :pointerover: именно так
+         обработчик меню помечает пункт под указателем, и так же устроена
+         штатная тема. -->
+    <ControlTheme x:Key="ModernContextMenu" TargetType="ContextMenu" BasedOn="{StaticResource {x:Type ContextMenu}}">
+        <Setter Property="MinWidth" Value="280"/>
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushColor}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Padding" Value="4"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <!-- Аналог HasDropShadow разметки: подсказка оконному менеджеру. -->
+        <Setter Property="WindowManagerAddShadowHint" Value="True"/>
+    </ControlTheme>
+
+    <ControlTheme x:Key="ModernMenuItem" TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="Padding" Value="12,6"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="CornerRadius" Value="4"/>
+        <Setter Property="Margin" Value="2,1"/>
+
+        <Style Selector="^:selected /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+        </Style>
+        <Style Selector="^:selected">
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        </Style>
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value="0.5"/>
+        </Style>
+    </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -898,14 +898,26 @@
         <Setter Property="CornerRadius" Value="4"/>
         <Setter Property="Margin" Value="2,1"/>
 
+        <!-- Цвет подписи штатная тема меняет не на контроле, а на части шаблона,
+             поэтому и здесь красится часть: у автора подсветка меняет только фон
+             (LightTheme.xaml:804), цвет текста остаётся прежним. -->
         <Style Selector="^:selected /template/ Border#PART_LayoutRoot">
             <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
         </Style>
-        <Style Selector="^:selected">
+        <Style Selector="^:selected /template/ ContentPresenter#PART_HeaderPresenter">
             <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
         </Style>
+        <!-- Недоступный пункт у автора только гаснет прозрачностью
+             (LightTheme.xaml:807), фон и цвет текста не меняются, поэтому
+             перекраска штатной темы снимается. -->
         <Style Selector="^:disabled">
             <Setter Property="Opacity" Value="0.5"/>
+        </Style>
+        <Style Selector="^:disabled /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="Transparent"/>
+        </Style>
+        <Style Selector="^:disabled /template/ ContentPresenter#PART_HeaderPresenter">
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
+++ b/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
@@ -1719,6 +1719,36 @@ public class MainViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Запуск базы из меню трея: прямо по ссылке, не трогая выделение в списке.
+    /// В Windows-версии это делает LaunchInfobaseById (MainViewModel.Commands.cs:544),
+    /// и она тоже не меняет SelectedInfobase: иначе запуск из трея переставлял бы
+    /// выделение, правую панель и строку состояния. Источник записи в истории
+    /// тот же, что у автора.
+    /// </summary>
+    public void LaunchFromTray(Infobase ib, bool configurator)
+    {
+        if (!_allInfobases.Contains(ib))
+            return;
+
+        var ok = configurator
+            ? _launcher.Launch(ib, Services.OneCLaunchMode.Configurator)
+            : _launcher.Launch(ib, Services.OneCLaunchMode.Enterprise);
+
+        if (ok)
+        {
+            ib.AddLaunchHistory(configurator ? "Configurator" : "Enterprise", "tray");
+            SaveSilently();
+            OnPropertyChanged(nameof(RecentInfobases));
+            _logger.Info($"[tray] Запущена «{ib.Name}» ({(configurator ? "Конфигуратор" : "Предприятие")})");
+            NotifyAfterLaunch();
+        }
+        else
+        {
+            _logger.Warn($"[tray] Не удалось запустить «{ib.Name}»");
+        }
+    }
+
     private void OnLaunched()
     {
         if (SelectedInfobase is not null)

--- a/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
+++ b/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
@@ -3763,12 +3763,15 @@ public class MainViewModel : ViewModelBase
 
     // ======================= Этап 6: папки / ярлыки / стартер =======================
 
-    /// <summary>Недавно запускавшиеся базы (для меню трея). До 8 по дате запуска.</summary>
+    /// <summary>
+    /// Недавно запускавшиеся базы (для меню трея). До семи по дате запуска,
+    /// как в Windows-версии (MainWindow.Tray.cs:216 запрашивает семь).
+    /// </summary>
     public List<Infobase> RecentInfobases =>
         _allInfobases
             .Where(ib => ib.LastLaunchDate.HasValue)
             .OrderByDescending(ib => ib.LastLaunchDate)
-            .Take(8)
+            .Take(7)
             .ToList();
 
     /// <summary>Все информационные базы (для диалога выбора при очистке кеша).</summary>

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -4805,41 +4805,32 @@ namespace Configuration_Management
         {
             menu.Items.Clear();
 
-            var showItem = new NativeMenuItem(LocalizationManager.T("Main.ShowWindow"));
+            // Состав и порядок как в Windows-версии (MainWindow.Tray.cs:209):
+            // открыть, недавние базы (или выбранная, если недавних нет),
+            // синхронизация, настройки, выход. У каждой базы своё подменю
+            // «Предприятие / Конфигуратор»: раньше пункт запускал только
+            // Предприятие, а выбора не было.
+            var showItem = new NativeMenuItem(LocalizationManager.T("Main.TrayOpen"));
             showItem.Click += (_, _) => ShowAndActivate();
             menu.Add(showItem);
-            menu.Add(new NativeMenuItemSeparator());
 
-            // Недавние базы (быстрый запуск прямо из трея).
             var recent = _vm?.RecentInfobases;
             if (recent is { Count: > 0 })
             {
-                var recentMenu = new NativeMenu();
+                menu.Add(new NativeMenuItemSeparator());
+                menu.Add(TrayHeader(LocalizationManager.T("Main.RecentBases")));
                 foreach (var ib in recent)
-                {
-                    var item = new NativeMenuItem($"{ib.Name}  ({ib.ServerDatabaseDisplay})");
-                    var baseRef = ib;
-                    item.Click += (_, _) => LaunchInfobase(baseRef);
-                    recentMenu.Add(item);
-                }
-                menu.Add(new NativeMenuItem(LocalizationManager.T("Main.RecentBases")) { Menu = recentMenu });
-                menu.Add(new NativeMenuItemSeparator());
+                    menu.Add(TrayInfobaseItem(ib, TrayItemName(ib.Name, "Main.NoName")));
             }
-
-            // Запуск выбранной базы: Предприятие / Конфигуратор.
-            if (_vm?.SelectedInfobase is { } sel)
+            else if (_vm?.SelectedInfobase is { } sel)
             {
-                var ent = new NativeMenuItem($"{LocalizationManager.T("Main.LaunchEnterprise")}: {sel.Name}");
-                ent.Click += (_, _) => _vm.LaunchEnterpriseCommand.Execute(null);
-                menu.Add(ent);
-
-                var cfg = new NativeMenuItem($"{LocalizationManager.T("Main.LaunchConfigurator")}: {sel.Name}");
-                cfg.Click += (_, _) => _vm.LaunchConfiguratorCommand.Execute(null);
-                menu.Add(cfg);
                 menu.Add(new NativeMenuItemSeparator());
+                menu.Add(TrayHeader(LocalizationManager.T("Main.SelectedBase")));
+                menu.Add(TrayInfobaseItem(sel, TrayItemName(sel.Name, "Main.SelectedBaseNoName")));
             }
 
-            // Синхронизация и настройки.
+            menu.Add(new NativeMenuItemSeparator());
+
             var sync = new NativeMenuItem(LocalizationManager.T("Main.SyncWithIbases"));
             sync.Click += (_, _) => _vm?.SynchronizeWithIbasesCommand.Execute(null);
             menu.Add(sync);
@@ -4857,6 +4848,49 @@ namespace Configuration_Management
                 _vm?.ExitCommand.Execute(null);
             };
             menu.Add(exitItem);
+        }
+
+        /// <summary>
+        /// Заголовок раздела в меню трея. В Windows это отдельный нерабочий
+        /// пункт (MainWindow.Tray.cs:216), здесь он же, но недоступный:
+        /// собственного вида у заголовка в системном меню нет.
+        /// </summary>
+        private static NativeMenuItem TrayHeader(string text) => new(text) { IsEnabled = false };
+
+        /// <summary>
+        /// Подпись базы в меню трея: пустое имя заменяется на подпись автора,
+        /// длинное обрезается до 48 знаков, как в Windows-версии
+        /// (MainWindow.Tray.cs:224).
+        /// </summary>
+        private static string TrayItemName(string? name, string emptyKey)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return LocalizationManager.T(emptyKey);
+            return name.Length > 48 ? name.Substring(0, 45) + "…" : name;
+        }
+
+        /// <summary>
+        /// Пункт базы с подменю выбора режима запуска: сам пункт запускает
+        /// Предприятие, подменю даёт Предприятие и Конфигуратор
+        /// (MainWindow.Tray.cs:271).
+        /// </summary>
+        private NativeMenuItem TrayInfobaseItem(Infobase ib, string title)
+        {
+            var baseRef = ib;
+            var item = new NativeMenuItem(title);
+            item.Click += (_, _) => LaunchInfobase(baseRef, configurator: false);
+
+            var submenu = new NativeMenu();
+            var enterprise = new NativeMenuItem(LocalizationManager.T("Main.Enterprise"));
+            enterprise.Click += (_, _) => LaunchInfobase(baseRef, configurator: false);
+            submenu.Add(enterprise);
+
+            var configurator = new NativeMenuItem(LocalizationManager.T("Main.SectionConfigurator"));
+            configurator.Click += (_, _) => LaunchInfobase(baseRef, configurator: true);
+            submenu.Add(configurator);
+
+            item.Menu = submenu;
+            return item;
         }
 
         private void SetupTray()
@@ -4899,7 +4933,7 @@ namespace Configuration_Management
         }
 
         /// <summary>Запускает базу из меню трея (Предприятие).</summary>
-        private void LaunchInfobase(Infobase ib)
+        private void LaunchInfobase(Infobase ib, bool configurator = false)
         {
             if (_vm is null)
                 return;
@@ -4911,7 +4945,10 @@ namespace Configuration_Management
                 return;
             }
             _vm.SelectedInfobase = ib;
-            _vm.LaunchEnterpriseCommand.Execute(null);
+            if (configurator)
+                _vm.LaunchConfiguratorCommand.Execute(null);
+            else
+                _vm.LaunchEnterpriseCommand.Execute(null);
         }
 
         /// <summary>

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -326,17 +326,14 @@ namespace Configuration_Management
 
             // Проверить доступность всех баз 1С: ручная команда вместо автопроверки при запуске.
             // Иконка — зелёный гидролокатор (сонар), как экран на подводных лодках.
-            var checkAvailBtn = new PanelButton(
-                "",
-                "ItemHoverBrush",
-                "SecondaryButtonPressedBrush",
-                "")
+            var checkAvailBtn = new Button
             {
                 Content = IconHelper.MakeIcon("IconSonar", UiMetrics.Scaled(18),
                     new SolidColorBrush(Color.Parse("#14B8A6"))),
-                Padding = new Thickness(UiMetrics.ButtonPadH, UiMetrics.ButtonPadV),
+                Padding = new Thickness(UiMetrics.Scaled(8)),
                 HorizontalContentAlignment = HorizontalAlignment.Center
             };
+            checkAvailBtn.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(checkAvailBtn, LocalizationManager.T("Main.CheckAvailabilityTooltip"));
             checkAvailBtn.Bind(Button.CommandProperty, new Binding("CheckAvailabilityCommand"));
             // Проверка доступности стоит между синхронизацией и темой, как у автора.
@@ -1174,7 +1171,6 @@ namespace Configuration_Management
                 Content = colorHex is not null
                     ? IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), new SolidColorBrush(Color.Parse(colorHex)))
                     : IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), brushKey ?? "TextSecondaryBrush"),
-                Padding = new Thickness(4),
                 Margin = new Thickness(1, 0),
                 MinWidth = 0,
                 MinHeight = 0,
@@ -1798,22 +1794,22 @@ namespace Configuration_Management
                     new SolidColorBrush(Color.Parse(colorHex)));
             }
 
-            // Не штатный Button: тема Fluent красит не саму кнопку, а её внутренний
-            // ContentPresenter через :pointerover, и локальный прозрачный Background
-            // этот фон не перебивает. Подсветка наведения оставалась висеть, когда
-            // строка пересобиралась под курсором, и фон то появлялся, то пропадал.
-            var button = new PanelButton("", "ItemHoverBrush", "SecondaryButtonPressedBrush", "",
-                new CornerRadius(UiMetrics.RadiusSm))
+            // Оформление берёт тема IconButton разметки: у автора все пять команд
+            // строки идут этим стилем с полем 1,0 (MainWindow.xaml:1282).
+            // Своя кнопка была нужна, пока темы не было: штатная тема Fluent красит
+            // не саму кнопку, а её внутренний ContentPresenter, и локальный
+            // прозрачный фон её не перебивал.
+            var button = new Button
             {
                 Content = glyph,
-                BorderThickness = new Thickness(0),
-                Padding = new Thickness(4),
+                Margin = new Thickness(1, 0),
                 MinWidth = 0,
                 MinHeight = 0,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
                 CommandParameter = ib
             };
+            button.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(button, tooltip);
             // Команда живёт во вьюмодели, а контекстом строки служит сама база.
             button.Bind(Button.CommandProperty, new Binding(commandPath) { Source = _vm });
@@ -4826,7 +4822,13 @@ namespace Configuration_Management
             {
                 menu.Add(new NativeMenuItemSeparator());
                 menu.Add(TrayHeader(LocalizationManager.T("Main.SelectedBase")));
-                menu.Add(TrayInfobaseItem(sel, TrayItemName(sel.Name, "Main.SelectedBaseNoName")));
+                // У выбранной базы сам пункт ничего не запускает, только раскрывает
+                // подменю, и её имя не обрезается: так у автора
+                // (MainWindow.Tray.cs:240).
+                var selName = string.IsNullOrWhiteSpace(sel.Name)
+                    ? LocalizationManager.T("Main.SelectedBaseNoName")
+                    : sel.Name;
+                menu.Add(TrayInfobaseItem(sel, selName, launchOnClick: false));
             }
 
             menu.Add(new NativeMenuItemSeparator());
@@ -4874,11 +4876,12 @@ namespace Configuration_Management
         /// Предприятие, подменю даёт Предприятие и Конфигуратор
         /// (MainWindow.Tray.cs:271).
         /// </summary>
-        private NativeMenuItem TrayInfobaseItem(Infobase ib, string title)
+        private NativeMenuItem TrayInfobaseItem(Infobase ib, string title, bool launchOnClick = true)
         {
             var baseRef = ib;
             var item = new NativeMenuItem(title);
-            item.Click += (_, _) => LaunchInfobase(baseRef, configurator: false);
+            if (launchOnClick)
+                item.Click += (_, _) => LaunchInfobase(baseRef, configurator: false);
 
             var submenu = new NativeMenu();
             var enterprise = new NativeMenuItem(LocalizationManager.T("Main.Enterprise"));
@@ -4944,11 +4947,7 @@ namespace Configuration_Management
                 QueueTrayMenuRefresh();
                 return;
             }
-            _vm.SelectedInfobase = ib;
-            if (configurator)
-                _vm.LaunchConfiguratorCommand.Execute(null);
-            else
-                _vm.LaunchEnterpriseCommand.Execute(null);
+            _vm.LaunchFromTray(ib, configurator);
         }
 
         /// <summary>

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -592,7 +592,7 @@ namespace Configuration_Management
         /// Явный цвет значка, как в разметке WPF: там часть команд верхней панели
         /// покрашена вручную, а часть берёт цвет из темы. Без него берётся тема.
         /// </param>
-        private static PanelButton TopBarIconButton(string iconKey, string tooltip, string? colorHex = null,
+        private static Button TopBarIconButton(string iconKey, string tooltip, string? colorHex = null,
             string themeBrushKey = "ButtonTextBrush")
         {
             Control icon;
@@ -606,21 +606,19 @@ namespace Configuration_Management
                     new SolidColorBrush(Color.Parse(colorHex)));
             }
 
-            // Плоская кнопка: у автора значковые команды верхней панели без
-            // подложки и рамки, подсветка появляется только при наведении.
-            // Подсветка наведения из ItemHover, а не из кремовой кисти вторичной
-            // кнопки: в тёмной теме та светлая, и значок на ней пропадал.
-            var button = new PanelButton(
-                "",
-                "ItemHoverBrush",
-                "SecondaryButtonPressedBrush",
-                "",
-                new CornerRadius(8))
+            // Оформление берёт тема IconButton разметки (LightTheme.xaml:561
+            // и DarkTheme.xaml:1105): прозрачный фон, скругление 8, отступ 8,
+            // подсветка только при наведении. Своя реализация красила наведение
+            // кистью ItemHover в обеих темах, тогда как в светлой у автора это
+            // серый #F1F5F9, и гасила недоступную кнопку прозрачностью, которой
+            // у этого стиля нет вовсе.
+            var button = new Button
             {
                 Content = icon,
                 Padding = new Thickness(UiMetrics.Scaled(8)),
                 HorizontalContentAlignment = HorizontalAlignment.Center
             };
+            button.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(button, tooltip);
             return button;
         }
@@ -1176,17 +1174,15 @@ namespace Configuration_Management
                 Content = colorHex is not null
                     ? IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), new SolidColorBrush(Color.Parse(colorHex)))
                     : IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), brushKey ?? "TextSecondaryBrush"),
-                Background = Brushes.Transparent,
-                BorderThickness = new Thickness(0),
                 Padding = new Thickness(4),
                 Margin = new Thickness(1, 0),
                 MinWidth = 0,
                 MinHeight = 0,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
-                Cursor = new Cursor(StandardCursorType.Hand),
                 CommandParameter = group
             };
+            button.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(button, tooltip);
             // Команда живёт во вьюмодели, а контекстом строки служит узел группы.
             button.Bind(Button.CommandProperty, new Binding(commandPath) { Source = _vm });
@@ -3552,20 +3548,17 @@ namespace Configuration_Management
         /// <summary>Компактная иконко-кнопка панели инструментов над списком.</summary>
         private Button HeaderIconButton(string iconKey, string tooltip, string commandPath)
         {
+            // Оформление берёт тема IconButton разметки (LightTheme.xaml:561):
+            // прозрачный фон, скругление 8, подсветка при наведении, отступ 8.
             var button = new Button
             {
-                // Отступ 8 и значок 15, как у IconButton в разметке
-                // (MainWindow.xaml:494, LightTheme.xaml:561): своя ширина 24
-                // делала кнопки заметно теснее.
                 Content = IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), "TextSecondaryBrush"),
-                Background = Brushes.Transparent,
-                BorderThickness = new Thickness(0),
                 Padding = new Thickness(UiMetrics.Scaled(8)),
                 MinWidth = 0,
                 MinHeight = 0,
-                VerticalAlignment = VerticalAlignment.Center,
-                Cursor = new Cursor(StandardCursorType.Hand)
+                VerticalAlignment = VerticalAlignment.Center
             };
+            button.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(button, tooltip);
             button.Bind(Button.CommandProperty, new Binding(commandPath));
             return button;
@@ -4083,11 +4076,14 @@ namespace Configuration_Management
                 Content = ThemedIconAndText("IconClose", LocalizationManager.T("Common.Clear"),
                     "ButtonTextBrush", UiMetrics.Scaled(12), centered: false, fontSize: UiMetrics.ScaledFont(11)),
                 Padding = new Thickness(4, 2),
-                Background = Brushes.Transparent,
-                BorderThickness = new Thickness(0),
                 HorizontalAlignment = HorizontalAlignment.Right,
                 VerticalAlignment = VerticalAlignment.Center
             };
+            // Оформление и состояния берёт тема HeaderIconButton разметки
+            // (LightTheme.xaml:586): наведение, нажатие и гашение у автора
+            // заданы, а здесь кнопка была плоской без единого состояния.
+            _tagClearButton.Styled(Themes.ControlThemes.HeaderIconButton);
+            ToolTip.SetTip(_tagClearButton, LocalizationManager.T("Main.ClearTagFilters"));
             _tagClearButton.Bind(Button.CommandProperty, new Binding("ClearTagFiltersCommand"));
 
             // Подсказка остаётся на месте и когда тегов нет: панель не прячется,
@@ -4271,22 +4267,22 @@ namespace Configuration_Management
         }
 
         /// <summary>
-        /// Кнопка строки состояния: плоская, со своим наведением по SidebarHover,
-        /// значок 18 контрастной кистью (стиль StatusBarIconButton, LightTheme.xaml:616).
+        /// Кнопка строки состояния: оформление берёт тема StatusBarIconButton
+        /// разметки (LightTheme.xaml:616). Нажатие у автора различается темами:
+        /// в светлой это тёмная заливка, в тёмной прозрачность 0.85, и тема
+        /// повторяет обе.
         /// </summary>
         private static Button StatusBarIconButton(string iconKey)
         {
-            var button = new PanelButton("", "SidebarHoverBrush", "SidebarHoverBrush", "",
-                new CornerRadius(6))
+            var button = new Button
             {
                 Content = IconHelper.MakeIcon(iconKey, 18, "TextOnAccentBrush"),
-                Padding = new Thickness(6, 4),
                 Margin = new Thickness(4, 0, 0, 0),
                 MinWidth = 0,
                 MinHeight = 0,
-                VerticalAlignment = VerticalAlignment.Center,
-                Cursor = new Cursor(StandardCursorType.Hand)
+                VerticalAlignment = VerticalAlignment.Center
             };
+            button.Styled(Themes.ControlThemes.StatusBarIconButton);
             return button;
         }
 

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -2652,7 +2652,7 @@ namespace Configuration_Management
             ToolTip.SetTip(main, tooltip);
             main.Bind(Button.CommandProperty, new Binding(commandPath));
 
-            var menu = new ContextMenu();
+            var menu = new ContextMenu().Styled(Themes.ControlThemes.ModernContextMenu);
             foreach (var (header, command, itemIcon, itemColor) in menuItems)
             {
                 if (header.Length == 0)
@@ -2665,6 +2665,7 @@ namespace Configuration_Management
                 // (MainWindow.xaml:1954 и 1962): настройка параметров голубая,
                 // запуск с авторизацией фиолетовый.
                 var item = new MenuItem { Header = header };
+                item.Styled(Themes.ControlThemes.ModernMenuItem);
                 if (itemIcon is not null)
                     item.Icon = IconHelper.MakeIcon(itemIcon, 18,
                         itemColor is not null ? new SolidColorBrush(Color.Parse(itemColor)) : Brushes.Gray);
@@ -4230,7 +4231,7 @@ namespace Configuration_Management
             _statusInfo.Bind(ToolTip.TipProperty, new Binding("StatusBarInfo"));
             if (_vm is not null)
             {
-                var statusMenu = new ContextMenu();
+                var statusMenu = new ContextMenu().Styled(Themes.ControlThemes.ModernContextMenu);
                 statusMenu.Items.Add(MenuAction("Main.CopyPath", _vm.CopyConnectionStringCommand, iconKey: "IconCopy"));
                 _statusInfo.ContextMenu = statusMenu;
             }
@@ -4548,7 +4549,7 @@ namespace Configuration_Management
         /// </summary>
         private ContextMenu BuildRowContextMenu()
         {
-            var menu = new ContextMenu();
+            var menu = new ContextMenu().Styled(Themes.ControlThemes.ModernContextMenu);
             if (_vm is null)
                 return menu;
 
@@ -4557,6 +4558,7 @@ namespace Configuration_Management
                 Header = LocalizationManager.T("Main.ClearCache"),
                 Icon = MenuIcon("IconBroom", "#14B8A6")
             };
+            cacheMenu.Styled(Themes.ControlThemes.ModernMenuItem);
             cacheMenu.Items.Add(MenuAction("Main.ClearProgramCache", _vm.ClearProgramCacheCommand));
             cacheMenu.Items.Add(MenuAction("Main.ClearUserCache", _vm.ClearUserCacheCommand));
             cacheMenu.Items.Add(new Separator());
@@ -4603,6 +4605,7 @@ namespace Configuration_Management
                 Header = LocalizationManager.T(textKey),
                 Command = command
             };
+            item.Styled(Themes.ControlThemes.ModernMenuItem);
             if (iconKey is not null && iconColor is not null)
                 item.Icon = MenuIcon(iconKey, iconColor);
             if (Controls.HotkeyBox.TryParse(gesture, out var parsed) && parsed is not null)


### PR DESCRIPTION
# Linux/Avalonia: меню, значковые кнопки и меню трея главного окна

## Зачем

Пять именованных стилей главного окна не были перенесены вовсе: `IconButton`
(18 применений), `HeaderIconButton`, `StatusBarIconButton`, `ModernContextMenu`
и `ModernMenuItem` (25 применений). Меню шли штатными Fluent, а значковые
кнопки были собраны вручную у каждого места вызова. Меню трея расходилось
составом: у недавних баз не было подменю выбора режима запуска.

## Что сделано

**Значковые кнопки.** Три темы контролов по разметке. На них перешли семь кнопок
верхней панели, четыре кнопки заголовка групп, две команды строки группы, пять
команд строки базы, кнопка сброса фильтра тегов и две кнопки строки состояния.

Закрылись расхождения, которые до этого были не видны:

* подсветка при наведении в светлой теме у автора серая `#F1F5F9`, а в порте
  бралась кисть `ItemHover`, то есть янтарная; различие тем вынесено в словари;
* недоступная кнопка верхней панели гасла прозрачностью 0.55, хотя у стиля
  `IconButton` триггера недоступности нет вовсе;
* нажатие кнопки строки состояния снова различается темами: в светлой тёмная
  заливка, в тёмной прозрачность 0.85 поверх подсветки наведения;
* кнопка сброса фильтра тегов была плоской без единого состояния и без
  подсказки `Main.ClearTagFilters`, которая в разметке есть;
* у команд строки базы вернулись поле `1,0` и отступ из стиля.

**Меню.** Темы `ModernContextMenu` и `ModernMenuItem`: карточный фон, контур,
минимальная ширина 280, отступ 4, скругление 6 у меню и 4 у пункта, отступ пункта
12 на 6, кегль 13, зазор после значка 8, подсветка выделенного пункта кистью
`ItemHover`, гашение недоступного прозрачностью.

Обе темы наследуют штатные, а не заменяют шаблон: у `MenuItem` обязательна часть
`PART_Popup`, без неё не открывается подменю, а у `ContextMenu` нужен
`ItemsPresenter`. Подсветка повешена на `:selected`, а не на `:pointerover`:
именно так обработчик меню помечает пункт под указателем, и так же устроена
штатная тема. Фон и отступ подменю задаются ресурсами штатной темы, потому что
подменю живёт в своём `Popup` и получает значения прямо из шаблона, а значение
из шаблона старше значения из именованного стиля.

**Меню трея.** Приведено к составу Windows-версии: у каждой недавней базы своё
подменю «Предприятие / Конфигуратор», появились заголовки разделов «Недавние
базы» и «Выбранная база», пустое имя заменяется подписью, длинное обрезается
до 48 знаков, недавних баз семь. Запуск из трея идёт прямо по ссылке на базу
и **не меняет выделение в списке**: в Windows это делает `LaunchInfobaseById`,
а в порте запуск шёл через команду окна и переставлял выделение, правую панель
и строку состояния. Источник записи в истории тот же, что у автора.

## Что осталось расхождением, названо здесь

1. **Клавиатурный фокус.** Тема значковой кнопки не наследует штатную кнопочную,
   поэтому у этих кнопок нет отрисовки фокуса. В WPF её рисует система.
2. **Подпись `Ctrl+Shift+C`** у пункта очистки кеша стоит на дочернем «очистить
   оба», а у автора на родительском пункте: в Avalonia родительский пункт
   с подменю по щелчку команду не исполняет.
3. **Синхронизация и настройки из трея** не показывают окно перед выполнением,
   в отличие от Windows-версии. Расхождение старше этой правки.
4. **Тень контекстного меню.** `HasDropShadow` разметки передан как
   `WindowManagerAddShadowHint`, но на X11 это лишь подсказка оконному
   менеджеру и тень рисует он, а не приложение.
5. Пункты «Зарегистрировать COM-коннектор» и «История запусков» в контекстном
   меню строки по-прежнему отсутствуют, как и раньше.

## Как проверено

Сборка Linux-цели без ошибок и без новых предупреждений, публикация, прогон
в отдельном каталоге данных. Сняты и осмотрены: контекстное меню строки базы
с раскрытым подменю очистки кеша, верхняя панель значковых кнопок (подсветка
наведения замерена пикселем, ровно `#F1F5F9`), меню трея с подменю базы.

Три встречных аудита дали двенадцать находок, все закрыты в этом же PR.
