### PR TITLE
Linux/Avalonia: окно выбора группы по разметке автора

### DIFF
--- a/Configuration Management/Themes/ControlThemes.Avalonia.cs
+++ b/Configuration Management/Themes/ControlThemes.Avalonia.cs
@@ -59,6 +59,8 @@ namespace Configuration_Management.Themes
 
         /// <summary>Значковая кнопка строки состояния: отступ 6 на 4, подсветка боковой панели.</summary>
         public const string StatusBarIconButton = "StatusBarIconButton";
+        /// <summary>Элемент дерева окна выбора группы: раскрыватель «+»/«-» и подсветка выбранной строки.</summary>
+        public const string GroupPickerTreeItem = "GroupPickerTreeItem";
 
         /// <summary>Плитка выбора значка группы: тёмная в обеих темах, как у автора.</summary>
         public const string IconPickButton = "IconPickButton";

--- a/Configuration Management/Themes/ControlThemes.Avalonia.cs
+++ b/Configuration Management/Themes/ControlThemes.Avalonia.cs
@@ -45,6 +45,12 @@ namespace Configuration_Management.Themes
         /// <summary>Переключатель настроек: дорожка 40 на 22 с кружком 16.</summary>
         public const string SettingsToggle = "SettingsToggle";
 
+        /// <summary>Всплывающее меню: карточный фон, контур, минимальная ширина 280.</summary>
+        public const string ModernContextMenu = "ModernContextMenu";
+
+        /// <summary>Пункт меню: отступ 12 на 6, скругление 4, подсветка выделенного.</summary>
+        public const string ModernMenuItem = "ModernMenuItem";
+
         /// <summary>Значковая кнопка: прозрачный фон, скругление 8, подсветка при наведении.</summary>
         public const string IconButton = "IconButton";
 

--- a/Configuration Management/Themes/ControlThemes.Avalonia.cs
+++ b/Configuration Management/Themes/ControlThemes.Avalonia.cs
@@ -45,6 +45,15 @@ namespace Configuration_Management.Themes
         /// <summary>Переключатель настроек: дорожка 40 на 22 с кружком 16.</summary>
         public const string SettingsToggle = "SettingsToggle";
 
+        /// <summary>Значковая кнопка: прозрачный фон, скругление 8, подсветка при наведении.</summary>
+        public const string IconButton = "IconButton";
+
+        /// <summary>Значковая кнопка заголовка: скругление 6, своё нажатие и гашение.</summary>
+        public const string HeaderIconButton = "HeaderIconButton";
+
+        /// <summary>Значковая кнопка строки состояния: отступ 6 на 4, подсветка боковой панели.</summary>
+        public const string StatusBarIconButton = "StatusBarIconButton";
+
         /// <summary>Плитка выбора значка группы: тёмная в обеих темах, как у автора.</summary>
         public const string IconPickButton = "IconPickButton";
 

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -20,6 +20,9 @@
             <SolidColorBrush x:Key="SecondaryButtonPressedSurfaceBrush" Color="{DynamicResource SecondaryButtonPressedColor}"/>
             <Thickness x:Key="SecondaryButtonOutlineThickness">0</Thickness>
             <SolidColorBrush x:Key="SettingsToggleTrackBrush">#CBD5E1</SolidColorBrush>
+            <SolidColorBrush x:Key="IconButtonHoverBrush">#F1F5F9</SolidColorBrush>
+            <SolidColorBrush x:Key="StatusBarIconPressedBrush">#0F172A</SolidColorBrush>
+            <x:Double x:Key="StatusBarIconPressedOpacity">1</x:Double>
         </ResourceDictionary>
         <!-- Тёмная: вторичная кнопка это карточка в контуре, при наведении контур акцентный. -->
         <ResourceDictionary x:Key="Dark">
@@ -31,6 +34,9 @@
             <SolidColorBrush x:Key="SecondaryButtonPressedSurfaceBrush" Color="{DynamicResource SidebarHoverColor}"/>
             <Thickness x:Key="SecondaryButtonOutlineThickness">1</Thickness>
             <SolidColorBrush x:Key="SettingsToggleTrackBrush">#475569</SolidColorBrush>
+            <SolidColorBrush x:Key="IconButtonHoverBrush" Color="{DynamicResource ItemHoverColor}"/>
+            <SolidColorBrush x:Key="StatusBarIconPressedBrush" Color="{DynamicResource SidebarHoverColor}"/>
+            <x:Double x:Key="StatusBarIconPressedOpacity">0.85</x:Double>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
@@ -754,6 +760,103 @@
         <Style Selector="^:pointerover /template/ Border#PART_Surface">
             <Setter Property="Background" Value="#4B5563"/>
             <Setter Property="BorderBrush" Value="#9CA3AF"/>
+        </Style>
+    </ControlTheme>
+    <!-- ===================== Значковые кнопки =====================
+         Стили IconButton (LightTheme.xaml:561, DarkTheme.xaml:1105),
+         HeaderIconButton (:586 и :1130) и StatusBarIconButton (:616 и :1160).
+         Различие тем у первой одно: в светлой наведение задано числом #F1F5F9,
+         в тёмной берётся ItemHoverBrush, поэтому кисть вынесена в словари темы.
+         Триггера недоступности у IconButton в разметке нет вовсе. -->
+    <ControlTheme x:Key="IconButton" TargetType="Button">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="8"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        BorderThickness="0"
+                        CornerRadius="8"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource IconButtonHoverBrush}"/>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="HeaderIconButton" TargetType="Button" BasedOn="{StaticResource IconButton}">
+        <Setter Property="Padding" Value="5"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        BorderThickness="0"
+                        CornerRadius="6"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+        </Style>
+        <Style Selector="^:pressed /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource SecondaryButtonHoverBrush}"/>
+        </Style>
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value="0.4"/>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="StatusBarIconButton" TargetType="Button" BasedOn="{StaticResource IconButton}">
+        <Setter Property="Padding" Value="6,4"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        BorderThickness="0"
+                        CornerRadius="6"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource SidebarHoverBrush}"/>
+        </Style>
+        <!-- Нажатие у автора различается темами: в светлой это заливка числом,
+             в тёмной прозрачность 0.85 (LightTheme.xaml:634, DarkTheme.xaml:1178). -->
+        <Style Selector="^:pressed /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource StatusBarIconPressedBrush}"/>
+        </Style>
+        <Style Selector="^:pressed">
+            <Setter Property="Opacity" Value="{DynamicResource StatusBarIconPressedOpacity}"/>
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -859,4 +859,53 @@
             <Setter Property="Opacity" Value="{DynamicResource StatusBarIconPressedOpacity}"/>
         </Style>
     </ControlTheme>
+    <!-- Ресурсы штатной темы, которыми она красит всплывающее меню и колонку
+         значка. Через ресурсы, а не селектором: подменю живёт в своём Popup,
+         и его рамка получает значения прямо из шаблона. Числа из разметки
+         (LightTheme.xaml:817 и :742): фон карточки, контур темы, толщина 1,
+         внутренний отступ 4, зазор после значка 8 вместо штатных 12. -->
+    <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="{DynamicResource CardBackgroundColor}"/>
+    <SolidColorBrush x:Key="MenuFlyoutPresenterBorderBrush" Color="{DynamicResource BorderColor}"/>
+    <Thickness x:Key="MenuFlyoutPresenterBorderThemeThickness">1</Thickness>
+    <Thickness x:Key="MenuFlyoutPresenterThemePadding">4</Thickness>
+    <Thickness x:Key="MenuIconPresenterMargin">0,0,8,0</Thickness>
+
+    <!-- ===================== Меню =====================
+         Стили ModernContextMenu (LightTheme.xaml:817) и ModernMenuItem (:742);
+         в тёмной теме оба дословно те же. Темы наследуют штатные: у MenuItem
+         обязательна часть PART_Popup, без неё не открывается подменю, а у
+         ContextMenu нужен ItemsPresenter, иначе пункты не показываются.
+         Подсветка пункта идёт по :selected, а не по :pointerover: именно так
+         обработчик меню помечает пункт под указателем, и так же устроена
+         штатная тема. -->
+    <ControlTheme x:Key="ModernContextMenu" TargetType="ContextMenu" BasedOn="{StaticResource {x:Type ContextMenu}}">
+        <Setter Property="MinWidth" Value="280"/>
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushColor}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Padding" Value="4"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <!-- Аналог HasDropShadow разметки: подсказка оконному менеджеру. -->
+        <Setter Property="WindowManagerAddShadowHint" Value="True"/>
+    </ControlTheme>
+
+    <ControlTheme x:Key="ModernMenuItem" TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="Padding" Value="12,6"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="CornerRadius" Value="4"/>
+        <Setter Property="Margin" Value="2,1"/>
+
+        <Style Selector="^:selected /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+        </Style>
+        <Style Selector="^:selected">
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        </Style>
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value="0.5"/>
+        </Style>
+    </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -898,14 +898,26 @@
         <Setter Property="CornerRadius" Value="4"/>
         <Setter Property="Margin" Value="2,1"/>
 
+        <!-- Цвет подписи штатная тема меняет не на контроле, а на части шаблона,
+             поэтому и здесь красится часть: у автора подсветка меняет только фон
+             (LightTheme.xaml:804), цвет текста остаётся прежним. -->
         <Style Selector="^:selected /template/ Border#PART_LayoutRoot">
             <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
         </Style>
-        <Style Selector="^:selected">
+        <Style Selector="^:selected /template/ ContentPresenter#PART_HeaderPresenter">
             <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
         </Style>
+        <!-- Недоступный пункт у автора только гаснет прозрачностью
+             (LightTheme.xaml:807), фон и цвет текста не меняются, поэтому
+             перекраска штатной темы снимается. -->
         <Style Selector="^:disabled">
             <Setter Property="Opacity" Value="0.5"/>
+        </Style>
+        <Style Selector="^:disabled /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="Transparent"/>
+        </Style>
+        <Style Selector="^:disabled /template/ ContentPresenter#PART_HeaderPresenter">
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -920,4 +920,55 @@
             <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
         </Style>
     </ControlTheme>
+    <!-- Элемент дерева окна выбора группы: шаблон автора
+         (GroupPickerWindow.xaml:29). Раскрыватель это «+»/«-» в колонке 24,
+         подсвечивается только сама выбранная строка, вложенные сдвинуты на 16. -->
+    <ControlTheme x:Key="GroupPickerTreeItem" TargetType="TreeViewItem">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="IsExpanded" Value="True"/>
+        <Setter Property="Padding" Value="4,2"/>
+        <Setter Property="Template">
+            <ControlTemplate>
+                <StackPanel>
+                    <Border x:Name="PART_Header" Background="Transparent" CornerRadius="6"
+                            Padding="4,3" Margin="0,1">
+                        <Grid ColumnDefinitions="24,*">
+                            <ToggleButton x:Name="PART_ExpandCollapseChevron" Grid.Column="0"
+                                          IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource AncestorType=TreeViewItem}, Mode=TwoWay}"
+                                          ClickMode="Press" Width="20" Height="22"
+                                          Background="Transparent" BorderThickness="0" Padding="0"
+                                          Cursor="Hand" VerticalAlignment="Center">
+                                <ToggleButton.Template>
+                                    <ControlTemplate>
+                                        <TextBlock x:Name="ExpanderSymbol" Text="+"
+                                                   FontSize="16" FontWeight="Bold"
+                                                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                   Foreground="{DynamicResource TextSecondaryBrush}"/>
+                                    </ControlTemplate>
+                                </ToggleButton.Template>
+                                <ToggleButton.Styles>
+                                    <Style Selector="ToggleButton:checked /template/ TextBlock#ExpanderSymbol">
+                                        <Setter Property="Text" Value="-"/>
+                                    </Style>
+                                </ToggleButton.Styles>
+                            </ToggleButton>
+                            <ContentPresenter x:Name="PART_HeaderPresenter" Grid.Column="1"
+                                              Content="{TemplateBinding Header}"
+                                              ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                              VerticalAlignment="Center"/>
+                        </Grid>
+                    </Border>
+                    <ItemsPresenter x:Name="PART_ItemsPresenter" Margin="16,0,0,0"
+                                    IsVisible="{TemplateBinding IsExpanded}"
+                                    ItemsPanel="{TemplateBinding ItemsPanel}"/>
+                </StackPanel>
+            </ControlTemplate>
+        </Setter>
+        <Style Selector="^:empty /template/ ToggleButton#PART_ExpandCollapseChevron">
+            <Setter Property="IsVisible" Value="False"/>
+        </Style>
+        <Style Selector="^:selected /template/ Border#PART_Header">
+            <Setter Property="Background" Value="{DynamicResource TreeSelectedBrush}"/>
+        </Style>
+    </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
+++ b/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
@@ -1719,6 +1719,36 @@ public class MainViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Запуск базы из меню трея: прямо по ссылке, не трогая выделение в списке.
+    /// В Windows-версии это делает LaunchInfobaseById (MainViewModel.Commands.cs:544),
+    /// и она тоже не меняет SelectedInfobase: иначе запуск из трея переставлял бы
+    /// выделение, правую панель и строку состояния. Источник записи в истории
+    /// тот же, что у автора.
+    /// </summary>
+    public void LaunchFromTray(Infobase ib, bool configurator)
+    {
+        if (!_allInfobases.Contains(ib))
+            return;
+
+        var ok = configurator
+            ? _launcher.Launch(ib, Services.OneCLaunchMode.Configurator)
+            : _launcher.Launch(ib, Services.OneCLaunchMode.Enterprise);
+
+        if (ok)
+        {
+            ib.AddLaunchHistory(configurator ? "Configurator" : "Enterprise", "tray");
+            SaveSilently();
+            OnPropertyChanged(nameof(RecentInfobases));
+            _logger.Info($"[tray] Запущена «{ib.Name}» ({(configurator ? "Конфигуратор" : "Предприятие")})");
+            NotifyAfterLaunch();
+        }
+        else
+        {
+            _logger.Warn($"[tray] Не удалось запустить «{ib.Name}»");
+        }
+    }
+
     private void OnLaunched()
     {
         if (SelectedInfobase is not null)

--- a/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
+++ b/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
@@ -3763,12 +3763,15 @@ public class MainViewModel : ViewModelBase
 
     // ======================= Этап 6: папки / ярлыки / стартер =======================
 
-    /// <summary>Недавно запускавшиеся базы (для меню трея). До 8 по дате запуска.</summary>
+    /// <summary>
+    /// Недавно запускавшиеся базы (для меню трея). До семи по дате запуска,
+    /// как в Windows-версии (MainWindow.Tray.cs:216 запрашивает семь).
+    /// </summary>
     public List<Infobase> RecentInfobases =>
         _allInfobases
             .Where(ib => ib.LastLaunchDate.HasValue)
             .OrderByDescending(ib => ib.LastLaunchDate)
-            .Take(8)
+            .Take(7)
             .ToList();
 
     /// <summary>Все информационные базы (для диалога выбора при очистке кеша).</summary>

--- a/Configuration Management/Views/ConnectionSettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/ConnectionSettingsWindow.Avalonia.cs
@@ -810,7 +810,8 @@ namespace Configuration_Management
                 _viewModel.Groups,
                 currentGroupId: _viewModel.SelectedGroup?.Id,
                 allowNone: true,
-                noneLabel: LocalizationManager.T("Connection.NoGroup"));
+                noneLabel: LocalizationManager.T("Connection.NoGroup"),
+                kind: GroupPickerObjectKind.Infobase);
             if (dialog.ShowDialogSync(this))
             {
                 _viewModel.SelectedGroup = dialog.ResultGroup;

--- a/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
+++ b/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
@@ -613,7 +613,8 @@ namespace Configuration_Management
                 _groups,
                 currentGroupId: null,
                 allowNone: true,
-                noneLabel: LocalizationManager.T("Connection.NoGroup"));
+                noneLabel: LocalizationManager.T("Connection.NoGroup"),
+                kind: GroupPickerObjectKind.Infobase);
             if (dialog.ShowDialogSync(this))
             {
                 _selectedGroupPath = string.IsNullOrWhiteSpace(dialog.ResultFullPath)

--- a/Configuration Management/Views/GroupEditWindow.Avalonia.cs
+++ b/Configuration Management/Views/GroupEditWindow.Avalonia.cs
@@ -435,7 +435,8 @@ namespace Configuration_Management
                 currentGroupId: _parentId,
                 excludeGroupId: _editingGroup?.Id,
                 allowNone: true,
-                noneLabel: LocalizationManager.T("GroupEdit.RootGroup"));
+                noneLabel: LocalizationManager.T("GroupEdit.RootGroup"),
+                kind: GroupPickerObjectKind.Group);
             if (dialog.ShowDialogSync(this))
             {
                 _parentId = dialog.ResultGroupId;

--- a/Configuration Management/Views/GroupPickerWindow.Avalonia.cs
+++ b/Configuration Management/Views/GroupPickerWindow.Avalonia.cs
@@ -9,6 +9,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
@@ -20,6 +21,18 @@ using Configuration_Management.ViewModels;
 
 namespace Configuration_Management
 {
+    /// <summary>
+    /// Вид объекта, для которого выбирается группа: от него зависят заголовок,
+    /// подзаголовок и текст справки (GroupPickerWindow.xaml.cs:11).
+    /// В Windows-версии это перечисление объявлено в code-behind, который
+    /// в Linux-сборку не входит, поэтому здесь свой такой же.
+    /// </summary>
+    public enum GroupPickerObjectKind
+    {
+        Group,
+        Infobase
+    }
+
     /// <summary>
     /// Диалог выбора группы в виде дерева (или «Без группы» / корень) в стиле Material Design:
     /// шапка с иконкой и подзаголовком, поле поиска, переключатель сортировки, карточка-дерево
@@ -51,18 +64,37 @@ namespace Configuration_Management
         /// <param name="excludeGroupId">Группа, которую нельзя выбрать (сама редактируемая + потомки отфильтруются).</param>
         /// <param name="allowNone">Разрешить выбор «Без группы» / корень.</param>
         /// <param name="noneLabel">Подпись корневого пункта.</param>
+        /// <summary>Вид объекта, для которого выбирают группу: от него зависят формулировки.</summary>
+        private readonly GroupPickerObjectKind _objectKind;
+
+        private string TitleKey => _objectKind == GroupPickerObjectKind.Infobase
+            ? "GroupPicker.TitleBase"
+            : "GroupPicker.TitleGroup";
+
+        private string SubtitleKey => _objectKind == GroupPickerObjectKind.Infobase
+            ? "GroupPicker.SubtitleBase"
+            : "GroupPicker.SubtitleGroup";
+
+        private string HelpKey => _objectKind == GroupPickerObjectKind.Infobase
+            ? "GroupPicker.HelpBase"
+            : "GroupPicker.HelpGroup";
+
         public GroupPickerWindow(
             IEnumerable<Group> groups,
             string? currentGroupId = null,
             string? excludeGroupId = null,
             bool allowNone = true,
-            string noneLabel = "")
+            string noneLabel = "",
+            GroupPickerObjectKind kind = GroupPickerObjectKind.Group)
         {
-            Title = LocalizationManager.T("GroupPicker.Title");
-            Width = 520;
-            Height = 600;
-            MinWidth = 440;
-            MinHeight = 460;
+            // Формулировки зависят от того, для чего выбирают группу: для базы
+            // или для другой группы (GroupPickerWindow.xaml.cs:70).
+            _objectKind = kind;
+            Title = LocalizationManager.T(TitleKey);
+            Width = 560;
+            Height = 620;
+            MinWidth = 460;
+            MinHeight = 480;
 
             _groups = groups.ToList();
             _currentGroupId = currentGroupId ?? string.Empty;
@@ -154,16 +186,16 @@ namespace Configuration_Management
             // занимает остаток, и после titleStack кружок «?» встал бы не к краю.
             var help = new HelpLink
             {
-                HelpText = LocalizationManager.T("GroupPicker.Help"),
+                HelpText = LocalizationManager.T(HelpKey),
                 VerticalAlignment = VerticalAlignment.Top,
-                Margin = new Thickness(12, 4, 0, 0)
+                Margin = new Thickness(8, 0, 0, 0)
             };
             DockPanel.SetDock(help, Dock.Right);
             header.Children.Add(help);
 
             var titleStack = new StackPanel { Spacing = 2 };
-            titleStack.Children.Add(ThemedText(LocalizationManager.T("GroupPicker.Title"), 17, secondary: false, FontWeight.SemiBold));
-            var subtitle = ThemedText(LocalizationManager.T("GroupPicker.Subtitle"), 12.5, secondary: true, FontWeight.Normal);
+            titleStack.Children.Add(ThemedText(LocalizationManager.T(TitleKey), 17, secondary: false, FontWeight.SemiBold));
+            var subtitle = ThemedText(LocalizationManager.T(SubtitleKey), 12.5, secondary: true, FontWeight.Normal);
             subtitle.TextWrapping = TextWrapping.Wrap;
             titleStack.Children.Add(subtitle);
             header.Children.Add(titleStack);
@@ -173,13 +205,15 @@ namespace Configuration_Management
 
         private Control BuildToolbar()
         {
-            var toolbar = new Grid { Margin = new Thickness(0, 0, 0, 10) };
+            var toolbar = new Grid { Margin = new Thickness(0, 0, 0, 8) };
             toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
             toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
             toolbar.Children.Add(BuildSearchField());
 
-            var sortPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6, Margin = new Thickness(10, 0, 0, 0) };
+            // Кнопки сортировки: ширина 34 и поле 2,0 из разметки
+            // (GroupPickerWindow.xaml:86), зазор задаётся полем кнопок.
+            var sortPanel = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(10, 0, 0, 0) };
             _sortAsc = BuildSortToggle("IconSortAscending", LocalizationManager.T("Main.SortGroupsAscending"), isAscending: true);
             _sortDesc = BuildSortToggle("IconSortDescending", LocalizationManager.T("Main.SortGroupsDescending"), isAscending: false);
             sortPanel.Children.Add(_sortAsc);
@@ -200,6 +234,7 @@ namespace Configuration_Management
                 Padding = new Thickness(10, 2)
             };
             ThemeBrushes.Bind(field, Border.BorderBrushProperty, "BorderColorBrush");
+            ThemeBrushes.Bind(field, Border.BackgroundProperty, "CardBackgroundColorBrush");
 
             var grid = new Grid();
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
@@ -262,31 +297,36 @@ namespace Configuration_Management
             };
             ThemeBrushes.Bind(card, Border.BackgroundProperty, "CardBackgroundColorBrush");
             ThemeBrushes.Bind(card, Border.BorderBrushProperty, "BorderColorBrush");
-            UiMetrics.AddSoftShadow(card);
 
             var root = new Grid();
-            root.RowDefinitions.Add(new RowDefinition(new GridLength(1, GridUnitType.Star)));
-            root.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
 
             _tree.ItemTemplate = new FuncTreeDataTemplate(
                 typeof(object),
                 (item, _) => BuildTreeRow(item),
                 item => item is GroupNodeViewModel g && g.HasChildren ? g.Children : null);
+            if (Application.Current?.TryFindResource(ControlThemes.GroupPickerTreeItem, out var treeItemTheme) == true
+                && treeItemTheme is ControlTheme itemTheme)
+            {
+                _tree.ItemContainerTheme = itemTheme;
+            }
             _tree.SelectionChanged += (_, _) =>
             {
                 _selectedNode = _tree.SelectedItem as GroupNodeViewModel;
                 UpdateSelection();
             };
-            _tree.DoubleTapped += (_, _) =>
+            // Двойной щелчок доходит до дерева только с handledEventsToo: у элемента
+            // с детьми Avalonia помечает событие обработанным (раскрытие узла), а
+            // разметка WPF подтверждает выбор при щелчке по любому узлу.
+            _tree.AddHandler(InputElement.DoubleTappedEvent, (object? _, TappedEventArgs _) =>
             {
                 if (_selectedNode is not null)
                     OnSelect_Click();
-            };
+            }, RoutingStrategies.Bubble, handledEventsToo: true);
 
             var treeHost = new ScrollViewer
             {
                 Content = _tree,
-                Padding = new Thickness(8, 6),
+                Padding = new Thickness(6),
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
                 VerticalScrollBarVisibility = ScrollBarVisibility.Auto
             };
@@ -312,16 +352,17 @@ namespace Configuration_Management
             var row = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
-                Spacing = 8,
-                Margin = new Thickness(4, 3)
+                Margin = new Thickness(0, 1)
             };
 
-            // Крупный цветной «чип» с иконкой группы — выразительнее и лучше читается.
+            // Цветной чип со значком группы: размер задаётся отступом, как
+            // в разметке (GroupPickerWindow.xaml:271), а не фиксированной
+            // шириной с высотой.
             var chip = new Border
             {
-                Width = 36,
-                Height = 28,
-                CornerRadius = new CornerRadius(UiMetrics.RadiusSm),
+                Padding = new Thickness(6, 3),
+                Margin = new Thickness(0, 0, 8, 0),
+                CornerRadius = new CornerRadius(6),
                 VerticalAlignment = VerticalAlignment.Center,
                 Background = node.HeaderBrush,
                 Child = new Avalonia.Controls.Shapes.Path
@@ -376,12 +417,12 @@ namespace Configuration_Management
             _selectButton = BuildActionButton(
                 "AccentBrush", "AccentHoverBrush", "AccentPressedBrush", "AccentBrush",
                 ActionContent("IconCheck", LocalizationManager.T("Common.Select"), "TextOnAccentBrush"),
-                minWidth: 132, isCancel: false, isDefault: true, onClick: OnSelect_Click);
+                minWidth: 116, isCancel: false, isDefault: true, onClick: OnSelect_Click);
             buttons.Children.Add(_selectButton);
 
             buttons.Children.Add(BuildActionButton(
-                "SecondaryButtonBackgroundBrush", "SecondaryButtonHoverBrush", "SecondaryButtonPressedBrush", "BorderColorBrush",
-                ActionContent("IconClose", LocalizationManager.T("Common.Cancel"), "ButtonTextBrush"),
+                "", "SecondaryButtonHoverBrush", "SecondaryButtonPressedBrush", "SecondaryButtonBackgroundBrush",
+                ActionContent("IconClose", LocalizationManager.T("Common.Cancel"), "ButtonTextBrush", iconSize: 15),
                 minWidth: 116, isCancel: true, isDefault: false, onClick: () => Close()));
             Grid.SetColumn(buttons, 1);
             footer.Children.Add(buttons);
@@ -398,14 +439,17 @@ namespace Configuration_Management
             string baseKey, string hoverKey, string pressedKey, string borderKey,
             Control content, double minWidth, bool isCancel, bool isDefault, Action onClick)
         {
+            // Высота 38, отступ 14 на 6 и контур 1.5 из стилей разметки
+            // (GroupPickerWindow.xaml:117): у акцентной кнопки контура нет.
             var btn = new Button
             {
                 Content = content,
                 MinWidth = minWidth,
-                Padding = new Thickness(UiMetrics.ButtonPadH, UiMetrics.ButtonPadV),
+                Height = 38,
+                Padding = new Thickness(14, 6),
                 HorizontalContentAlignment = HorizontalAlignment.Center,
                 VerticalContentAlignment = VerticalAlignment.Center,
-                BorderThickness = new Thickness(1),
+                BorderThickness = new Thickness(isDefault ? 0 : 1.5),
                 Cursor = new Cursor(StandardCursorType.Hand),
                 IsCancel = isCancel,
                 IsDefault = isDefault
@@ -438,18 +482,19 @@ namespace Configuration_Management
             return btn;
         }
 
-        /// <summary>Переключатель сортировки (А→Я / Я→А): активное состояние — акцентная заливка.</summary>
+        /// <summary>Переключатель сортировки (А→Я / Я→А): активный заливается акцентом, значок белеет.</summary>
         private ToggleButton BuildSortToggle(string iconKey, string tooltip, bool isAscending)
         {
             var toggle = new ToggleButton
             {
-                Width = 36,
+                Width = 34,
                 Height = 32,
-                Padding = new Thickness(0),
+                Margin = new Thickness(2, 0),
+                Padding = new Thickness(2),
                 BorderThickness = new Thickness(1),
                 Cursor = new Cursor(StandardCursorType.Hand),
                 IsChecked = isAscending == _sortAscending,
-                Content = IconHelper.MakeIcon(iconKey, 16, "ButtonTextBrush")
+                Content = IconHelper.MakeIcon(iconKey, 16, out var iconPath)
             };
             ToolTip.SetTip(toggle, tooltip);
 
@@ -475,9 +520,10 @@ namespace Configuration_Management
                 }
             };
 
-            var state = new ToggleState();
-            ThemeBrushes.Observe(toggle, "SecondaryButtonBackgroundBrush", b => { state.Base = b; state.Apply(toggle); });
-            ThemeBrushes.Observe(toggle, "SecondaryButtonHoverBrush", b => { state.Hover = b; state.Apply(toggle); });
+            var state = new ToggleState { Icon = iconPath };
+            ThemeBrushes.Observe(toggle, "ItemHoverBrush", b => { state.Hover = b; state.Apply(toggle); });
+            ThemeBrushes.Observe(toggle, "ButtonTextBrush", b => { state.IconBase = b; state.Apply(toggle); });
+            ThemeBrushes.Observe(toggle, "TextOnAccentBrush", b => { state.IconOnAccent = b; state.Apply(toggle); });
             ThemeBrushes.Observe(toggle, "SecondaryButtonPressedBrush", b => { state.Pressed = b; state.Apply(toggle); });
             ThemeBrushes.Observe(toggle, "BorderColorBrush", b => { state.Border = b; state.Apply(toggle); });
             ThemeBrushes.Observe(toggle, "AccentBrush", b => { state.Accent = b; state.Apply(toggle); });
@@ -516,7 +562,8 @@ namespace Configuration_Management
             string baseKey, string hoverKey, string pressedKey, string borderKey, bool? isActive)
         {
             var state = new ToggleState();
-            ThemeBrushes.Observe(btn, baseKey, b => { state.Base = b; state.Apply(btn); });
+            if (baseKey.Length > 0)
+                ThemeBrushes.Observe(btn, baseKey, b => { state.Base = b; state.Apply(btn); });
             ThemeBrushes.Observe(btn, hoverKey, b => { state.Hover = b; state.Apply(btn); });
             ThemeBrushes.Observe(btn, pressedKey, b => { state.Pressed = b; state.Apply(btn); });
             ThemeBrushes.Observe(btn, borderKey, b => { state.Border = b; state.Apply(btn); });
@@ -547,12 +594,12 @@ namespace Configuration_Management
         }
 
         /// <summary>Содержимое кнопки: иконка + подпись цветом из темы.</summary>
-        private static Control ActionContent(string iconKey, string text, string brushKey)
+        private static Control ActionContent(string iconKey, string text, string brushKey, double iconSize = 16)
         {
             var tb = new TextBlock
             {
                 Text = text,
-                FontSize = 13.5,
+                FontSize = 13,
                 FontWeight = FontWeight.SemiBold,
                 VerticalAlignment = VerticalAlignment.Center
             };
@@ -563,7 +610,7 @@ namespace Configuration_Management
                 Spacing = 6,
                 Children =
                 {
-                    IconHelper.MakeIcon(iconKey, 16, brushKey),
+                    IconHelper.MakeIcon(iconKey, iconSize, brushKey),
                     tb
                 }
             };
@@ -720,27 +767,30 @@ namespace Configuration_Management
             public IBrush Pressed = Brushes.Transparent;
             public IBrush Border = Brushes.Transparent;
             public IBrush Accent = Brushes.Transparent;
+            public IBrush IconBase = Brushes.Transparent;
+            public IBrush IconOnAccent = Brushes.Transparent;
+            public Avalonia.Controls.Shapes.Path? Icon;
             public bool Hovered;
             public bool IsPressed;
 
             public void Apply(Button btn)
             {
                 var isActive = btn is ToggleButton t && t.IsChecked == true;
+                var fill = isActive ? Accent : (IsPressed ? Pressed : (Hovered ? Hover : Base));
+                if (Icon is not null)
+                    Icon.Fill = isActive ? IconOnAccent : IconBase;
+
                 if (!btn.IsEnabled)
                 {
                     btn.Opacity = 0.5;
-                    btn.Background = Base;
-                    btn.BorderBrush = isActive ? Accent : Border;
-                    btn.BorderThickness = new Thickness(isActive ? 2 : 1);
+                    btn.Background = fill;
+                    btn.BorderBrush = Border;
                     return;
                 }
 
                 btn.Opacity = 1.0;
-                btn.Background = IsPressed ? Pressed : (Hovered ? Hover : Base);
-                btn.BorderBrush = isActive ? Accent : Border;
-                // Активный сегмент сортировки подсвечивается акцентной рамкой (как сегментный
-                // переключатель Material): контраст иконки сохраняется в обеих темах.
-                btn.BorderThickness = new Thickness(isActive ? 2 : 1);
+                btn.Background = fill;
+                btn.BorderBrush = Border;
             }
         }
 

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -4805,41 +4805,32 @@ namespace Configuration_Management
         {
             menu.Items.Clear();
 
-            var showItem = new NativeMenuItem(LocalizationManager.T("Main.ShowWindow"));
+            // Состав и порядок как в Windows-версии (MainWindow.Tray.cs:209):
+            // открыть, недавние базы (или выбранная, если недавних нет),
+            // синхронизация, настройки, выход. У каждой базы своё подменю
+            // «Предприятие / Конфигуратор»: раньше пункт запускал только
+            // Предприятие, а выбора не было.
+            var showItem = new NativeMenuItem(LocalizationManager.T("Main.TrayOpen"));
             showItem.Click += (_, _) => ShowAndActivate();
             menu.Add(showItem);
-            menu.Add(new NativeMenuItemSeparator());
 
-            // Недавние базы (быстрый запуск прямо из трея).
             var recent = _vm?.RecentInfobases;
             if (recent is { Count: > 0 })
             {
-                var recentMenu = new NativeMenu();
+                menu.Add(new NativeMenuItemSeparator());
+                menu.Add(TrayHeader(LocalizationManager.T("Main.RecentBases")));
                 foreach (var ib in recent)
-                {
-                    var item = new NativeMenuItem($"{ib.Name}  ({ib.ServerDatabaseDisplay})");
-                    var baseRef = ib;
-                    item.Click += (_, _) => LaunchInfobase(baseRef);
-                    recentMenu.Add(item);
-                }
-                menu.Add(new NativeMenuItem(LocalizationManager.T("Main.RecentBases")) { Menu = recentMenu });
-                menu.Add(new NativeMenuItemSeparator());
+                    menu.Add(TrayInfobaseItem(ib, TrayItemName(ib.Name, "Main.NoName")));
             }
-
-            // Запуск выбранной базы: Предприятие / Конфигуратор.
-            if (_vm?.SelectedInfobase is { } sel)
+            else if (_vm?.SelectedInfobase is { } sel)
             {
-                var ent = new NativeMenuItem($"{LocalizationManager.T("Main.LaunchEnterprise")}: {sel.Name}");
-                ent.Click += (_, _) => _vm.LaunchEnterpriseCommand.Execute(null);
-                menu.Add(ent);
-
-                var cfg = new NativeMenuItem($"{LocalizationManager.T("Main.LaunchConfigurator")}: {sel.Name}");
-                cfg.Click += (_, _) => _vm.LaunchConfiguratorCommand.Execute(null);
-                menu.Add(cfg);
                 menu.Add(new NativeMenuItemSeparator());
+                menu.Add(TrayHeader(LocalizationManager.T("Main.SelectedBase")));
+                menu.Add(TrayInfobaseItem(sel, TrayItemName(sel.Name, "Main.SelectedBaseNoName")));
             }
 
-            // Синхронизация и настройки.
+            menu.Add(new NativeMenuItemSeparator());
+
             var sync = new NativeMenuItem(LocalizationManager.T("Main.SyncWithIbases"));
             sync.Click += (_, _) => _vm?.SynchronizeWithIbasesCommand.Execute(null);
             menu.Add(sync);
@@ -4857,6 +4848,49 @@ namespace Configuration_Management
                 _vm?.ExitCommand.Execute(null);
             };
             menu.Add(exitItem);
+        }
+
+        /// <summary>
+        /// Заголовок раздела в меню трея. В Windows это отдельный нерабочий
+        /// пункт (MainWindow.Tray.cs:216), здесь он же, но недоступный:
+        /// собственного вида у заголовка в системном меню нет.
+        /// </summary>
+        private static NativeMenuItem TrayHeader(string text) => new(text) { IsEnabled = false };
+
+        /// <summary>
+        /// Подпись базы в меню трея: пустое имя заменяется на подпись автора,
+        /// длинное обрезается до 48 знаков, как в Windows-версии
+        /// (MainWindow.Tray.cs:224).
+        /// </summary>
+        private static string TrayItemName(string? name, string emptyKey)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return LocalizationManager.T(emptyKey);
+            return name.Length > 48 ? name.Substring(0, 45) + "…" : name;
+        }
+
+        /// <summary>
+        /// Пункт базы с подменю выбора режима запуска: сам пункт запускает
+        /// Предприятие, подменю даёт Предприятие и Конфигуратор
+        /// (MainWindow.Tray.cs:271).
+        /// </summary>
+        private NativeMenuItem TrayInfobaseItem(Infobase ib, string title)
+        {
+            var baseRef = ib;
+            var item = new NativeMenuItem(title);
+            item.Click += (_, _) => LaunchInfobase(baseRef, configurator: false);
+
+            var submenu = new NativeMenu();
+            var enterprise = new NativeMenuItem(LocalizationManager.T("Main.Enterprise"));
+            enterprise.Click += (_, _) => LaunchInfobase(baseRef, configurator: false);
+            submenu.Add(enterprise);
+
+            var configurator = new NativeMenuItem(LocalizationManager.T("Main.SectionConfigurator"));
+            configurator.Click += (_, _) => LaunchInfobase(baseRef, configurator: true);
+            submenu.Add(configurator);
+
+            item.Menu = submenu;
+            return item;
         }
 
         private void SetupTray()
@@ -4899,7 +4933,7 @@ namespace Configuration_Management
         }
 
         /// <summary>Запускает базу из меню трея (Предприятие).</summary>
-        private void LaunchInfobase(Infobase ib)
+        private void LaunchInfobase(Infobase ib, bool configurator = false)
         {
             if (_vm is null)
                 return;
@@ -4911,7 +4945,10 @@ namespace Configuration_Management
                 return;
             }
             _vm.SelectedInfobase = ib;
-            _vm.LaunchEnterpriseCommand.Execute(null);
+            if (configurator)
+                _vm.LaunchConfiguratorCommand.Execute(null);
+            else
+                _vm.LaunchEnterpriseCommand.Execute(null);
         }
 
         /// <summary>

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -326,17 +326,14 @@ namespace Configuration_Management
 
             // Проверить доступность всех баз 1С: ручная команда вместо автопроверки при запуске.
             // Иконка — зелёный гидролокатор (сонар), как экран на подводных лодках.
-            var checkAvailBtn = new PanelButton(
-                "",
-                "ItemHoverBrush",
-                "SecondaryButtonPressedBrush",
-                "")
+            var checkAvailBtn = new Button
             {
                 Content = IconHelper.MakeIcon("IconSonar", UiMetrics.Scaled(18),
                     new SolidColorBrush(Color.Parse("#14B8A6"))),
-                Padding = new Thickness(UiMetrics.ButtonPadH, UiMetrics.ButtonPadV),
+                Padding = new Thickness(UiMetrics.Scaled(8)),
                 HorizontalContentAlignment = HorizontalAlignment.Center
             };
+            checkAvailBtn.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(checkAvailBtn, LocalizationManager.T("Main.CheckAvailabilityTooltip"));
             checkAvailBtn.Bind(Button.CommandProperty, new Binding("CheckAvailabilityCommand"));
             // Проверка доступности стоит между синхронизацией и темой, как у автора.
@@ -1174,7 +1171,6 @@ namespace Configuration_Management
                 Content = colorHex is not null
                     ? IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), new SolidColorBrush(Color.Parse(colorHex)))
                     : IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), brushKey ?? "TextSecondaryBrush"),
-                Padding = new Thickness(4),
                 Margin = new Thickness(1, 0),
                 MinWidth = 0,
                 MinHeight = 0,
@@ -1798,22 +1794,22 @@ namespace Configuration_Management
                     new SolidColorBrush(Color.Parse(colorHex)));
             }
 
-            // Не штатный Button: тема Fluent красит не саму кнопку, а её внутренний
-            // ContentPresenter через :pointerover, и локальный прозрачный Background
-            // этот фон не перебивает. Подсветка наведения оставалась висеть, когда
-            // строка пересобиралась под курсором, и фон то появлялся, то пропадал.
-            var button = new PanelButton("", "ItemHoverBrush", "SecondaryButtonPressedBrush", "",
-                new CornerRadius(UiMetrics.RadiusSm))
+            // Оформление берёт тема IconButton разметки: у автора все пять команд
+            // строки идут этим стилем с полем 1,0 (MainWindow.xaml:1282).
+            // Своя кнопка была нужна, пока темы не было: штатная тема Fluent красит
+            // не саму кнопку, а её внутренний ContentPresenter, и локальный
+            // прозрачный фон её не перебивал.
+            var button = new Button
             {
                 Content = glyph,
-                BorderThickness = new Thickness(0),
-                Padding = new Thickness(4),
+                Margin = new Thickness(1, 0),
                 MinWidth = 0,
                 MinHeight = 0,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
                 CommandParameter = ib
             };
+            button.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(button, tooltip);
             // Команда живёт во вьюмодели, а контекстом строки служит сама база.
             button.Bind(Button.CommandProperty, new Binding(commandPath) { Source = _vm });
@@ -4826,7 +4822,13 @@ namespace Configuration_Management
             {
                 menu.Add(new NativeMenuItemSeparator());
                 menu.Add(TrayHeader(LocalizationManager.T("Main.SelectedBase")));
-                menu.Add(TrayInfobaseItem(sel, TrayItemName(sel.Name, "Main.SelectedBaseNoName")));
+                // У выбранной базы сам пункт ничего не запускает, только раскрывает
+                // подменю, и её имя не обрезается: так у автора
+                // (MainWindow.Tray.cs:240).
+                var selName = string.IsNullOrWhiteSpace(sel.Name)
+                    ? LocalizationManager.T("Main.SelectedBaseNoName")
+                    : sel.Name;
+                menu.Add(TrayInfobaseItem(sel, selName, launchOnClick: false));
             }
 
             menu.Add(new NativeMenuItemSeparator());
@@ -4874,11 +4876,12 @@ namespace Configuration_Management
         /// Предприятие, подменю даёт Предприятие и Конфигуратор
         /// (MainWindow.Tray.cs:271).
         /// </summary>
-        private NativeMenuItem TrayInfobaseItem(Infobase ib, string title)
+        private NativeMenuItem TrayInfobaseItem(Infobase ib, string title, bool launchOnClick = true)
         {
             var baseRef = ib;
             var item = new NativeMenuItem(title);
-            item.Click += (_, _) => LaunchInfobase(baseRef, configurator: false);
+            if (launchOnClick)
+                item.Click += (_, _) => LaunchInfobase(baseRef, configurator: false);
 
             var submenu = new NativeMenu();
             var enterprise = new NativeMenuItem(LocalizationManager.T("Main.Enterprise"));
@@ -4944,11 +4947,7 @@ namespace Configuration_Management
                 QueueTrayMenuRefresh();
                 return;
             }
-            _vm.SelectedInfobase = ib;
-            if (configurator)
-                _vm.LaunchConfiguratorCommand.Execute(null);
-            else
-                _vm.LaunchEnterpriseCommand.Execute(null);
+            _vm.LaunchFromTray(ib, configurator);
         }
 
         /// <summary>

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -592,7 +592,7 @@ namespace Configuration_Management
         /// Явный цвет значка, как в разметке WPF: там часть команд верхней панели
         /// покрашена вручную, а часть берёт цвет из темы. Без него берётся тема.
         /// </param>
-        private static PanelButton TopBarIconButton(string iconKey, string tooltip, string? colorHex = null,
+        private static Button TopBarIconButton(string iconKey, string tooltip, string? colorHex = null,
             string themeBrushKey = "ButtonTextBrush")
         {
             Control icon;
@@ -606,21 +606,19 @@ namespace Configuration_Management
                     new SolidColorBrush(Color.Parse(colorHex)));
             }
 
-            // Плоская кнопка: у автора значковые команды верхней панели без
-            // подложки и рамки, подсветка появляется только при наведении.
-            // Подсветка наведения из ItemHover, а не из кремовой кисти вторичной
-            // кнопки: в тёмной теме та светлая, и значок на ней пропадал.
-            var button = new PanelButton(
-                "",
-                "ItemHoverBrush",
-                "SecondaryButtonPressedBrush",
-                "",
-                new CornerRadius(8))
+            // Оформление берёт тема IconButton разметки (LightTheme.xaml:561
+            // и DarkTheme.xaml:1105): прозрачный фон, скругление 8, отступ 8,
+            // подсветка только при наведении. Своя реализация красила наведение
+            // кистью ItemHover в обеих темах, тогда как в светлой у автора это
+            // серый #F1F5F9, и гасила недоступную кнопку прозрачностью, которой
+            // у этого стиля нет вовсе.
+            var button = new Button
             {
                 Content = icon,
                 Padding = new Thickness(UiMetrics.Scaled(8)),
                 HorizontalContentAlignment = HorizontalAlignment.Center
             };
+            button.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(button, tooltip);
             return button;
         }
@@ -1176,17 +1174,15 @@ namespace Configuration_Management
                 Content = colorHex is not null
                     ? IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), new SolidColorBrush(Color.Parse(colorHex)))
                     : IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), brushKey ?? "TextSecondaryBrush"),
-                Background = Brushes.Transparent,
-                BorderThickness = new Thickness(0),
                 Padding = new Thickness(4),
                 Margin = new Thickness(1, 0),
                 MinWidth = 0,
                 MinHeight = 0,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
-                Cursor = new Cursor(StandardCursorType.Hand),
                 CommandParameter = group
             };
+            button.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(button, tooltip);
             // Команда живёт во вьюмодели, а контекстом строки служит узел группы.
             button.Bind(Button.CommandProperty, new Binding(commandPath) { Source = _vm });
@@ -3552,20 +3548,17 @@ namespace Configuration_Management
         /// <summary>Компактная иконко-кнопка панели инструментов над списком.</summary>
         private Button HeaderIconButton(string iconKey, string tooltip, string commandPath)
         {
+            // Оформление берёт тема IconButton разметки (LightTheme.xaml:561):
+            // прозрачный фон, скругление 8, подсветка при наведении, отступ 8.
             var button = new Button
             {
-                // Отступ 8 и значок 15, как у IconButton в разметке
-                // (MainWindow.xaml:494, LightTheme.xaml:561): своя ширина 24
-                // делала кнопки заметно теснее.
                 Content = IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), "TextSecondaryBrush"),
-                Background = Brushes.Transparent,
-                BorderThickness = new Thickness(0),
                 Padding = new Thickness(UiMetrics.Scaled(8)),
                 MinWidth = 0,
                 MinHeight = 0,
-                VerticalAlignment = VerticalAlignment.Center,
-                Cursor = new Cursor(StandardCursorType.Hand)
+                VerticalAlignment = VerticalAlignment.Center
             };
+            button.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(button, tooltip);
             button.Bind(Button.CommandProperty, new Binding(commandPath));
             return button;
@@ -4083,11 +4076,14 @@ namespace Configuration_Management
                 Content = ThemedIconAndText("IconClose", LocalizationManager.T("Common.Clear"),
                     "ButtonTextBrush", UiMetrics.Scaled(12), centered: false, fontSize: UiMetrics.ScaledFont(11)),
                 Padding = new Thickness(4, 2),
-                Background = Brushes.Transparent,
-                BorderThickness = new Thickness(0),
                 HorizontalAlignment = HorizontalAlignment.Right,
                 VerticalAlignment = VerticalAlignment.Center
             };
+            // Оформление и состояния берёт тема HeaderIconButton разметки
+            // (LightTheme.xaml:586): наведение, нажатие и гашение у автора
+            // заданы, а здесь кнопка была плоской без единого состояния.
+            _tagClearButton.Styled(Themes.ControlThemes.HeaderIconButton);
+            ToolTip.SetTip(_tagClearButton, LocalizationManager.T("Main.ClearTagFilters"));
             _tagClearButton.Bind(Button.CommandProperty, new Binding("ClearTagFiltersCommand"));
 
             // Подсказка остаётся на месте и когда тегов нет: панель не прячется,
@@ -4271,22 +4267,22 @@ namespace Configuration_Management
         }
 
         /// <summary>
-        /// Кнопка строки состояния: плоская, со своим наведением по SidebarHover,
-        /// значок 18 контрастной кистью (стиль StatusBarIconButton, LightTheme.xaml:616).
+        /// Кнопка строки состояния: оформление берёт тема StatusBarIconButton
+        /// разметки (LightTheme.xaml:616). Нажатие у автора различается темами:
+        /// в светлой это тёмная заливка, в тёмной прозрачность 0.85, и тема
+        /// повторяет обе.
         /// </summary>
         private static Button StatusBarIconButton(string iconKey)
         {
-            var button = new PanelButton("", "SidebarHoverBrush", "SidebarHoverBrush", "",
-                new CornerRadius(6))
+            var button = new Button
             {
                 Content = IconHelper.MakeIcon(iconKey, 18, "TextOnAccentBrush"),
-                Padding = new Thickness(6, 4),
                 Margin = new Thickness(4, 0, 0, 0),
                 MinWidth = 0,
                 MinHeight = 0,
-                VerticalAlignment = VerticalAlignment.Center,
-                Cursor = new Cursor(StandardCursorType.Hand)
+                VerticalAlignment = VerticalAlignment.Center
             };
+            button.Styled(Themes.ControlThemes.StatusBarIconButton);
             return button;
         }
 

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -2652,7 +2652,7 @@ namespace Configuration_Management
             ToolTip.SetTip(main, tooltip);
             main.Bind(Button.CommandProperty, new Binding(commandPath));
 
-            var menu = new ContextMenu();
+            var menu = new ContextMenu().Styled(Themes.ControlThemes.ModernContextMenu);
             foreach (var (header, command, itemIcon, itemColor) in menuItems)
             {
                 if (header.Length == 0)
@@ -2665,6 +2665,7 @@ namespace Configuration_Management
                 // (MainWindow.xaml:1954 и 1962): настройка параметров голубая,
                 // запуск с авторизацией фиолетовый.
                 var item = new MenuItem { Header = header };
+                item.Styled(Themes.ControlThemes.ModernMenuItem);
                 if (itemIcon is not null)
                     item.Icon = IconHelper.MakeIcon(itemIcon, 18,
                         itemColor is not null ? new SolidColorBrush(Color.Parse(itemColor)) : Brushes.Gray);
@@ -4230,7 +4231,7 @@ namespace Configuration_Management
             _statusInfo.Bind(ToolTip.TipProperty, new Binding("StatusBarInfo"));
             if (_vm is not null)
             {
-                var statusMenu = new ContextMenu();
+                var statusMenu = new ContextMenu().Styled(Themes.ControlThemes.ModernContextMenu);
                 statusMenu.Items.Add(MenuAction("Main.CopyPath", _vm.CopyConnectionStringCommand, iconKey: "IconCopy"));
                 _statusInfo.ContextMenu = statusMenu;
             }
@@ -4548,7 +4549,7 @@ namespace Configuration_Management
         /// </summary>
         private ContextMenu BuildRowContextMenu()
         {
-            var menu = new ContextMenu();
+            var menu = new ContextMenu().Styled(Themes.ControlThemes.ModernContextMenu);
             if (_vm is null)
                 return menu;
 
@@ -4557,6 +4558,7 @@ namespace Configuration_Management
                 Header = LocalizationManager.T("Main.ClearCache"),
                 Icon = MenuIcon("IconBroom", "#14B8A6")
             };
+            cacheMenu.Styled(Themes.ControlThemes.ModernMenuItem);
             cacheMenu.Items.Add(MenuAction("Main.ClearProgramCache", _vm.ClearProgramCacheCommand));
             cacheMenu.Items.Add(MenuAction("Main.ClearUserCache", _vm.ClearUserCacheCommand));
             cacheMenu.Items.Add(new Separator());
@@ -4603,6 +4605,7 @@ namespace Configuration_Management
                 Header = LocalizationManager.T(textKey),
                 Command = command
             };
+            item.Styled(Themes.ControlThemes.ModernMenuItem);
             if (iconKey is not null && iconColor is not null)
                 item.Icon = MenuIcon(iconKey, iconColor);
             if (Controls.HotkeyBox.TryParse(gesture, out var parsed) && parsed is not null)


### PR DESCRIPTION
Окно выбора группы (`GroupPickerWindow`) в Linux-сборке приведено к разметке
`Configuration Management/Views/GroupPickerWindow.xaml`. Правки только в файлах
Avalonia, WPF-часть не тронута.

**Зависимость:** ветка построена поверх `linux-fixes-28` (PR #114), потому что обе
меняют `Configuration Management/Themes/Controls.axaml`. Мержить после #114,
иначе будет конфликт в этом файле.

### Что сделано

1. **Шаблон элемента дерева перенесён темой `GroupPickerTreeItem`**
   (`Configuration Management/Themes/Controls.axaml`). До этого дерево рисовалось
   штатной темой Fluent: шеврон вместо «+»/«-», своя подсветка, свои отступы.
   Перенесены все девять чисел из `GroupPickerWindow.xaml:32-66`: `Padding 4,2`,
   заголовок `CornerRadius 6` и `Padding 4,3` с полем `0,1`, колонка раскрывателя
   `24`, сам раскрыватель `20x22` с кеглем `16`, отступ вложенных `16,0,0,0`.
   Подсвечивается только выбранная строка, у листьев раскрывателя нет.

2. **Заголовки по виду объекта.** Перенесена ваша правка: заголовок, подзаголовок
   и справка берутся из пар ключей `GroupPicker.*Group` и `GroupPicker.*Base`.
   Добавлено перечисление `GroupPickerObjectKind`, вид передают три вызывающих
   окна: `GroupEditWindow.Avalonia.cs:439` (Group),
   `ConnectionSettingsWindow.Avalonia.cs:814` и
   `CreateInfobaseWindow.Avalonia.cs:617` (Infobase), как в WPF-двойниках.

3. **Геометрия окна и элементов.** Размеры `560x620` при минимуме `460x480`
   (`GroupPickerWindow.xaml:13-14`), отступ дерева `6`, панель инструментов
   `0,0,0,8`, кнопки сортировки `34x32` с полем `2,0` и отступом `2`, справка
   `8,0,0,0`, строка дерева `0,1`, цветной чип `Padding 6,3` с радиусом `6`
   вместо фиксированных `36x28`.

4. **Кнопки нижней панели** по стилям `OutlinedButton` и `PrimaryButton`
   (`GroupPickerWindow.xaml:115-160`): высота `38`, отступ `14,6`, минимальная
   ширина `116`, контур `1.5` у отмены и `0` у акцентной, прозрачный фон отмены
   с контуром `SecondaryButtonBackgroundBrush`, значок отмены `15`.

5. **Кнопки сортировки** в покое прозрачные с контуром `BorderBrushColor`,
   активная заливается `AccentBrush` со значком `TextOnAccentBrush`, наведение
   `ItemHoverBrush` (`GroupPickerWindow.xaml:85-110`). Раньше в Linux-версии
   активная кнопка обозначалась акцентной рамкой, а не заливкой.

6. **Двойной щелчок по группе с детьми не подтверждал выбор.** Avalonia помечает
   `DoubleTapped` обработанным в заголовке элемента дерева (это её раскрытие
   узла), и обработчик окна события не получал. У листьев работало, у групп
   с вложенными нет. Обработчик повешен через `AddHandler` с `handledEventsToo`.
   В WPF `MouseDoubleClick` доходит до `TreeView` всегда, так что расхождения
   в поведении между сборками теперь нет.

7. **Мелочи по разметке**: у карточки дерева снята мягкая тень (у вас плоская
   рамка), полю поиска возвращён фон `CardBackgroundBrush`, кегль подписи кнопок
   `13` вместо `13.5`.

### Вынужденное расхождение

Кнопки этого окна получили жёсткие `Height 38` и `Padding 14,6` из разметки
вместо метрик Linux-сборки, поэтому компактный режим (наша настройка плотности,
в Windows-версии её нет) на кнопки этого диалога больше не влияет. Выбор в пользу
совпадения с вашей разметкой.

### Проверено

Сборка `dotnet build -c Release` без ошибок и предупреждений AVLN. Окно открыто
живьём из настройки группы: тема дерева применяется, подсвечивается ровно
выбранная строка, у листьев раскрывателя нет, двойной щелчок подтверждает выбор
и подставляет группу в поле. Три встречных аудита: внешний по фактам Avalonia
11.3.20 (имена частей шаблона, псевдокласс `:empty`, двусторонняя привязка
раскрывателя), чтение вглубь по репозиторию и проверка перечислением всех чисел
разметки.
