### PR TITLE
Linux/Avalonia: колонки списка по набору автора

### DIFF
--- a/Configuration Management/Controls/LeveledTreeViewItem.Avalonia.cs
+++ b/Configuration Management/Controls/LeveledTreeViewItem.Avalonia.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Data;
+using Avalonia.Data.Converters;
 using Avalonia.Input;
 using Avalonia.Controls.Primitives;
 using Path = Avalonia.Controls.Shapes.Path;
@@ -34,7 +35,7 @@ namespace Configuration_Management.Controls
         private Control? _chevron;
 
         /// <summary>
-        /// Подсказка стрелки раскрытия. Сама стрелка приходит из шаблона Fluent,
+        /// Подсказка стрелки раскрытия. Кнопка приходит из нашего шаблона,
         /// поэтому ищется по имени части после его применения. В разметке WPF
         /// подсказка тоже своя на каждое состояние (MainWindow.xaml:1436 и 1439).
         /// </summary>
@@ -46,6 +47,99 @@ namespace Configuration_Management.Controls
                 chevron.Theme = ExpanderTheme();
             UpdateChevronTooltip();
         }
+
+        /// <summary>
+        /// Шаблон строки списка по разметке WPF (MainWindow.xaml:1432-1441):
+        /// колонка кнопки разворота по содержимому и колонка заголовка, а список
+        /// вложенных строк без отступа. Штатный шаблон Fluent вместо этого
+        /// сдвигает всю строку на каждый уровень вложенности, и тогда колонки
+        /// значений вложенных строк уезжают от заголовков, как только ширина
+        /// колонки «Название» задана числом.
+        /// </summary>
+        public static ControlTheme RowTheme()
+        {
+            var theme = new ControlTheme(typeof(TreeViewItem))
+            {
+                Setters =
+                {
+                    new Setter(TemplatedControl.BackgroundProperty, Brushes.Transparent),
+                    new Setter(TemplatedControl.PaddingProperty, new Thickness(0)),
+                    new Setter(TemplatedControl.BorderThicknessProperty, new Thickness(0)),
+                    new Setter(TemplatedControl.TemplateProperty, new FuncControlTemplate<TreeViewItem>((_, scope) =>
+                    {
+                        var chevron = new ToggleButton { Name = "PART_ExpandCollapseChevron" };
+                        chevron[!ToggleButton.IsCheckedProperty] = new Binding(nameof(TreeViewItem.IsExpanded))
+                        {
+                            RelativeSource = new RelativeSource(RelativeSourceMode.TemplatedParent),
+                            Mode = BindingMode.TwoWay
+                        };
+                        // Отступ уровня стоит на кнопке разворота, как у автора:
+                        // он сдвигает заголовок группы, а строка остаётся у края.
+                        chevron[!Layoutable.MarginProperty] = new Binding(nameof(TreeViewItem.Level))
+                        {
+                            RelativeSource = new RelativeSource(RelativeSourceMode.TemplatedParent),
+                            Converter = LevelIndent
+                        };
+                        chevron.RegisterInNameScope(scope);
+
+                        var header = new ContentPresenter
+                        {
+                            Name = "PART_HeaderPresenter",
+                            VerticalAlignment = VerticalAlignment.Center
+                        };
+                        header[!ContentPresenter.ContentProperty] =
+                            new TemplateBinding(HeaderedItemsControl.HeaderProperty);
+                        header[!ContentPresenter.ContentTemplateProperty] =
+                            new TemplateBinding(HeaderedItemsControl.HeaderTemplateProperty);
+                        header.RegisterInNameScope(scope);
+                        Grid.SetColumn(header, 1);
+
+                        var row = new Grid();
+                        row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto, MinWidth = 0 });
+                        row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                        row.Children.Add(chevron);
+                        row.Children.Add(header);
+
+                        var items = new ItemsPresenter { Name = "PART_ItemsPresenter" };
+                        items[!Visual.IsVisibleProperty] = new TemplateBinding(TreeViewItem.IsExpandedProperty);
+                        items[!ItemsPresenter.ItemsPanelProperty] = new TemplateBinding(ItemsControl.ItemsPanelProperty);
+                        items.RegisterInNameScope(scope);
+
+                        var stack = new StackPanel();
+                        stack.Children.Add(row);
+                        stack.Children.Add(items);
+                        return stack;
+                    }))
+                }
+            };
+
+            // У строки базы вложенных нет, и кнопка разворота ей не нужна:
+            // у автора она в этом случае Collapsed (MainWindow.xaml:1524).
+            theme.Add(new Style(x => x.Nesting().Class(":empty").Template().Name("PART_ExpandCollapseChevron"))
+            {
+                Setters = { new Setter(Visual.IsVisibleProperty, false) }
+            });
+            return theme;
+        }
+
+        /// <summary>Уровень вложенности в отступ слева: шаг 18, как у автора.</summary>
+        public static readonly IValueConverter LevelIndent =
+            new FuncValueConverter<int, Thickness>(level =>
+                new Thickness(level * Converters.LevelToThicknessConverter.IndentStep, 0, 0, 0));
+
+        /// <summary>
+        /// Уровень вложенности в отступ ведущего блока строки базы: отступ
+        /// родительской группы плюс ширина кнопки разворота, которой у строки
+        /// базы нет (MainWindow.xaml:1155, параметр конвертера «base»).
+        /// </summary>
+        public static readonly IValueConverter LeadIndent =
+            new FuncValueConverter<int, Thickness>(level => new Thickness(LeadIndentFor(level), 0, 0, 0));
+
+        /// <summary>Тот же отступ числом: нужен там, где у панели есть свои отступы по другим сторонам.</summary>
+        public static double LeadIndentFor(int level)
+            => (level > 0 ? level - 1 : 0) * Converters.LevelToThicknessConverter.IndentStep
+                + Converters.LevelToThicknessConverter.ExpanderWidth;
+
 
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {

--- a/Configuration Management/Themes/ControlThemes.Avalonia.cs
+++ b/Configuration Management/Themes/ControlThemes.Avalonia.cs
@@ -59,6 +59,8 @@ namespace Configuration_Management.Themes
 
         /// <summary>Значковая кнопка строки состояния: отступ 6 на 4, подсветка боковой панели.</summary>
         public const string StatusBarIconButton = "StatusBarIconButton";
+        /// <summary>Элемент дерева окна выбора группы: раскрыватель «+»/«-» и подсветка выбранной строки.</summary>
+        public const string GroupPickerTreeItem = "GroupPickerTreeItem";
 
         /// <summary>Плитка выбора значка группы: тёмная в обеих темах, как у автора.</summary>
         public const string IconPickButton = "IconPickButton";

--- a/Configuration Management/Themes/ControlThemes.Avalonia.cs
+++ b/Configuration Management/Themes/ControlThemes.Avalonia.cs
@@ -45,6 +45,12 @@ namespace Configuration_Management.Themes
         /// <summary>Переключатель настроек: дорожка 40 на 22 с кружком 16.</summary>
         public const string SettingsToggle = "SettingsToggle";
 
+        /// <summary>Всплывающее меню: карточный фон, контур, минимальная ширина 280.</summary>
+        public const string ModernContextMenu = "ModernContextMenu";
+
+        /// <summary>Пункт меню: отступ 12 на 6, скругление 4, подсветка выделенного.</summary>
+        public const string ModernMenuItem = "ModernMenuItem";
+
         /// <summary>Значковая кнопка: прозрачный фон, скругление 8, подсветка при наведении.</summary>
         public const string IconButton = "IconButton";
 

--- a/Configuration Management/Themes/ControlThemes.Avalonia.cs
+++ b/Configuration Management/Themes/ControlThemes.Avalonia.cs
@@ -45,6 +45,15 @@ namespace Configuration_Management.Themes
         /// <summary>Переключатель настроек: дорожка 40 на 22 с кружком 16.</summary>
         public const string SettingsToggle = "SettingsToggle";
 
+        /// <summary>Значковая кнопка: прозрачный фон, скругление 8, подсветка при наведении.</summary>
+        public const string IconButton = "IconButton";
+
+        /// <summary>Значковая кнопка заголовка: скругление 6, своё нажатие и гашение.</summary>
+        public const string HeaderIconButton = "HeaderIconButton";
+
+        /// <summary>Значковая кнопка строки состояния: отступ 6 на 4, подсветка боковой панели.</summary>
+        public const string StatusBarIconButton = "StatusBarIconButton";
+
         /// <summary>Плитка выбора значка группы: тёмная в обеих темах, как у автора.</summary>
         public const string IconPickButton = "IconPickButton";
 

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -20,6 +20,9 @@
             <SolidColorBrush x:Key="SecondaryButtonPressedSurfaceBrush" Color="{DynamicResource SecondaryButtonPressedColor}"/>
             <Thickness x:Key="SecondaryButtonOutlineThickness">0</Thickness>
             <SolidColorBrush x:Key="SettingsToggleTrackBrush">#CBD5E1</SolidColorBrush>
+            <SolidColorBrush x:Key="IconButtonHoverBrush">#F1F5F9</SolidColorBrush>
+            <SolidColorBrush x:Key="StatusBarIconPressedBrush">#0F172A</SolidColorBrush>
+            <x:Double x:Key="StatusBarIconPressedOpacity">1</x:Double>
         </ResourceDictionary>
         <!-- Тёмная: вторичная кнопка это карточка в контуре, при наведении контур акцентный. -->
         <ResourceDictionary x:Key="Dark">
@@ -31,6 +34,9 @@
             <SolidColorBrush x:Key="SecondaryButtonPressedSurfaceBrush" Color="{DynamicResource SidebarHoverColor}"/>
             <Thickness x:Key="SecondaryButtonOutlineThickness">1</Thickness>
             <SolidColorBrush x:Key="SettingsToggleTrackBrush">#475569</SolidColorBrush>
+            <SolidColorBrush x:Key="IconButtonHoverBrush" Color="{DynamicResource ItemHoverColor}"/>
+            <SolidColorBrush x:Key="StatusBarIconPressedBrush" Color="{DynamicResource SidebarHoverColor}"/>
+            <x:Double x:Key="StatusBarIconPressedOpacity">0.85</x:Double>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
@@ -754,6 +760,103 @@
         <Style Selector="^:pointerover /template/ Border#PART_Surface">
             <Setter Property="Background" Value="#4B5563"/>
             <Setter Property="BorderBrush" Value="#9CA3AF"/>
+        </Style>
+    </ControlTheme>
+    <!-- ===================== Значковые кнопки =====================
+         Стили IconButton (LightTheme.xaml:561, DarkTheme.xaml:1105),
+         HeaderIconButton (:586 и :1130) и StatusBarIconButton (:616 и :1160).
+         Различие тем у первой одно: в светлой наведение задано числом #F1F5F9,
+         в тёмной берётся ItemHoverBrush, поэтому кисть вынесена в словари темы.
+         Триггера недоступности у IconButton в разметке нет вовсе. -->
+    <ControlTheme x:Key="IconButton" TargetType="Button">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="8"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        BorderThickness="0"
+                        CornerRadius="8"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource IconButtonHoverBrush}"/>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="HeaderIconButton" TargetType="Button" BasedOn="{StaticResource IconButton}">
+        <Setter Property="Padding" Value="5"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        BorderThickness="0"
+                        CornerRadius="6"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+        </Style>
+        <Style Selector="^:pressed /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource SecondaryButtonHoverBrush}"/>
+        </Style>
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value="0.4"/>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="StatusBarIconButton" TargetType="Button" BasedOn="{StaticResource IconButton}">
+        <Setter Property="Padding" Value="6,4"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="PART_Surface"
+                        Background="{TemplateBinding Background}"
+                        BorderThickness="0"
+                        CornerRadius="6"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource SidebarHoverBrush}"/>
+        </Style>
+        <!-- Нажатие у автора различается темами: в светлой это заливка числом,
+             в тёмной прозрачность 0.85 (LightTheme.xaml:634, DarkTheme.xaml:1178). -->
+        <Style Selector="^:pressed /template/ Border#PART_Surface">
+            <Setter Property="Background" Value="{DynamicResource StatusBarIconPressedBrush}"/>
+        </Style>
+        <Style Selector="^:pressed">
+            <Setter Property="Opacity" Value="{DynamicResource StatusBarIconPressedOpacity}"/>
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -859,4 +859,53 @@
             <Setter Property="Opacity" Value="{DynamicResource StatusBarIconPressedOpacity}"/>
         </Style>
     </ControlTheme>
+    <!-- Ресурсы штатной темы, которыми она красит всплывающее меню и колонку
+         значка. Через ресурсы, а не селектором: подменю живёт в своём Popup,
+         и его рамка получает значения прямо из шаблона. Числа из разметки
+         (LightTheme.xaml:817 и :742): фон карточки, контур темы, толщина 1,
+         внутренний отступ 4, зазор после значка 8 вместо штатных 12. -->
+    <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="{DynamicResource CardBackgroundColor}"/>
+    <SolidColorBrush x:Key="MenuFlyoutPresenterBorderBrush" Color="{DynamicResource BorderColor}"/>
+    <Thickness x:Key="MenuFlyoutPresenterBorderThemeThickness">1</Thickness>
+    <Thickness x:Key="MenuFlyoutPresenterThemePadding">4</Thickness>
+    <Thickness x:Key="MenuIconPresenterMargin">0,0,8,0</Thickness>
+
+    <!-- ===================== Меню =====================
+         Стили ModernContextMenu (LightTheme.xaml:817) и ModernMenuItem (:742);
+         в тёмной теме оба дословно те же. Темы наследуют штатные: у MenuItem
+         обязательна часть PART_Popup, без неё не открывается подменю, а у
+         ContextMenu нужен ItemsPresenter, иначе пункты не показываются.
+         Подсветка пункта идёт по :selected, а не по :pointerover: именно так
+         обработчик меню помечает пункт под указателем, и так же устроена
+         штатная тема. -->
+    <ControlTheme x:Key="ModernContextMenu" TargetType="ContextMenu" BasedOn="{StaticResource {x:Type ContextMenu}}">
+        <Setter Property="MinWidth" Value="280"/>
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushColor}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Padding" Value="4"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <!-- Аналог HasDropShadow разметки: подсказка оконному менеджеру. -->
+        <Setter Property="WindowManagerAddShadowHint" Value="True"/>
+    </ControlTheme>
+
+    <ControlTheme x:Key="ModernMenuItem" TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="Padding" Value="12,6"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="CornerRadius" Value="4"/>
+        <Setter Property="Margin" Value="2,1"/>
+
+        <Style Selector="^:selected /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+        </Style>
+        <Style Selector="^:selected">
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        </Style>
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value="0.5"/>
+        </Style>
+    </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -898,14 +898,26 @@
         <Setter Property="CornerRadius" Value="4"/>
         <Setter Property="Margin" Value="2,1"/>
 
+        <!-- Цвет подписи штатная тема меняет не на контроле, а на части шаблона,
+             поэтому и здесь красится часть: у автора подсветка меняет только фон
+             (LightTheme.xaml:804), цвет текста остаётся прежним. -->
         <Style Selector="^:selected /template/ Border#PART_LayoutRoot">
             <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
         </Style>
-        <Style Selector="^:selected">
+        <Style Selector="^:selected /template/ ContentPresenter#PART_HeaderPresenter">
             <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
         </Style>
+        <!-- Недоступный пункт у автора только гаснет прозрачностью
+             (LightTheme.xaml:807), фон и цвет текста не меняются, поэтому
+             перекраска штатной темы снимается. -->
         <Style Selector="^:disabled">
             <Setter Property="Opacity" Value="0.5"/>
+        </Style>
+        <Style Selector="^:disabled /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="Transparent"/>
+        </Style>
+        <Style Selector="^:disabled /template/ ContentPresenter#PART_HeaderPresenter">
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -920,4 +920,55 @@
             <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
         </Style>
     </ControlTheme>
+    <!-- Элемент дерева окна выбора группы: шаблон автора
+         (GroupPickerWindow.xaml:29). Раскрыватель это «+»/«-» в колонке 24,
+         подсвечивается только сама выбранная строка, вложенные сдвинуты на 16. -->
+    <ControlTheme x:Key="GroupPickerTreeItem" TargetType="TreeViewItem">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="IsExpanded" Value="True"/>
+        <Setter Property="Padding" Value="4,2"/>
+        <Setter Property="Template">
+            <ControlTemplate>
+                <StackPanel>
+                    <Border x:Name="PART_Header" Background="Transparent" CornerRadius="6"
+                            Padding="4,3" Margin="0,1">
+                        <Grid ColumnDefinitions="24,*">
+                            <ToggleButton x:Name="PART_ExpandCollapseChevron" Grid.Column="0"
+                                          IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource AncestorType=TreeViewItem}, Mode=TwoWay}"
+                                          ClickMode="Press" Width="20" Height="22"
+                                          Background="Transparent" BorderThickness="0" Padding="0"
+                                          Cursor="Hand" VerticalAlignment="Center">
+                                <ToggleButton.Template>
+                                    <ControlTemplate>
+                                        <TextBlock x:Name="ExpanderSymbol" Text="+"
+                                                   FontSize="16" FontWeight="Bold"
+                                                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                   Foreground="{DynamicResource TextSecondaryBrush}"/>
+                                    </ControlTemplate>
+                                </ToggleButton.Template>
+                                <ToggleButton.Styles>
+                                    <Style Selector="ToggleButton:checked /template/ TextBlock#ExpanderSymbol">
+                                        <Setter Property="Text" Value="-"/>
+                                    </Style>
+                                </ToggleButton.Styles>
+                            </ToggleButton>
+                            <ContentPresenter x:Name="PART_HeaderPresenter" Grid.Column="1"
+                                              Content="{TemplateBinding Header}"
+                                              ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                              VerticalAlignment="Center"/>
+                        </Grid>
+                    </Border>
+                    <ItemsPresenter x:Name="PART_ItemsPresenter" Margin="16,0,0,0"
+                                    IsVisible="{TemplateBinding IsExpanded}"
+                                    ItemsPanel="{TemplateBinding ItemsPanel}"/>
+                </StackPanel>
+            </ControlTemplate>
+        </Setter>
+        <Style Selector="^:empty /template/ ToggleButton#PART_ExpandCollapseChevron">
+            <Setter Property="IsVisible" Value="False"/>
+        </Style>
+        <Style Selector="^:selected /template/ Border#PART_Header">
+            <Setter Property="Background" Value="{DynamicResource TreeSelectedBrush}"/>
+        </Style>
+    </ControlTheme>
 </ResourceDictionary>

--- a/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
+++ b/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
@@ -1719,6 +1719,36 @@ public class MainViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Запуск базы из меню трея: прямо по ссылке, не трогая выделение в списке.
+    /// В Windows-версии это делает LaunchInfobaseById (MainViewModel.Commands.cs:544),
+    /// и она тоже не меняет SelectedInfobase: иначе запуск из трея переставлял бы
+    /// выделение, правую панель и строку состояния. Источник записи в истории
+    /// тот же, что у автора.
+    /// </summary>
+    public void LaunchFromTray(Infobase ib, bool configurator)
+    {
+        if (!_allInfobases.Contains(ib))
+            return;
+
+        var ok = configurator
+            ? _launcher.Launch(ib, Services.OneCLaunchMode.Configurator)
+            : _launcher.Launch(ib, Services.OneCLaunchMode.Enterprise);
+
+        if (ok)
+        {
+            ib.AddLaunchHistory(configurator ? "Configurator" : "Enterprise", "tray");
+            SaveSilently();
+            OnPropertyChanged(nameof(RecentInfobases));
+            _logger.Info($"[tray] Запущена «{ib.Name}» ({(configurator ? "Конфигуратор" : "Предприятие")})");
+            NotifyAfterLaunch();
+        }
+        else
+        {
+            _logger.Warn($"[tray] Не удалось запустить «{ib.Name}»");
+        }
+    }
+
     private void OnLaunched()
     {
         if (SelectedInfobase is not null)

--- a/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
+++ b/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
@@ -3763,12 +3763,15 @@ public class MainViewModel : ViewModelBase
 
     // ======================= Этап 6: папки / ярлыки / стартер =======================
 
-    /// <summary>Недавно запускавшиеся базы (для меню трея). До 8 по дате запуска.</summary>
+    /// <summary>
+    /// Недавно запускавшиеся базы (для меню трея). До семи по дате запуска,
+    /// как в Windows-версии (MainWindow.Tray.cs:216 запрашивает семь).
+    /// </summary>
     public List<Infobase> RecentInfobases =>
         _allInfobases
             .Where(ib => ib.LastLaunchDate.HasValue)
             .OrderByDescending(ib => ib.LastLaunchDate)
-            .Take(8)
+            .Take(7)
             .ToList();
 
     /// <summary>Все информационные базы (для диалога выбора при очистке кеша).</summary>

--- a/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
+++ b/Configuration Management/ViewModels/MainViewModel.Avalonia.cs
@@ -789,7 +789,7 @@ public class MainViewModel : ViewModelBase
     /// конце). Используется, пока пользователь не задал собственный порядок.
     /// </summary>
     private static readonly string[] DefaultColumnOrder =
-        { "Version", "LaunchMode", "ServerBase", "LastLaunch", "Size", "Configuration" };
+        { "Version", "LaunchMode", "Actions", "ServerBase", "LastLaunch", "Size", "Configuration" };
 
     /// <summary>
     /// Порядок колонок списка баз слева направо (кроме фиксированных колонок

--- a/Configuration Management/Views/ConnectionSettingsWindow.Avalonia.cs
+++ b/Configuration Management/Views/ConnectionSettingsWindow.Avalonia.cs
@@ -810,7 +810,8 @@ namespace Configuration_Management
                 _viewModel.Groups,
                 currentGroupId: _viewModel.SelectedGroup?.Id,
                 allowNone: true,
-                noneLabel: LocalizationManager.T("Connection.NoGroup"));
+                noneLabel: LocalizationManager.T("Connection.NoGroup"),
+                kind: GroupPickerObjectKind.Infobase);
             if (dialog.ShowDialogSync(this))
             {
                 _viewModel.SelectedGroup = dialog.ResultGroup;

--- a/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
+++ b/Configuration Management/Views/CreateInfobaseWindow.Avalonia.cs
@@ -613,7 +613,8 @@ namespace Configuration_Management
                 _groups,
                 currentGroupId: null,
                 allowNone: true,
-                noneLabel: LocalizationManager.T("Connection.NoGroup"));
+                noneLabel: LocalizationManager.T("Connection.NoGroup"),
+                kind: GroupPickerObjectKind.Infobase);
             if (dialog.ShowDialogSync(this))
             {
                 _selectedGroupPath = string.IsNullOrWhiteSpace(dialog.ResultFullPath)

--- a/Configuration Management/Views/GroupEditWindow.Avalonia.cs
+++ b/Configuration Management/Views/GroupEditWindow.Avalonia.cs
@@ -435,7 +435,8 @@ namespace Configuration_Management
                 currentGroupId: _parentId,
                 excludeGroupId: _editingGroup?.Id,
                 allowNone: true,
-                noneLabel: LocalizationManager.T("GroupEdit.RootGroup"));
+                noneLabel: LocalizationManager.T("GroupEdit.RootGroup"),
+                kind: GroupPickerObjectKind.Group);
             if (dialog.ShowDialogSync(this))
             {
                 _parentId = dialog.ResultGroupId;

--- a/Configuration Management/Views/GroupPickerWindow.Avalonia.cs
+++ b/Configuration Management/Views/GroupPickerWindow.Avalonia.cs
@@ -9,6 +9,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
@@ -20,6 +21,18 @@ using Configuration_Management.ViewModels;
 
 namespace Configuration_Management
 {
+    /// <summary>
+    /// Вид объекта, для которого выбирается группа: от него зависят заголовок,
+    /// подзаголовок и текст справки (GroupPickerWindow.xaml.cs:11).
+    /// В Windows-версии это перечисление объявлено в code-behind, который
+    /// в Linux-сборку не входит, поэтому здесь свой такой же.
+    /// </summary>
+    public enum GroupPickerObjectKind
+    {
+        Group,
+        Infobase
+    }
+
     /// <summary>
     /// Диалог выбора группы в виде дерева (или «Без группы» / корень) в стиле Material Design:
     /// шапка с иконкой и подзаголовком, поле поиска, переключатель сортировки, карточка-дерево
@@ -51,18 +64,37 @@ namespace Configuration_Management
         /// <param name="excludeGroupId">Группа, которую нельзя выбрать (сама редактируемая + потомки отфильтруются).</param>
         /// <param name="allowNone">Разрешить выбор «Без группы» / корень.</param>
         /// <param name="noneLabel">Подпись корневого пункта.</param>
+        /// <summary>Вид объекта, для которого выбирают группу: от него зависят формулировки.</summary>
+        private readonly GroupPickerObjectKind _objectKind;
+
+        private string TitleKey => _objectKind == GroupPickerObjectKind.Infobase
+            ? "GroupPicker.TitleBase"
+            : "GroupPicker.TitleGroup";
+
+        private string SubtitleKey => _objectKind == GroupPickerObjectKind.Infobase
+            ? "GroupPicker.SubtitleBase"
+            : "GroupPicker.SubtitleGroup";
+
+        private string HelpKey => _objectKind == GroupPickerObjectKind.Infobase
+            ? "GroupPicker.HelpBase"
+            : "GroupPicker.HelpGroup";
+
         public GroupPickerWindow(
             IEnumerable<Group> groups,
             string? currentGroupId = null,
             string? excludeGroupId = null,
             bool allowNone = true,
-            string noneLabel = "")
+            string noneLabel = "",
+            GroupPickerObjectKind kind = GroupPickerObjectKind.Group)
         {
-            Title = LocalizationManager.T("GroupPicker.Title");
-            Width = 520;
-            Height = 600;
-            MinWidth = 440;
-            MinHeight = 460;
+            // Формулировки зависят от того, для чего выбирают группу: для базы
+            // или для другой группы (GroupPickerWindow.xaml.cs:70).
+            _objectKind = kind;
+            Title = LocalizationManager.T(TitleKey);
+            Width = 560;
+            Height = 620;
+            MinWidth = 460;
+            MinHeight = 480;
 
             _groups = groups.ToList();
             _currentGroupId = currentGroupId ?? string.Empty;
@@ -154,16 +186,16 @@ namespace Configuration_Management
             // занимает остаток, и после titleStack кружок «?» встал бы не к краю.
             var help = new HelpLink
             {
-                HelpText = LocalizationManager.T("GroupPicker.Help"),
+                HelpText = LocalizationManager.T(HelpKey),
                 VerticalAlignment = VerticalAlignment.Top,
-                Margin = new Thickness(12, 4, 0, 0)
+                Margin = new Thickness(8, 0, 0, 0)
             };
             DockPanel.SetDock(help, Dock.Right);
             header.Children.Add(help);
 
             var titleStack = new StackPanel { Spacing = 2 };
-            titleStack.Children.Add(ThemedText(LocalizationManager.T("GroupPicker.Title"), 17, secondary: false, FontWeight.SemiBold));
-            var subtitle = ThemedText(LocalizationManager.T("GroupPicker.Subtitle"), 12.5, secondary: true, FontWeight.Normal);
+            titleStack.Children.Add(ThemedText(LocalizationManager.T(TitleKey), 17, secondary: false, FontWeight.SemiBold));
+            var subtitle = ThemedText(LocalizationManager.T(SubtitleKey), 12.5, secondary: true, FontWeight.Normal);
             subtitle.TextWrapping = TextWrapping.Wrap;
             titleStack.Children.Add(subtitle);
             header.Children.Add(titleStack);
@@ -173,13 +205,15 @@ namespace Configuration_Management
 
         private Control BuildToolbar()
         {
-            var toolbar = new Grid { Margin = new Thickness(0, 0, 0, 10) };
+            var toolbar = new Grid { Margin = new Thickness(0, 0, 0, 8) };
             toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
             toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
             toolbar.Children.Add(BuildSearchField());
 
-            var sortPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6, Margin = new Thickness(10, 0, 0, 0) };
+            // Кнопки сортировки: ширина 34 и поле 2,0 из разметки
+            // (GroupPickerWindow.xaml:86), зазор задаётся полем кнопок.
+            var sortPanel = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(10, 0, 0, 0) };
             _sortAsc = BuildSortToggle("IconSortAscending", LocalizationManager.T("Main.SortGroupsAscending"), isAscending: true);
             _sortDesc = BuildSortToggle("IconSortDescending", LocalizationManager.T("Main.SortGroupsDescending"), isAscending: false);
             sortPanel.Children.Add(_sortAsc);
@@ -200,6 +234,7 @@ namespace Configuration_Management
                 Padding = new Thickness(10, 2)
             };
             ThemeBrushes.Bind(field, Border.BorderBrushProperty, "BorderColorBrush");
+            ThemeBrushes.Bind(field, Border.BackgroundProperty, "CardBackgroundColorBrush");
 
             var grid = new Grid();
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
@@ -262,31 +297,36 @@ namespace Configuration_Management
             };
             ThemeBrushes.Bind(card, Border.BackgroundProperty, "CardBackgroundColorBrush");
             ThemeBrushes.Bind(card, Border.BorderBrushProperty, "BorderColorBrush");
-            UiMetrics.AddSoftShadow(card);
 
             var root = new Grid();
-            root.RowDefinitions.Add(new RowDefinition(new GridLength(1, GridUnitType.Star)));
-            root.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
 
             _tree.ItemTemplate = new FuncTreeDataTemplate(
                 typeof(object),
                 (item, _) => BuildTreeRow(item),
                 item => item is GroupNodeViewModel g && g.HasChildren ? g.Children : null);
+            if (Application.Current?.TryFindResource(ControlThemes.GroupPickerTreeItem, out var treeItemTheme) == true
+                && treeItemTheme is ControlTheme itemTheme)
+            {
+                _tree.ItemContainerTheme = itemTheme;
+            }
             _tree.SelectionChanged += (_, _) =>
             {
                 _selectedNode = _tree.SelectedItem as GroupNodeViewModel;
                 UpdateSelection();
             };
-            _tree.DoubleTapped += (_, _) =>
+            // Двойной щелчок доходит до дерева только с handledEventsToo: у элемента
+            // с детьми Avalonia помечает событие обработанным (раскрытие узла), а
+            // разметка WPF подтверждает выбор при щелчке по любому узлу.
+            _tree.AddHandler(InputElement.DoubleTappedEvent, (object? _, TappedEventArgs _) =>
             {
                 if (_selectedNode is not null)
                     OnSelect_Click();
-            };
+            }, RoutingStrategies.Bubble, handledEventsToo: true);
 
             var treeHost = new ScrollViewer
             {
                 Content = _tree,
-                Padding = new Thickness(8, 6),
+                Padding = new Thickness(6),
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
                 VerticalScrollBarVisibility = ScrollBarVisibility.Auto
             };
@@ -312,16 +352,17 @@ namespace Configuration_Management
             var row = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
-                Spacing = 8,
-                Margin = new Thickness(4, 3)
+                Margin = new Thickness(0, 1)
             };
 
-            // Крупный цветной «чип» с иконкой группы — выразительнее и лучше читается.
+            // Цветной чип со значком группы: размер задаётся отступом, как
+            // в разметке (GroupPickerWindow.xaml:271), а не фиксированной
+            // шириной с высотой.
             var chip = new Border
             {
-                Width = 36,
-                Height = 28,
-                CornerRadius = new CornerRadius(UiMetrics.RadiusSm),
+                Padding = new Thickness(6, 3),
+                Margin = new Thickness(0, 0, 8, 0),
+                CornerRadius = new CornerRadius(6),
                 VerticalAlignment = VerticalAlignment.Center,
                 Background = node.HeaderBrush,
                 Child = new Avalonia.Controls.Shapes.Path
@@ -376,12 +417,12 @@ namespace Configuration_Management
             _selectButton = BuildActionButton(
                 "AccentBrush", "AccentHoverBrush", "AccentPressedBrush", "AccentBrush",
                 ActionContent("IconCheck", LocalizationManager.T("Common.Select"), "TextOnAccentBrush"),
-                minWidth: 132, isCancel: false, isDefault: true, onClick: OnSelect_Click);
+                minWidth: 116, isCancel: false, isDefault: true, onClick: OnSelect_Click);
             buttons.Children.Add(_selectButton);
 
             buttons.Children.Add(BuildActionButton(
-                "SecondaryButtonBackgroundBrush", "SecondaryButtonHoverBrush", "SecondaryButtonPressedBrush", "BorderColorBrush",
-                ActionContent("IconClose", LocalizationManager.T("Common.Cancel"), "ButtonTextBrush"),
+                "", "SecondaryButtonHoverBrush", "SecondaryButtonPressedBrush", "SecondaryButtonBackgroundBrush",
+                ActionContent("IconClose", LocalizationManager.T("Common.Cancel"), "ButtonTextBrush", iconSize: 15),
                 minWidth: 116, isCancel: true, isDefault: false, onClick: () => Close()));
             Grid.SetColumn(buttons, 1);
             footer.Children.Add(buttons);
@@ -398,14 +439,17 @@ namespace Configuration_Management
             string baseKey, string hoverKey, string pressedKey, string borderKey,
             Control content, double minWidth, bool isCancel, bool isDefault, Action onClick)
         {
+            // Высота 38, отступ 14 на 6 и контур 1.5 из стилей разметки
+            // (GroupPickerWindow.xaml:117): у акцентной кнопки контура нет.
             var btn = new Button
             {
                 Content = content,
                 MinWidth = minWidth,
-                Padding = new Thickness(UiMetrics.ButtonPadH, UiMetrics.ButtonPadV),
+                Height = 38,
+                Padding = new Thickness(14, 6),
                 HorizontalContentAlignment = HorizontalAlignment.Center,
                 VerticalContentAlignment = VerticalAlignment.Center,
-                BorderThickness = new Thickness(1),
+                BorderThickness = new Thickness(isDefault ? 0 : 1.5),
                 Cursor = new Cursor(StandardCursorType.Hand),
                 IsCancel = isCancel,
                 IsDefault = isDefault
@@ -438,18 +482,19 @@ namespace Configuration_Management
             return btn;
         }
 
-        /// <summary>Переключатель сортировки (А→Я / Я→А): активное состояние — акцентная заливка.</summary>
+        /// <summary>Переключатель сортировки (А→Я / Я→А): активный заливается акцентом, значок белеет.</summary>
         private ToggleButton BuildSortToggle(string iconKey, string tooltip, bool isAscending)
         {
             var toggle = new ToggleButton
             {
-                Width = 36,
+                Width = 34,
                 Height = 32,
-                Padding = new Thickness(0),
+                Margin = new Thickness(2, 0),
+                Padding = new Thickness(2),
                 BorderThickness = new Thickness(1),
                 Cursor = new Cursor(StandardCursorType.Hand),
                 IsChecked = isAscending == _sortAscending,
-                Content = IconHelper.MakeIcon(iconKey, 16, "ButtonTextBrush")
+                Content = IconHelper.MakeIcon(iconKey, 16, out var iconPath)
             };
             ToolTip.SetTip(toggle, tooltip);
 
@@ -475,9 +520,10 @@ namespace Configuration_Management
                 }
             };
 
-            var state = new ToggleState();
-            ThemeBrushes.Observe(toggle, "SecondaryButtonBackgroundBrush", b => { state.Base = b; state.Apply(toggle); });
-            ThemeBrushes.Observe(toggle, "SecondaryButtonHoverBrush", b => { state.Hover = b; state.Apply(toggle); });
+            var state = new ToggleState { Icon = iconPath };
+            ThemeBrushes.Observe(toggle, "ItemHoverBrush", b => { state.Hover = b; state.Apply(toggle); });
+            ThemeBrushes.Observe(toggle, "ButtonTextBrush", b => { state.IconBase = b; state.Apply(toggle); });
+            ThemeBrushes.Observe(toggle, "TextOnAccentBrush", b => { state.IconOnAccent = b; state.Apply(toggle); });
             ThemeBrushes.Observe(toggle, "SecondaryButtonPressedBrush", b => { state.Pressed = b; state.Apply(toggle); });
             ThemeBrushes.Observe(toggle, "BorderColorBrush", b => { state.Border = b; state.Apply(toggle); });
             ThemeBrushes.Observe(toggle, "AccentBrush", b => { state.Accent = b; state.Apply(toggle); });
@@ -516,7 +562,8 @@ namespace Configuration_Management
             string baseKey, string hoverKey, string pressedKey, string borderKey, bool? isActive)
         {
             var state = new ToggleState();
-            ThemeBrushes.Observe(btn, baseKey, b => { state.Base = b; state.Apply(btn); });
+            if (baseKey.Length > 0)
+                ThemeBrushes.Observe(btn, baseKey, b => { state.Base = b; state.Apply(btn); });
             ThemeBrushes.Observe(btn, hoverKey, b => { state.Hover = b; state.Apply(btn); });
             ThemeBrushes.Observe(btn, pressedKey, b => { state.Pressed = b; state.Apply(btn); });
             ThemeBrushes.Observe(btn, borderKey, b => { state.Border = b; state.Apply(btn); });
@@ -547,12 +594,12 @@ namespace Configuration_Management
         }
 
         /// <summary>Содержимое кнопки: иконка + подпись цветом из темы.</summary>
-        private static Control ActionContent(string iconKey, string text, string brushKey)
+        private static Control ActionContent(string iconKey, string text, string brushKey, double iconSize = 16)
         {
             var tb = new TextBlock
             {
                 Text = text,
-                FontSize = 13.5,
+                FontSize = 13,
                 FontWeight = FontWeight.SemiBold,
                 VerticalAlignment = VerticalAlignment.Center
             };
@@ -563,7 +610,7 @@ namespace Configuration_Management
                 Spacing = 6,
                 Children =
                 {
-                    IconHelper.MakeIcon(iconKey, 16, brushKey),
+                    IconHelper.MakeIcon(iconKey, iconSize, brushKey),
                     tb
                 }
             };
@@ -720,27 +767,30 @@ namespace Configuration_Management
             public IBrush Pressed = Brushes.Transparent;
             public IBrush Border = Brushes.Transparent;
             public IBrush Accent = Brushes.Transparent;
+            public IBrush IconBase = Brushes.Transparent;
+            public IBrush IconOnAccent = Brushes.Transparent;
+            public Avalonia.Controls.Shapes.Path? Icon;
             public bool Hovered;
             public bool IsPressed;
 
             public void Apply(Button btn)
             {
                 var isActive = btn is ToggleButton t && t.IsChecked == true;
+                var fill = isActive ? Accent : (IsPressed ? Pressed : (Hovered ? Hover : Base));
+                if (Icon is not null)
+                    Icon.Fill = isActive ? IconOnAccent : IconBase;
+
                 if (!btn.IsEnabled)
                 {
                     btn.Opacity = 0.5;
-                    btn.Background = Base;
-                    btn.BorderBrush = isActive ? Accent : Border;
-                    btn.BorderThickness = new Thickness(isActive ? 2 : 1);
+                    btn.Background = fill;
+                    btn.BorderBrush = Border;
                     return;
                 }
 
                 btn.Opacity = 1.0;
-                btn.Background = IsPressed ? Pressed : (Hovered ? Hover : Base);
-                btn.BorderBrush = isActive ? Accent : Border;
-                // Активный сегмент сортировки подсвечивается акцентной рамкой (как сегментный
-                // переключатель Material): контраст иконки сохраняется в обеих темах.
-                btn.BorderThickness = new Thickness(isActive ? 2 : 1);
+                btn.Background = fill;
+                btn.BorderBrush = Border;
             }
         }
 

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -1156,8 +1156,10 @@ namespace Configuration_Management
             deleteBtn.IsVisible = group.Marker != GroupNodeViewModel.PinnedMarker
                                   && group.Marker != GroupNodeViewModel.NoGroupMarker;
             actions.Children.Add(deleteBtn);
-            Grid.SetColumn(actions, actionsIndex);
-            row.Children.Add(actions);
+            var groupActionsHost = new Panel { ClipToBounds = true };
+            groupActionsHost.Children.Add(actions);
+            Grid.SetColumn(groupActionsHost, actionsIndex);
+            row.Children.Add(groupActionsHost);
 
             Grid.SetColumn(caption, 0);
             Grid.SetColumnSpan(caption, actionsIndex);
@@ -1400,8 +1402,13 @@ namespace Configuration_Management
             actions.Children.Add(RowActionButton(ib, "IconEdit", "EditInfobaseCommand", LocalizationManager.T("Main.EditBaseTooltip")));
             actions.Children.Add(RowActionButton(ib, "IconBroom", "ClearCacheCommand", LocalizationManager.T("Main.ClearCacheTooltip")));
             actions.Children.Add(RowActionButton(ib, "IconDelete", "DeleteInfobaseCommand", LocalizationManager.T("Main.DeleteTooltip"), "#DC2626"));
-            grid.Children.Add(actions);
-            Grid.SetColumn(actions, actionsCol);
+            // Кнопки живут внутри обрезающей колонку панели: в узкой колонке
+            // «Действия» они у автора просто срезаются её границей, а у нас
+            // вылезали поверх колонки «Сервер/База».
+            var actionsHost = new Panel { ClipToBounds = true };
+            actionsHost.Children.Add(actions);
+            grid.Children.Add(actionsHost);
+            Grid.SetColumn(actionsHost, actionsCol);
 
             if (_vm?.ShowTags == true)
             {
@@ -1411,7 +1418,7 @@ namespace Configuration_Management
                 // действиями и остальными значениями.
                 grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
                 grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-                Grid.SetRowSpan(actions, 2);
+                Grid.SetRowSpan(actionsHost, 2);
 
                 var tags = BuildRowTags(card, ib);
                 // Тот же отступ вложенности, что и у ведущего блока

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -4805,41 +4805,32 @@ namespace Configuration_Management
         {
             menu.Items.Clear();
 
-            var showItem = new NativeMenuItem(LocalizationManager.T("Main.ShowWindow"));
+            // Состав и порядок как в Windows-версии (MainWindow.Tray.cs:209):
+            // открыть, недавние базы (или выбранная, если недавних нет),
+            // синхронизация, настройки, выход. У каждой базы своё подменю
+            // «Предприятие / Конфигуратор»: раньше пункт запускал только
+            // Предприятие, а выбора не было.
+            var showItem = new NativeMenuItem(LocalizationManager.T("Main.TrayOpen"));
             showItem.Click += (_, _) => ShowAndActivate();
             menu.Add(showItem);
-            menu.Add(new NativeMenuItemSeparator());
 
-            // Недавние базы (быстрый запуск прямо из трея).
             var recent = _vm?.RecentInfobases;
             if (recent is { Count: > 0 })
             {
-                var recentMenu = new NativeMenu();
+                menu.Add(new NativeMenuItemSeparator());
+                menu.Add(TrayHeader(LocalizationManager.T("Main.RecentBases")));
                 foreach (var ib in recent)
-                {
-                    var item = new NativeMenuItem($"{ib.Name}  ({ib.ServerDatabaseDisplay})");
-                    var baseRef = ib;
-                    item.Click += (_, _) => LaunchInfobase(baseRef);
-                    recentMenu.Add(item);
-                }
-                menu.Add(new NativeMenuItem(LocalizationManager.T("Main.RecentBases")) { Menu = recentMenu });
-                menu.Add(new NativeMenuItemSeparator());
+                    menu.Add(TrayInfobaseItem(ib, TrayItemName(ib.Name, "Main.NoName")));
             }
-
-            // Запуск выбранной базы: Предприятие / Конфигуратор.
-            if (_vm?.SelectedInfobase is { } sel)
+            else if (_vm?.SelectedInfobase is { } sel)
             {
-                var ent = new NativeMenuItem($"{LocalizationManager.T("Main.LaunchEnterprise")}: {sel.Name}");
-                ent.Click += (_, _) => _vm.LaunchEnterpriseCommand.Execute(null);
-                menu.Add(ent);
-
-                var cfg = new NativeMenuItem($"{LocalizationManager.T("Main.LaunchConfigurator")}: {sel.Name}");
-                cfg.Click += (_, _) => _vm.LaunchConfiguratorCommand.Execute(null);
-                menu.Add(cfg);
                 menu.Add(new NativeMenuItemSeparator());
+                menu.Add(TrayHeader(LocalizationManager.T("Main.SelectedBase")));
+                menu.Add(TrayInfobaseItem(sel, TrayItemName(sel.Name, "Main.SelectedBaseNoName")));
             }
 
-            // Синхронизация и настройки.
+            menu.Add(new NativeMenuItemSeparator());
+
             var sync = new NativeMenuItem(LocalizationManager.T("Main.SyncWithIbases"));
             sync.Click += (_, _) => _vm?.SynchronizeWithIbasesCommand.Execute(null);
             menu.Add(sync);
@@ -4857,6 +4848,49 @@ namespace Configuration_Management
                 _vm?.ExitCommand.Execute(null);
             };
             menu.Add(exitItem);
+        }
+
+        /// <summary>
+        /// Заголовок раздела в меню трея. В Windows это отдельный нерабочий
+        /// пункт (MainWindow.Tray.cs:216), здесь он же, но недоступный:
+        /// собственного вида у заголовка в системном меню нет.
+        /// </summary>
+        private static NativeMenuItem TrayHeader(string text) => new(text) { IsEnabled = false };
+
+        /// <summary>
+        /// Подпись базы в меню трея: пустое имя заменяется на подпись автора,
+        /// длинное обрезается до 48 знаков, как в Windows-версии
+        /// (MainWindow.Tray.cs:224).
+        /// </summary>
+        private static string TrayItemName(string? name, string emptyKey)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return LocalizationManager.T(emptyKey);
+            return name.Length > 48 ? name.Substring(0, 45) + "…" : name;
+        }
+
+        /// <summary>
+        /// Пункт базы с подменю выбора режима запуска: сам пункт запускает
+        /// Предприятие, подменю даёт Предприятие и Конфигуратор
+        /// (MainWindow.Tray.cs:271).
+        /// </summary>
+        private NativeMenuItem TrayInfobaseItem(Infobase ib, string title)
+        {
+            var baseRef = ib;
+            var item = new NativeMenuItem(title);
+            item.Click += (_, _) => LaunchInfobase(baseRef, configurator: false);
+
+            var submenu = new NativeMenu();
+            var enterprise = new NativeMenuItem(LocalizationManager.T("Main.Enterprise"));
+            enterprise.Click += (_, _) => LaunchInfobase(baseRef, configurator: false);
+            submenu.Add(enterprise);
+
+            var configurator = new NativeMenuItem(LocalizationManager.T("Main.SectionConfigurator"));
+            configurator.Click += (_, _) => LaunchInfobase(baseRef, configurator: true);
+            submenu.Add(configurator);
+
+            item.Menu = submenu;
+            return item;
         }
 
         private void SetupTray()
@@ -4899,7 +4933,7 @@ namespace Configuration_Management
         }
 
         /// <summary>Запускает базу из меню трея (Предприятие).</summary>
-        private void LaunchInfobase(Infobase ib)
+        private void LaunchInfobase(Infobase ib, bool configurator = false)
         {
             if (_vm is null)
                 return;
@@ -4911,7 +4945,10 @@ namespace Configuration_Management
                 return;
             }
             _vm.SelectedInfobase = ib;
-            _vm.LaunchEnterpriseCommand.Execute(null);
+            if (configurator)
+                _vm.LaunchConfiguratorCommand.Execute(null);
+            else
+                _vm.LaunchEnterpriseCommand.Execute(null);
         }
 
         /// <summary>

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -326,17 +326,14 @@ namespace Configuration_Management
 
             // Проверить доступность всех баз 1С: ручная команда вместо автопроверки при запуске.
             // Иконка — зелёный гидролокатор (сонар), как экран на подводных лодках.
-            var checkAvailBtn = new PanelButton(
-                "",
-                "ItemHoverBrush",
-                "SecondaryButtonPressedBrush",
-                "")
+            var checkAvailBtn = new Button
             {
                 Content = IconHelper.MakeIcon("IconSonar", UiMetrics.Scaled(18),
                     new SolidColorBrush(Color.Parse("#14B8A6"))),
-                Padding = new Thickness(UiMetrics.ButtonPadH, UiMetrics.ButtonPadV),
+                Padding = new Thickness(UiMetrics.Scaled(8)),
                 HorizontalContentAlignment = HorizontalAlignment.Center
             };
+            checkAvailBtn.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(checkAvailBtn, LocalizationManager.T("Main.CheckAvailabilityTooltip"));
             checkAvailBtn.Bind(Button.CommandProperty, new Binding("CheckAvailabilityCommand"));
             // Проверка доступности стоит между синхронизацией и темой, как у автора.
@@ -1174,7 +1171,6 @@ namespace Configuration_Management
                 Content = colorHex is not null
                     ? IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), new SolidColorBrush(Color.Parse(colorHex)))
                     : IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), brushKey ?? "TextSecondaryBrush"),
-                Padding = new Thickness(4),
                 Margin = new Thickness(1, 0),
                 MinWidth = 0,
                 MinHeight = 0,
@@ -1798,22 +1794,22 @@ namespace Configuration_Management
                     new SolidColorBrush(Color.Parse(colorHex)));
             }
 
-            // Не штатный Button: тема Fluent красит не саму кнопку, а её внутренний
-            // ContentPresenter через :pointerover, и локальный прозрачный Background
-            // этот фон не перебивает. Подсветка наведения оставалась висеть, когда
-            // строка пересобиралась под курсором, и фон то появлялся, то пропадал.
-            var button = new PanelButton("", "ItemHoverBrush", "SecondaryButtonPressedBrush", "",
-                new CornerRadius(UiMetrics.RadiusSm))
+            // Оформление берёт тема IconButton разметки: у автора все пять команд
+            // строки идут этим стилем с полем 1,0 (MainWindow.xaml:1282).
+            // Своя кнопка была нужна, пока темы не было: штатная тема Fluent красит
+            // не саму кнопку, а её внутренний ContentPresenter, и локальный
+            // прозрачный фон её не перебивал.
+            var button = new Button
             {
                 Content = glyph,
-                BorderThickness = new Thickness(0),
-                Padding = new Thickness(4),
+                Margin = new Thickness(1, 0),
                 MinWidth = 0,
                 MinHeight = 0,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
                 CommandParameter = ib
             };
+            button.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(button, tooltip);
             // Команда живёт во вьюмодели, а контекстом строки служит сама база.
             button.Bind(Button.CommandProperty, new Binding(commandPath) { Source = _vm });
@@ -4826,7 +4822,13 @@ namespace Configuration_Management
             {
                 menu.Add(new NativeMenuItemSeparator());
                 menu.Add(TrayHeader(LocalizationManager.T("Main.SelectedBase")));
-                menu.Add(TrayInfobaseItem(sel, TrayItemName(sel.Name, "Main.SelectedBaseNoName")));
+                // У выбранной базы сам пункт ничего не запускает, только раскрывает
+                // подменю, и её имя не обрезается: так у автора
+                // (MainWindow.Tray.cs:240).
+                var selName = string.IsNullOrWhiteSpace(sel.Name)
+                    ? LocalizationManager.T("Main.SelectedBaseNoName")
+                    : sel.Name;
+                menu.Add(TrayInfobaseItem(sel, selName, launchOnClick: false));
             }
 
             menu.Add(new NativeMenuItemSeparator());
@@ -4874,11 +4876,12 @@ namespace Configuration_Management
         /// Предприятие, подменю даёт Предприятие и Конфигуратор
         /// (MainWindow.Tray.cs:271).
         /// </summary>
-        private NativeMenuItem TrayInfobaseItem(Infobase ib, string title)
+        private NativeMenuItem TrayInfobaseItem(Infobase ib, string title, bool launchOnClick = true)
         {
             var baseRef = ib;
             var item = new NativeMenuItem(title);
-            item.Click += (_, _) => LaunchInfobase(baseRef, configurator: false);
+            if (launchOnClick)
+                item.Click += (_, _) => LaunchInfobase(baseRef, configurator: false);
 
             var submenu = new NativeMenu();
             var enterprise = new NativeMenuItem(LocalizationManager.T("Main.Enterprise"));
@@ -4944,11 +4947,7 @@ namespace Configuration_Management
                 QueueTrayMenuRefresh();
                 return;
             }
-            _vm.SelectedInfobase = ib;
-            if (configurator)
-                _vm.LaunchConfiguratorCommand.Execute(null);
-            else
-                _vm.LaunchEnterpriseCommand.Execute(null);
+            _vm.LaunchFromTray(ib, configurator);
         }
 
         /// <summary>

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -592,7 +592,7 @@ namespace Configuration_Management
         /// Явный цвет значка, как в разметке WPF: там часть команд верхней панели
         /// покрашена вручную, а часть берёт цвет из темы. Без него берётся тема.
         /// </param>
-        private static PanelButton TopBarIconButton(string iconKey, string tooltip, string? colorHex = null,
+        private static Button TopBarIconButton(string iconKey, string tooltip, string? colorHex = null,
             string themeBrushKey = "ButtonTextBrush")
         {
             Control icon;
@@ -606,21 +606,19 @@ namespace Configuration_Management
                     new SolidColorBrush(Color.Parse(colorHex)));
             }
 
-            // Плоская кнопка: у автора значковые команды верхней панели без
-            // подложки и рамки, подсветка появляется только при наведении.
-            // Подсветка наведения из ItemHover, а не из кремовой кисти вторичной
-            // кнопки: в тёмной теме та светлая, и значок на ней пропадал.
-            var button = new PanelButton(
-                "",
-                "ItemHoverBrush",
-                "SecondaryButtonPressedBrush",
-                "",
-                new CornerRadius(8))
+            // Оформление берёт тема IconButton разметки (LightTheme.xaml:561
+            // и DarkTheme.xaml:1105): прозрачный фон, скругление 8, отступ 8,
+            // подсветка только при наведении. Своя реализация красила наведение
+            // кистью ItemHover в обеих темах, тогда как в светлой у автора это
+            // серый #F1F5F9, и гасила недоступную кнопку прозрачностью, которой
+            // у этого стиля нет вовсе.
+            var button = new Button
             {
                 Content = icon,
                 Padding = new Thickness(UiMetrics.Scaled(8)),
                 HorizontalContentAlignment = HorizontalAlignment.Center
             };
+            button.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(button, tooltip);
             return button;
         }
@@ -1176,17 +1174,15 @@ namespace Configuration_Management
                 Content = colorHex is not null
                     ? IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), new SolidColorBrush(Color.Parse(colorHex)))
                     : IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), brushKey ?? "TextSecondaryBrush"),
-                Background = Brushes.Transparent,
-                BorderThickness = new Thickness(0),
                 Padding = new Thickness(4),
                 Margin = new Thickness(1, 0),
                 MinWidth = 0,
                 MinHeight = 0,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
-                Cursor = new Cursor(StandardCursorType.Hand),
                 CommandParameter = group
             };
+            button.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(button, tooltip);
             // Команда живёт во вьюмодели, а контекстом строки служит узел группы.
             button.Bind(Button.CommandProperty, new Binding(commandPath) { Source = _vm });
@@ -3552,20 +3548,17 @@ namespace Configuration_Management
         /// <summary>Компактная иконко-кнопка панели инструментов над списком.</summary>
         private Button HeaderIconButton(string iconKey, string tooltip, string commandPath)
         {
+            // Оформление берёт тема IconButton разметки (LightTheme.xaml:561):
+            // прозрачный фон, скругление 8, подсветка при наведении, отступ 8.
             var button = new Button
             {
-                // Отступ 8 и значок 15, как у IconButton в разметке
-                // (MainWindow.xaml:494, LightTheme.xaml:561): своя ширина 24
-                // делала кнопки заметно теснее.
                 Content = IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), "TextSecondaryBrush"),
-                Background = Brushes.Transparent,
-                BorderThickness = new Thickness(0),
                 Padding = new Thickness(UiMetrics.Scaled(8)),
                 MinWidth = 0,
                 MinHeight = 0,
-                VerticalAlignment = VerticalAlignment.Center,
-                Cursor = new Cursor(StandardCursorType.Hand)
+                VerticalAlignment = VerticalAlignment.Center
             };
+            button.Styled(Themes.ControlThemes.IconButton);
             ToolTip.SetTip(button, tooltip);
             button.Bind(Button.CommandProperty, new Binding(commandPath));
             return button;
@@ -4083,11 +4076,14 @@ namespace Configuration_Management
                 Content = ThemedIconAndText("IconClose", LocalizationManager.T("Common.Clear"),
                     "ButtonTextBrush", UiMetrics.Scaled(12), centered: false, fontSize: UiMetrics.ScaledFont(11)),
                 Padding = new Thickness(4, 2),
-                Background = Brushes.Transparent,
-                BorderThickness = new Thickness(0),
                 HorizontalAlignment = HorizontalAlignment.Right,
                 VerticalAlignment = VerticalAlignment.Center
             };
+            // Оформление и состояния берёт тема HeaderIconButton разметки
+            // (LightTheme.xaml:586): наведение, нажатие и гашение у автора
+            // заданы, а здесь кнопка была плоской без единого состояния.
+            _tagClearButton.Styled(Themes.ControlThemes.HeaderIconButton);
+            ToolTip.SetTip(_tagClearButton, LocalizationManager.T("Main.ClearTagFilters"));
             _tagClearButton.Bind(Button.CommandProperty, new Binding("ClearTagFiltersCommand"));
 
             // Подсказка остаётся на месте и когда тегов нет: панель не прячется,
@@ -4271,22 +4267,22 @@ namespace Configuration_Management
         }
 
         /// <summary>
-        /// Кнопка строки состояния: плоская, со своим наведением по SidebarHover,
-        /// значок 18 контрастной кистью (стиль StatusBarIconButton, LightTheme.xaml:616).
+        /// Кнопка строки состояния: оформление берёт тема StatusBarIconButton
+        /// разметки (LightTheme.xaml:616). Нажатие у автора различается темами:
+        /// в светлой это тёмная заливка, в тёмной прозрачность 0.85, и тема
+        /// повторяет обе.
         /// </summary>
         private static Button StatusBarIconButton(string iconKey)
         {
-            var button = new PanelButton("", "SidebarHoverBrush", "SidebarHoverBrush", "",
-                new CornerRadius(6))
+            var button = new Button
             {
                 Content = IconHelper.MakeIcon(iconKey, 18, "TextOnAccentBrush"),
-                Padding = new Thickness(6, 4),
                 Margin = new Thickness(4, 0, 0, 0),
                 MinWidth = 0,
                 MinHeight = 0,
-                VerticalAlignment = VerticalAlignment.Center,
-                Cursor = new Cursor(StandardCursorType.Hand)
+                VerticalAlignment = VerticalAlignment.Center
             };
+            button.Styled(Themes.ControlThemes.StatusBarIconButton);
             return button;
         }
 

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -2652,7 +2652,7 @@ namespace Configuration_Management
             ToolTip.SetTip(main, tooltip);
             main.Bind(Button.CommandProperty, new Binding(commandPath));
 
-            var menu = new ContextMenu();
+            var menu = new ContextMenu().Styled(Themes.ControlThemes.ModernContextMenu);
             foreach (var (header, command, itemIcon, itemColor) in menuItems)
             {
                 if (header.Length == 0)
@@ -2665,6 +2665,7 @@ namespace Configuration_Management
                 // (MainWindow.xaml:1954 и 1962): настройка параметров голубая,
                 // запуск с авторизацией фиолетовый.
                 var item = new MenuItem { Header = header };
+                item.Styled(Themes.ControlThemes.ModernMenuItem);
                 if (itemIcon is not null)
                     item.Icon = IconHelper.MakeIcon(itemIcon, 18,
                         itemColor is not null ? new SolidColorBrush(Color.Parse(itemColor)) : Brushes.Gray);
@@ -4230,7 +4231,7 @@ namespace Configuration_Management
             _statusInfo.Bind(ToolTip.TipProperty, new Binding("StatusBarInfo"));
             if (_vm is not null)
             {
-                var statusMenu = new ContextMenu();
+                var statusMenu = new ContextMenu().Styled(Themes.ControlThemes.ModernContextMenu);
                 statusMenu.Items.Add(MenuAction("Main.CopyPath", _vm.CopyConnectionStringCommand, iconKey: "IconCopy"));
                 _statusInfo.ContextMenu = statusMenu;
             }
@@ -4548,7 +4549,7 @@ namespace Configuration_Management
         /// </summary>
         private ContextMenu BuildRowContextMenu()
         {
-            var menu = new ContextMenu();
+            var menu = new ContextMenu().Styled(Themes.ControlThemes.ModernContextMenu);
             if (_vm is null)
                 return menu;
 
@@ -4557,6 +4558,7 @@ namespace Configuration_Management
                 Header = LocalizationManager.T("Main.ClearCache"),
                 Icon = MenuIcon("IconBroom", "#14B8A6")
             };
+            cacheMenu.Styled(Themes.ControlThemes.ModernMenuItem);
             cacheMenu.Items.Add(MenuAction("Main.ClearProgramCache", _vm.ClearProgramCacheCommand));
             cacheMenu.Items.Add(MenuAction("Main.ClearUserCache", _vm.ClearUserCacheCommand));
             cacheMenu.Items.Add(new Separator());
@@ -4603,6 +4605,7 @@ namespace Configuration_Management
                 Header = LocalizationManager.T(textKey),
                 Command = command
             };
+            item.Styled(Themes.ControlThemes.ModernMenuItem);
             if (iconKey is not null && iconColor is not null)
                 item.Icon = MenuIcon(iconKey, iconColor);
             if (Controls.HotkeyBox.TryParse(gesture, out var parsed) && parsed is not null)

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -1142,12 +1142,7 @@ namespace Configuration_Management
             var actionsIndex = AddListColumns(row,
                 _vm?.ShowFavoritesButton ?? true, _vm?.ShowPinnedButton ?? true);
 
-            var actions = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center
-            };
+            var actions = new ActionsPanel();
             actions.Children.Add(GroupRowActionButton(group, "IconEdit", "EditGroupCommand",
                 LocalizationManager.T("Main.EditGroupTooltip"), "TextSecondaryBrush"));
             // «Удалить» у служебных узлов скрыта: у них нет модели группы.
@@ -1156,10 +1151,8 @@ namespace Configuration_Management
             deleteBtn.IsVisible = group.Marker != GroupNodeViewModel.PinnedMarker
                                   && group.Marker != GroupNodeViewModel.NoGroupMarker;
             actions.Children.Add(deleteBtn);
-            var groupActionsHost = new Panel { ClipToBounds = true };
-            groupActionsHost.Children.Add(actions);
-            Grid.SetColumn(groupActionsHost, actionsIndex);
-            row.Children.Add(groupActionsHost);
+            Grid.SetColumn(actions, actionsIndex);
+            row.Children.Add(actions);
 
             Grid.SetColumn(caption, 0);
             Grid.SetColumnSpan(caption, actionsIndex);
@@ -1167,6 +1160,61 @@ namespace Configuration_Management
 
             header.Child = row;
             return header;
+        }
+
+        /// <summary>
+        /// Панель кнопок колонки «Действия»: раскладывает по горизонтали столько
+        /// кнопок, сколько помещается в колонку, остальные не показывает вовсе.
+        /// Обычная панель с обрезкой оставляла бы половину значка у самой границы
+        /// колонки «Сервер/База», а в версии для Windows лишние значки пропадают.
+        /// </summary>
+        private sealed class ActionsPanel : Panel
+        {
+            /// <summary>Зазор между кнопками.</summary>
+            public double Spacing { get; init; }
+
+            protected override Size MeasureOverride(Size availableSize)
+            {
+                double width = 0, height = 0;
+                foreach (var child in Children)
+                {
+                    child.Measure(Size.Infinity);
+                    width += child.DesiredSize.Width + Spacing;
+                    height = Math.Max(height, child.DesiredSize.Height);
+                }
+                return new Size(Math.Min(width, availableSize.Width), height);
+            }
+
+            protected override Size ArrangeOverride(Size finalSize)
+            {
+                double total = 0;
+                var fit = 0;
+                foreach (var child in Children)
+                {
+                    var next = total + child.DesiredSize.Width + (fit > 0 ? Spacing : 0);
+                    if (next > finalSize.Width)
+                        break;
+                    total = next;
+                    fit++;
+                }
+
+                var x = Math.Max(0, (finalSize.Width - total) / 2);
+                for (var i = 0; i < Children.Count; i++)
+                {
+                    var child = Children[i];
+                    if (i >= fit)
+                    {
+                        child.Arrange(new Rect(0, 0, 0, 0));
+                        continue;
+                    }
+                    if (i > 0)
+                        x += Spacing;
+                    var size = child.DesiredSize;
+                    child.Arrange(new Rect(x, Math.Max(0, (finalSize.Height - size.Height) / 2), size.Width, size.Height));
+                    x += size.Width;
+                }
+                return finalSize;
+            }
         }
 
         /// <summary>
@@ -1369,6 +1417,11 @@ namespace Configuration_Management
                 var value = ColumnValue(ib, columns[i].Key);
                 var cell = SecondaryText(string.IsNullOrWhiteSpace(value) ? string.Empty : value, card);
                 cell.VerticalAlignment = VerticalAlignment.Center;
+                // Отступ ячейки значения как в разметке (MainWindow.xaml:1249):
+                // без него значения стояли на 6 пикселей левее своих заголовков,
+                // у которых такой отступ есть.
+                cell.HorizontalAlignment = HorizontalAlignment.Left;
+                cell.Margin = new Thickness(6, 0, 6, 0);
                 if (columns[i].Key == "Version")
                 {
                     // Двойной щелчок открывает выбор версии платформы, как
@@ -1390,25 +1443,17 @@ namespace Configuration_Management
             // Кнопки действий в колонке «Действия» (после колонки «Режим запуска»):
             // запуск, конфигуратор, изменить настройки, очистить кеш, удалить.
             var actionsCol = NameRowColumn + 1 + actionsOffset;
-            var actions = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center,
-                Spacing = 1
-            };
+            var actions = new ActionsPanel { Spacing = 1 };
             actions.Children.Add(RowActionButton(ib, "IconPlay", "LaunchEnterpriseCommand", LocalizationManager.T("Main.LaunchEnterpriseTooltip")));
             actions.Children.Add(RowActionButton(ib, "IconWrench", "LaunchConfiguratorCommand", LocalizationManager.T("Main.LaunchConfiguratorSectionTooltip")));
             actions.Children.Add(RowActionButton(ib, "IconEdit", "EditInfobaseCommand", LocalizationManager.T("Main.EditBaseTooltip")));
             actions.Children.Add(RowActionButton(ib, "IconBroom", "ClearCacheCommand", LocalizationManager.T("Main.ClearCacheTooltip")));
             actions.Children.Add(RowActionButton(ib, "IconDelete", "DeleteInfobaseCommand", LocalizationManager.T("Main.DeleteTooltip"), "#DC2626"));
-            // Кнопки живут внутри обрезающей колонку панели: в узкой колонке
-            // «Действия» они у автора просто срезаются её границей, а у нас
-            // вылезали поверх колонки «Сервер/База».
-            var actionsHost = new Panel { ClipToBounds = true };
-            actionsHost.Children.Add(actions);
-            grid.Children.Add(actionsHost);
-            Grid.SetColumn(actionsHost, actionsCol);
+            // Кнопки живут внутри панели, обрезанной по своей колонке: в узкой
+            // колонке «Действия» лишние значки у автора пропадают, а у нас
+            // рисовались поверх колонки «Сервер/База».
+            grid.Children.Add(actions);
+            Grid.SetColumn(actions, actionsCol);
 
             if (_vm?.ShowTags == true)
             {
@@ -1418,7 +1463,7 @@ namespace Configuration_Management
                 // действиями и остальными значениями.
                 grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
                 grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-                Grid.SetRowSpan(actionsHost, 2);
+                Grid.SetRowSpan(actions, 2);
 
                 var tags = BuildRowTags(card, ib);
                 // Тот же отступ вложенности, что и у ведущего блока
@@ -4118,6 +4163,8 @@ namespace Configuration_Management
                 _headerOffsetColumn.Width = new GridLength(offset);
 
             SyncHeaderWidthWithList();
+
+
 
 
         }

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -13,6 +13,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Controls.Shapes;
 using Avalonia.Data;
+using Avalonia.Data.Converters;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
@@ -57,7 +58,6 @@ namespace Configuration_Management
         private Border? _columnHeader;
         private Grid? _columnHeaderRow;
         private ColumnDefinition? _headerOffsetColumn;
-        private Control? _headerPinMark;
         private double _headerToolbarWidth;
         private StackPanel? _groupToolbar;
         private Grid? _listContent;
@@ -642,30 +642,24 @@ namespace Configuration_Management
             _tree.Bind(TreeView.ItemsSourceProperty, new Binding("GroupNodes"));
             _tree.SelectionMode = SelectionMode.Single;
 
-            // Убираем стандартную подсветку контейнера TreeViewItem: карточка строки
-            // сама рисует hover и выделение из ресурсов темы. Селектор сопоставляется
-            // по ключу стиля, а он переопределён на TreeViewItem, иначе стиль
-            // не нашёл бы контейнеры.
-            var tviStyle = new Style(x => x.OfType<TreeViewItem>());
-            tviStyle.Setters.Add(new Setter(TemplatedControl.BackgroundProperty, Brushes.Transparent));
-            _tree.Styles.Add(tviStyle);
-
-            // Фон покоя этим снят, но состояния выделения и наведения Fluent задаёт
-            // не свойством контейнера, а вложенным стилем на части шаблона, поэтому
-            // синяя полоса рисовалась бы за карточкой. Гасим её адресно.
-            foreach (var state in new[] { ":selected", ":pointerover" })
-            {
-                var stateStyle = new Style(x => x.OfType<TreeViewItem>().Class(state)
-                    .Template().OfType<Border>().Name("PART_LayoutRoot"));
-                stateStyle.Setters.Add(new Setter(Border.BackgroundProperty, Brushes.Transparent));
-                _tree.Styles.Add(stateStyle);
-            }
+            // Строки списка идут по своему шаблону, а не по Fluent: тот сдвигает
+            // на уровень вложенности всю строку, и колонки значений вложенных
+            // строк уезжают от заголовков. Подсветки в этом шаблоне нет вовсе,
+            // фон рисует карточка строки из ресурсов темы.
+            _tree.ItemContainerTheme = LeveledTreeViewItem.RowTheme();
 
             // Раскрытие узла связывает с моделью сам LeveledTreeView, при подготовке
             // контейнера на любом уровне вложенности. Здесь остаётся только
             // выравнивание заголовка: раскрытие группы добавляет строки, а с ними
             // может измениться и самый левый отступ, по которому выровнен заголовок.
             _tree.ContainerPrepared += (_, _) => QueueHeaderAlign();
+
+            // Ширина шапки приравнивается ширине содержимого списка, а колонка
+            // «Название» звёздная: любая разница общей ширины уходит в неё и
+            // сдвигает все колонки значений. Поэтому пересчёт нужен на каждое
+            // изменение размеров списка, а не только на пересборку строк.
+            _tree.GetObservable(Visual.BoundsProperty)
+                .Subscribe(new PropertyObserver<Rect>(_ => QueueHeaderAlign()));
 
             // Меню висит на дереве, как в WPF: над группой и над пустым местом
             // оно тоже открывается, а недоступные пункты гасит CanExecute.
@@ -1058,14 +1052,28 @@ namespace Configuration_Management
             {
                 CornerRadius = new CornerRadius(6),
                 Padding = new Thickness(UiMetrics.Compact ? 6 : 8, UiMetrics.GroupHeaderPadV),
-                // Пустая группа сдвигается вправо на ширину кнопки разворота:
-                // у неё этой кнопки нет, и без сдвига её заголовок начинался бы
-                // левее соседних (в разметке это делает GroupOffsetConverter).
-                Margin = new Thickness(group.Items.Count == 0 ? EmptyGroupOffset : 0,
-                    UiMetrics.GroupHeaderMarginV, 0, UiMetrics.GroupHeaderMarginV),
+                Margin = new Thickness(0, UiMetrics.GroupHeaderMarginV, 0, UiMetrics.GroupHeaderMarginV),
                 BorderThickness = new Thickness(2),
                 BorderBrush = Brushes.Transparent
             };
+            // Пустая группа сдвигается вправо на отступ своего уровня и ширину
+            // кнопки разворота: этой кнопки у неё нет, и без сдвига её заголовок
+            // начинался бы левее соседних (Converters/GroupOffsetConverter.cs:37).
+            if (group.Items.Count == 0)
+            {
+                var marginV = UiMetrics.GroupHeaderMarginV;
+                header[!Border.MarginProperty] = new Binding(nameof(TreeViewItem.Level))
+                {
+                    RelativeSource = new RelativeSource
+                    {
+                        Mode = RelativeSourceMode.FindAncestor,
+                        AncestorType = typeof(TreeViewItem)
+                    },
+                    Converter = new FuncValueConverter<int, Thickness>(level =>
+                        new Thickness(EmptyGroupOffsetFor(level), marginV, 0, marginV))
+                };
+            }
+
             header.Bind(Border.BackgroundProperty, new Binding("HeaderBrush") { Source = group });
 
             // Кисть берётся наблюдателем темы, а подписка на узел живёт ровно
@@ -1130,7 +1138,7 @@ namespace Configuration_Management
             // Колонки те же, что у строки базы: команды группы стоят в колонке
             // «Действия» и попадают ровно под кнопки строк, а имя со счётчиком
             // занимает всё, что левее (MainWindow.xaml:961 и 1015).
-            var row = new Grid();
+            var row = new Grid { Name = GroupRowGridName };
             var actionsIndex = AddListColumns(row,
                 _vm?.ShowFavoritesButton ?? true, _vm?.ShowPinnedButton ?? true);
 
@@ -1186,30 +1194,35 @@ namespace Configuration_Management
         }
 
         /// <summary>
-        /// Колонки строки списка: звезда, булавка, значок подключения, имя, затем
-        /// колонки значений с «Действиями» на своём месте. Тот же набор нужен
-        /// заголовку группы, чтобы её команды встали под кнопками строк базы,
-        /// как в разметке (MainWindow.xaml:921 и 1015).
+        /// Колонки строки списка. Ведущих ровно пять и они одинаковы у заголовка,
+        /// строки группы и строки базы: место под кнопки групп, компенсатор отступа
+        /// дерева, звезда, булавка, название (MainWindow.xaml:495-512, 893-905
+        /// и 1077-1088). Одинаковый набор ведущих колонок и есть причина, по которой
+        /// значения строк стоят ровно под своими заголовками: дальше идут колонки
+        /// значений с «Действиями» на своём месте.
         /// </summary>
+        /// <param name="compensator">
+        /// Колонка-компенсатор заголовка: её ширину подбирает <see cref="AlignHeaderToRows"/>.
+        /// У строк компенсатор всегда нулевой, поэтому там передаётся null.
+        /// </param>
         /// <returns>Индекс колонки «Действия».</returns>
-        private int AddListColumns(Grid grid, bool showFavorite, bool showPin)
+        private int AddListColumns(Grid grid, bool showFavorite, bool showPin,
+            ColumnDefinition? compensator = null)
         {
-            // Колонки звезды и булавки по содержимому: в разметке звезда, плашка
-            // номера, булавка, значок и имя лежат в одной горизонтальной панели
-            // и пакуются вплотную (MainWindow.xaml:1152). При жёсткой ширине
-            // у неизбранной базы между звездой и булавкой оставался пустой зазор,
-            // а плашка избранного упиралась в край колонки.
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(GroupButtonsColumnWidth) });
+            grid.ColumnDefinitions.Add(compensator ?? new ColumnDefinition { Width = new GridLength(0) });
+            // Минимум колонки звезды держится всегда: под ним в заголовке стоит
+            // переключатель тегов, и без резерва он срезался бы границей колонки
+            // «Название» (MainWindow.xaml:502, issue 84 апстрима).
             grid.ColumnDefinitions.Add(new ColumnDefinition
             {
-                Width = showFavorite ? GridLength.Auto : new GridLength(0),
-                MinWidth = showFavorite ? UiMetrics.Scaled(16) : 0
+                Width = new GridLength(showFavorite ? FavoriteColumnWidth : 0),
+                MinWidth = TagsToggleReserve
             });
             grid.ColumnDefinitions.Add(new ColumnDefinition
             {
-                Width = showPin ? GridLength.Auto : new GridLength(0),
-                MinWidth = showPin ? UiMetrics.Scaled(16) : 0
+                Width = new GridLength(showPin ? PinColumnWidth : 0)
             });
-            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(IconColumnWidth) });
             grid.ColumnDefinitions.Add(new ColumnDefinition
             {
                 Width = NameColumnLength(),
@@ -1254,6 +1267,33 @@ namespace Configuration_Management
             var columns = ListColumns();
             var actionsOffset = ActionsOffsetInColumns(columns);
 
+            // Звезда, булавка, значок подключения и имя лежат в одной горизонтальной
+            // панели, которая занимает все пять ведущих колонок (MainWindow.xaml:1152).
+            // Так их собственная ширина не двигает колонки значений: те начинаются
+            // после ведущих и стоят под своими заголовками. Отступ вложенности
+            // ставит контейнер строки, панель его получает от него же.
+            var lead = new StackPanel
+            {
+                Name = LeadBlockName,
+                Orientation = Orientation.Horizontal,
+                VerticalAlignment = VerticalAlignment.Center,
+                // Обрезка по границе колонки «Название»: у автора имя тоже лежит
+                // в горизонтальной панели и ширины не знает, но там оно упирается
+                // в край окна, а у нас налезало бы на колонки значений.
+                ClipToBounds = true
+            };
+            // Отступ вложенности: сдвигается только ведущий блок, сама строка
+            // остаётся у левого края (MainWindow.xaml:1155).
+            lead[!StackPanel.MarginProperty] = new Binding(nameof(TreeViewItem.Level))
+            {
+                RelativeSource = new RelativeSource
+                {
+                    Mode = RelativeSourceMode.FindAncestor,
+                    AncestorType = typeof(TreeViewItem)
+                },
+                Converter = LeveledTreeViewItem.LeadIndent
+            };
+
             if (showFavorite)
             {
                 // Номер слота Alt+N идёт плашкой сразу за звездой и внутри той же
@@ -1261,19 +1301,17 @@ namespace Configuration_Management
                 // наложен на угол колонки мелкой цифрой без подложки.
                 var favorite = RowMarkButton(card, ib, "IconFavorite", "FavoriteBrush",
                     nameof(Infobase.IsFavorite), () => ib.IsFavorite,
-                    LocalizationManager.T("Main.ToggleFavoriteTooltip"), "ToggleFavoriteForCommand", FavoriteColumnWidth,
+                    LocalizationManager.T("Main.ToggleFavoriteTooltip"), "ToggleFavoriteForCommand",
                     FavoriteSlotBadge(card, ib));
-                grid.Children.Add(favorite);
-                Grid.SetColumn(favorite, 0);
+                lead.Children.Add(favorite);
             }
 
             if (showPin)
             {
                 var pin = RowMarkButton(card, ib, "IconPin", "AccentBrush",
                     nameof(Infobase.IsPinned), () => ib.IsPinned,
-                    LocalizationManager.T("Main.TogglePinTooltip"), "TogglePinForCommand", PinColumnWidth);
-                grid.Children.Add(pin);
-                Grid.SetColumn(pin, 1);
+                    LocalizationManager.T("Main.TogglePinTooltip"), "TogglePinForCommand");
+                lead.Children.Add(pin);
             }
 
             // Иконка статуса базы слева: тип подключения (папка / глобус / сеть)
@@ -1291,17 +1329,17 @@ namespace Configuration_Management
             iconBox.Margin = new Thickness(0, 0, 6, 0);
             ToolTip.SetTip(iconBox, ib.StatusDisplay);
 
-            grid.Children.Add(iconBox);
-            Grid.SetColumn(iconBox, 2);
+            lead.Children.Add(iconBox);
 
             // Правая колонка: имя (крупно) + строки вторичной информации.
             // В компактном режиме уменьшаем и межстрочный промежуток, чтобы строки с
             // полным набором метаданных тоже «сжимались», а не оставались прежней высоты.
             var content = new StackPanel { Spacing = UiMetrics.Scaled(2), VerticalAlignment = VerticalAlignment.Center };
 
-            // Имя базы кладётся в колонку напрямую: в горизонтальной панели оно
-            // получало бы бесконечную ширину и при узкой колонке налезало бы
-            // на соседние значения вместо обрезки многоточием.
+            // Имя лежит в горизонтальной панели, как в разметке (MainWindow.xaml:1244),
+            // и своей ширины не знает: обрезку по краю колонки «Название» даёт
+            // ClipToBounds ведущего блока. Многоточия при этом не будет, у автора
+            // имя тоже не подрезается.
             var name = new TextBlock
             {
                 Text = ib.Name,
@@ -1316,8 +1354,10 @@ namespace Configuration_Management
             // Второй подписи под именем в разметке нет: первая строка это значок
             // статуса и имя, а вторая отдана тегам (MainWindow.xaml:1230-1247).
             // Расположение живёт в своей колонке и в сведениях правой панели.
-            grid.Children.Add(content);
-            Grid.SetColumn(content, 3);
+            lead.Children.Add(content);
+            grid.Children.Add(lead);
+            Grid.SetColumn(lead, 0);
+            Grid.SetColumnSpan(lead, NameRowColumn + 1);
 
             var dataColumn = NameRowColumn + 1;
             for (var i = 0; i < columns.Count; i++)
@@ -1374,6 +1414,19 @@ namespace Configuration_Management
                 Grid.SetRowSpan(actions, 2);
 
                 var tags = BuildRowTags(card, ib);
+                // Тот же отступ вложенности, что и у ведущего блока
+                // (MainWindow.xaml:1316): теги стоят под именем, а не левее его.
+                tags[!Control.MarginProperty] = new Binding(nameof(TreeViewItem.Level))
+                {
+                    RelativeSource = new RelativeSource
+                    {
+                        Mode = RelativeSourceMode.FindAncestor,
+                        AncestorType = typeof(TreeViewItem)
+                    },
+                    // Верхний отступ 2 сохраняется: привязка задаёт Margin целиком.
+                    Converter = new FuncValueConverter<int, Thickness>(level =>
+                        new Thickness(LeveledTreeViewItem.LeadIndentFor(level), 2, 0, 0))
+                };
                 grid.Children.Add(tags);
                 Grid.SetRow(tags, 1);
                 Grid.SetColumn(tags, 0);
@@ -1708,7 +1761,7 @@ namespace Configuration_Management
 
         private Button RowMarkButton(InfobaseRowCard card, Infobase infobase, string iconKey,
             string activeBrushKey, string stateProperty, Func<bool> isActive,
-            string tooltip, string commandPath, double width, Control? trailing = null)
+            string tooltip, string commandPath, Control? trailing = null)
         {
             var iconHost = IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(14), out var icon);
             Control content = iconHost;
@@ -1756,8 +1809,8 @@ namespace Configuration_Management
                 Padding = new Thickness(0),
                 MinWidth = 0,
                 MinHeight = 0,
-                // Своей ширины у кнопки нет: колонка теперь по содержимому,
-                // и звезда с плашкой и без неё занимают ровно столько, сколько надо.
+                // Своей ширины у кнопки нет: она лежит в ведущем блоке строки
+                // и пакуется вплотную к соседям, как в разметке.
                 HorizontalAlignment = HorizontalAlignment.Left,
                 HorizontalContentAlignment = HorizontalAlignment.Left,
                 Margin = new Thickness(0, 0, 4, 0),
@@ -2014,7 +2067,7 @@ namespace Configuration_Management
                         BorderThickness = new Thickness(1),
                         Child = ThemedIconAndText("IconTag", tag ?? "", "AccentColorBrush", 10, centered: false)
                     };
-                    ThemeBrushes.Bind(chip, Border.BackgroundProperty, "ItemHoverColorBrush");
+                    ThemeBrushes.Bind(chip, Border.BackgroundProperty, "ItemHoverBrush");
                     ThemeBrushes.Bind(chip, Border.BorderBrushProperty, "BorderColorBrush");
                     return chip;
                 })
@@ -3114,29 +3167,48 @@ namespace Configuration_Management
         /// <summary>Минимум под имя базы: колонка звёздная, но схлопываться ей нельзя.</summary>
         private const double NameColumnMinWidth = 220;
 
-        /// <summary>Ширина кнопки разворота группы: на неё сдвигается пустая группа.</summary>
-        private static double EmptyGroupOffset => UiMetrics.Scaled(26);
+        /// <summary>
+        /// Сдвиг пустой группы: у неё нет кнопки разворота, и без сдвига её
+        /// заголовок начинался бы левее соседних. Считается как у автора
+        /// (Converters/GroupOffsetConverter.cs:37): отступ уровня плюс ширина
+        /// кнопки разворота, без масштабирования компактным режимом.
+        /// </summary>
+        private static double EmptyGroupOffsetFor(int level)
+            => level * Converters.LevelToThicknessConverter.IndentStep
+                + Converters.LevelToThicknessConverter.ExpanderWidth;
 
-        /// <summary>Ширина колонки звезды «избранное» в заголовке и в строке базы.</summary>
-        private static double FavoriteColumnWidth => UiMetrics.Scaled(30);
+        /// <summary>
+        /// Ширина колонки звезды «избранное» в заголовке и в строке базы.
+        /// Компактным режимом ведущие колонки не сжимаются: у автора их ширины
+        /// заданы числом, а компактный режим меняет только отступы и шрифты.
+        /// </summary>
+        private static double FavoriteColumnWidth => 28;
+
+        /// <summary>
+        /// Резерв под переключатель тегов: минимум колонки звезды, который держится
+        /// и при скрытой звезде (MainWindow.xaml:502).
+        /// </summary>
+        private static double TagsToggleReserve => 30;
+
+        /// <summary>
+        /// Место под кнопки групп в ведущих колонках всех трёх сеток списка.
+        /// Ширина фиксированная, как в разметке, и обнуляется вместе с кнопками
+        /// (MainWindow.xaml:495).
+        /// </summary>
+        private double GroupButtonsColumnWidth
+            => (_vm?.ShowExpandCollapseButtons ?? true) ? 144 : 0;
 
         /// <summary>Ширина колонки булавки «закреплено» в заголовке и в строке базы.</summary>
-        private static double PinColumnWidth => UiMetrics.Scaled(26);
+        private static double PinColumnWidth => 26;
 
-        /// <summary>Ширина фиксированной колонки «Действия» в заголовке и в строке базы.</summary>
+        /// <summary>
+        /// Ширина фиксированной колонки «Действия» в заголовке и в строке базы.
+        /// Компактным режимом не сжимается: остальные колонки списка тоже берут
+        /// ширину из настроек как есть (MainWindow.xaml:529), а кнопки действий
+        /// в сжатой колонке налезали на «Сервер/База».
+        /// </summary>
         private double ActionsColumnWidth
-            => UiMetrics.Scaled(_vm is { ActionsColumnWidth: > 0 } vm ? vm.ActionsColumnWidth : 170);
-
-        /// <summary>
-        /// Ширина колонки иконки базы: сама иконка и её правый отступ. В заголовке
-        /// эта колонка пустая, но она есть, иначе подпись «Название» стояла бы
-        /// левее имён строк на ширину иконки.
-        /// </summary>
-        /// <summary>
-        /// Ширина колонки значка подключения: сам значок 14 и отступ 6 справа,
-        /// как в разметке. Прежние 48 остались от подложки, которой больше нет.
-        /// </summary>
-        private static double IconColumnWidth => UiMetrics.Scaled(20);
+            => _vm is { ActionsColumnWidth: > 0 } vm ? vm.ActionsColumnWidth : 170;
 
         /// <summary>Ширина одной кнопки панели инструментов над списком.</summary>
         private static double ToolbarButtonWidth => UiMetrics.Scaled(24);
@@ -3155,16 +3227,23 @@ namespace Configuration_Management
         private const double HeaderToolbarGap = 2;
 
         /// <summary>
-        /// Номер колонки заголовка с именем базы: компенсатор отступа дерева,
-        /// звезда, булавка, иконка.
+        /// Номер колонки с именем: место кнопок групп, компенсатор, звезда, булавка.
+        /// Одинаков у заголовка и у строк, потому что набор ведущих колонок общий.
         /// </summary>
         private const int NameHeaderColumn = 4;
 
-        /// <summary>Номер колонки заголовка с пометкой закрепления.</summary>
-        private const int PinHeaderColumn = NameHeaderColumn - 2;
+        /// <summary>Номер колонки строки с именем базы, он же номер колонки заголовка.</summary>
+        private const int NameRowColumn = NameHeaderColumn;
 
-        /// <summary>Номер колонки строки с именем базы: звезда, булавка, иконка.</summary>
-        private const int NameRowColumn = 3;
+        /// <summary>
+        /// Имя ведущего блока строки базы: по нему контейнер дерева находит панель,
+        /// чтобы поставить ей отступ вложенности. Сдвигается только она, а сама
+        /// строка стоит от левого края, иначе значения уехали бы от заголовков.
+        /// </summary>
+        internal const string LeadBlockName = "ВедущийБлокСтроки";
+
+        /// <summary>Имя сетки заголовка группы: по нему она находится при перетаскивании разделителя колонок.</summary>
+        private const string GroupRowGridName = "СеткаСтрокиГруппы";
 
         /// <summary>Минимальная ширина колонки при перетаскивании разделителя.</summary>
         private const double MinColumnWidth = 40;
@@ -3363,40 +3442,14 @@ namespace Configuration_Management
             // ширину подставляет AlignHeaderToRows, когда панель разложена.
             _headerToolbarWidth = (_vm.ShowExpandCollapseButtons ? GroupToolbarWidth : 0)
                 + TagsToggleWidth + HeaderToolbarGap;
-            var favoriteWidth = _vm.ShowFavoritesButton ? FavoriteColumnWidth : 0;
-            var pinWidth = _vm.ShowPinnedButton ? PinColumnWidth : 0;
 
+            // Колонки заголовка строятся тем же построителем, что и колонки строк:
+            // набор ведущих колонок обязан совпадать, иначе значения разъезжаются
+            // с заголовками (MainWindow.xaml:1071-1076).
             _headerOffsetColumn = new ColumnDefinition { Width = new GridLength(0) };
-            _columnHeaderRow.ColumnDefinitions.Add(_headerOffsetColumn);
-            _columnHeaderRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(favoriteWidth) });
-            _columnHeaderRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(pinWidth) });
-            _columnHeaderRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(IconColumnWidth) });
-            _columnHeaderRow.ColumnDefinitions.Add(
-                new ColumnDefinition { Width = NameColumnLength(), MinWidth = MinColumnWidth });
-            // Колонка «Действия» встаёт сразу после колонки «Режим запуска», поэтому
-            // её определение встраивается в последовательность, а не добавляется в конец.
             var actionsOffset = ActionsOffsetInColumns(columns);
-            for (var i = 0; i < columns.Count; i++)
-            {
-                if (i == actionsOffset)
-                    _columnHeaderRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(ActionsColumnWidth) });
-                _columnHeaderRow.ColumnDefinitions.Add(
-                    new ColumnDefinition { Width = new GridLength(columns[i].Width), MinWidth = MinColumnWidth });
-            }
-            // «Режим запуска» скрыт или стоит последним — действия уходят в самый конец.
-            if (actionsOffset >= columns.Count)
-                _columnHeaderRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(ActionsColumnWidth) });
+            AddListColumns(_columnHeaderRow, _vm.ShowFavoritesButton, _vm.ShowPinnedButton, _headerOffsetColumn);
 
-            _headerPinMark = null;
-            if (_vm.ShowPinnedButton)
-            {
-                // Значок закрепления в заголовке — только пометка колонки, как в WPF.
-                var pinMark = IconHelper.MakeIcon("IconPin", UiMetrics.Scaled(13), "TextSecondaryBrush");
-                ToolTip.SetTip(pinMark, LocalizationManager.T("Main.Pinned"));
-                _columnHeaderRow.Children.Add(pinMark);
-                Grid.SetColumn(pinMark, PinHeaderColumn);
-                _headerPinMark = pinMark;
-            }
 
             // Кнопки лежат поверх компенсатора и пустых колонок звезды,
             // булавки и иконки: своя колонка сдвинула бы подписи вправо
@@ -3512,6 +3565,18 @@ namespace Configuration_Management
 
             var tagsToggle = BuildTagsInListToggle();
             panel.Children.Add(tagsToggle);
+
+            // Пометка закрепления стоит сразу за переключателем тегов внутри
+            // того же блока, как в разметке (MainWindow.xaml:620): своей колонки
+            // у неё нет, поэтому и прятать её ни от чего не нужно.
+            if (_vm?.ShowPinnedButton == true)
+            {
+                var pinMark = IconHelper.MakeIcon("IconPin", UiMetrics.Scaled(14), "TextSecondaryBrush");
+                pinMark.Margin = new Thickness(4, 0, 0, 0);
+                pinMark.VerticalAlignment = VerticalAlignment.Center;
+                ToolTip.SetTip(pinMark, LocalizationManager.T("Main.Pinned"));
+                panel.Children.Add(pinMark);
+            }
 
             _groupToolbar = panel;
             // Ширина известна только после раскладки, а подпись выравнивается
@@ -3826,6 +3891,14 @@ namespace Configuration_Management
                     if (card.Child is Grid grid)
                         _resizeRowGrids.Add(grid);
                 }
+                // Заголовки групп ведут те же колонки и обязаны ехать вместе
+                // со строками баз, иначе кнопки группы расходятся с кнопками
+                // строк на всё время перетаскивания.
+                foreach (var group in _tree.GetVisualDescendants().OfType<Grid>())
+                {
+                    if (group.Name == GroupRowGridName)
+                        _resizeRowGrids.Add(group);
+                }
             }
 
             e.Pointer.Capture(grip);
@@ -3912,6 +3985,9 @@ namespace Configuration_Management
             // Минимум области считается заново: иначе после сужения колонки
             // прокручиваемая область осталась бы прежней ширины с пустотой справа.
             UpdateListMinWidth();
+            // И заново выравнивается шапка: новая ширина колонки меняет и общую
+            // ширину сеток, от равенства которой зависит совпадение колонок.
+            QueueHeaderAlign();
         }
 
         /// <summary>
@@ -3926,8 +4002,11 @@ namespace Configuration_Management
                 return;
 
             var definitions = _columnHeaderRow.ColumnDefinitions;
+            // Считаются все ведущие колонки, включая нулевую с местом под кнопки
+            // групп: без неё минимум занижался, и правые колонки подрезались
+            // раньше, чем включалась горизонтальная прокрутка.
             double lead = 0;
-            for (var i = 1; i < NameHeaderColumn; i++)
+            for (var i = 0; i < NameHeaderColumn; i++)
                 lead += definitions[i].Width.IsAbsolute ? definitions[i].Width.Value : 0;
 
             var nameWidth = definitions[NameHeaderColumn].Width.IsAbsolute
@@ -3975,35 +4054,32 @@ namespace Configuration_Management
         private void AlignHeaderToRows()
         {
             if (_headerOffsetColumn is null || _columnHeaderRow is null || _tree is null
-                || _columnHeaderRow.ColumnDefinitions.Count == 0)
+                || _columnHeaderRow.ColumnDefinitions.Count <= NameHeaderColumn)
                 return;
 
-            // Ориентир — самая левая из видимых строк: узлы разной вложенности
-            // сдвинуты по-разному, и по первой встреченной заголовок уехал бы
-            // вправо от большинства строк.
-            double? left = null;
+            // Арифметика авторская (MainWindow.Columns.cs:265): компенсатор равен
+            // разнице между началом первой колонки значений строки и началом той же
+            // колонки заголовка, посчитанным без самого компенсатора. Ведущие колонки
+            // у обеих сеток одинаковы, поэтому разницу даёт только сдвиг строки
+            // деревом, и после подгонки значения стоят ровно под заголовками.
+            Grid? rowGrid = null;
+            double rowOrigin = 0;
             foreach (var card in _tree.GetVisualDescendants().OfType<InfobaseRowCard>())
             {
-                if (card.Child is not { } content)
+                if (card.Child is not Grid content)
                     continue;
                 var origin = content.TranslatePoint(new Point(0, 0), _columnHeaderRow);
                 if (origin is null)
                     continue;
-                if (left is null || origin.Value.X < left.Value)
-                    left = origin.Value.X;
+                if (rowGrid is null || origin.Value.X < rowOrigin)
+                {
+                    rowGrid = content;
+                    rowOrigin = origin.Value.X;
+                }
             }
-            // Строк может не быть вовсе: список пуст, всё отобрано фильтром
-            // или группы свёрнуты. Выходить нельзя, иначе подпись «Название»
-            // остаётся под блоком кнопок и он её перекрывает.
 
-            // Пустые колонки звезды, булавки и иконки заголовка кнопки перекрывают,
-            // а на подпись «Название» налезать не должны, отсюда нижняя граница.
-            var lead = _columnHeaderRow.ColumnDefinitions[1].ActualWidth
-                + _columnHeaderRow.ColumnDefinitions[2].ActualWidth
-                + _columnHeaderRow.ColumnDefinitions[3].ActualWidth;
-            // Измеренная ширина точнее расчётной, и она же нужна минимуму
-            // области списка: там расчёт по константам оставил бы пустоту
-            // или лишнюю прокрутку.
+            // Измеренная ширина блока кнопок нужна минимуму области списка:
+            // по константам он оставлял бы пустоту или лишнюю прокрутку.
             if (MeasuredToolbarWidth is { } measured)
             {
                 var target = measured + HeaderToolbarGap;
@@ -4014,14 +4090,54 @@ namespace Configuration_Management
                 }
             }
 
-            var offset = Math.Max(Math.Max(0, _headerToolbarWidth - lead), left ?? 0);
+            double offset = 0;
+            if (rowGrid is not null && rowGrid.ColumnDefinitions.Count > NameRowColumn)
+            {
+                double rowLead = 0;
+                for (var i = 0; i <= NameRowColumn; i++)
+                    rowLead += rowGrid.ColumnDefinitions[i].ActualWidth;
+
+                double headerLead = 0;
+                for (var i = 0; i <= NameHeaderColumn; i++)
+                {
+                    if (!ReferenceEquals(_columnHeaderRow.ColumnDefinitions[i], _headerOffsetColumn))
+                        headerLead += _columnHeaderRow.ColumnDefinitions[i].ActualWidth;
+                }
+
+                offset = Math.Max(0, (rowOrigin + rowLead) - headerLead);
+            }
+
             if (Math.Abs(offset - _headerOffsetColumn.Width.Value) > 0.5)
                 _headerOffsetColumn.Width = new GridLength(offset);
 
-            // Пометка булавки прячется, когда её место занял блок кнопок.
-            if (_headerPinMark is not null)
-                _headerPinMark.IsVisible = offset + _columnHeaderRow.ColumnDefinitions[1].ActualWidth
-                    >= _headerToolbarWidth;
+            SyncHeaderWidthWithList();
+
+
+        }
+
+        /// <summary>
+        /// Приравнивает ширину сетки заголовка ширине содержимого списка
+        /// (MainWindow.Columns.cs:299). Колонка «Название» звёздная, и лишний
+        /// пиксель общей ширины целиком уходит в неё: если заголовок шире строк
+        /// на полосу прокрутки, все колонки значений строк оказываются левее
+        /// своих заголовков ровно на эту разницу.
+        /// </summary>
+        private void SyncHeaderWidthWithList()
+        {
+            if (_columnHeaderRow is null || _tree is null)
+                return;
+
+            double extent = _tree.Bounds.Width;
+            double viewport = _tree.Bounds.Width;
+            if (TreeScroll is { } scroll)
+            {
+                extent = Math.Max(scroll.Extent.Width, scroll.Viewport.Width);
+                viewport = scroll.Viewport.Width;
+            }
+
+            var target = Math.Max(extent, viewport);
+            if (target > 0 && Math.Abs(_columnHeaderRow.Width - target) > 0.5)
+                _columnHeaderRow.Width = target;
         }
 
         /// <summary>


### PR DESCRIPTION
В Linux-сборке колонки значений стояли левее своих заголовков примерно на
полсотни пикселей, кнопки действий не совпадали с заголовком «Действия»,
а кнопка удаления налезала на колонку «Сервер/База». Правки только в файлах
Avalonia, WPF-часть не тронута.

**Зависимость:** ветка построена поверх `linux-fixes-29` (PR #115), та поверх
`linux-fixes-28` (PR #114). Мержить в порядке 114, 115, 116.

### Причина

Ведущие колонки трёх сеток списка у нас не совпадали. В разметке
(`MainWindow.xaml:495-512` для шапки, `:893-905` для строки группы,
`:1077-1088` для строки базы) набор один и тот же: место под кнопки групп 144,
компенсатор отступа дерева, звезда 28 при минимуме 30, булавка 26, название.
Звезда, булавка, значок подключения и имя лежат в одной панели, которая
занимает эти пять колонок целиком (`:1152`), поэтому их собственная ширина
не двигает колонки значений.

У нас в шапке было пять колонок с компенсатором и колонкой значка, в строке
четыре без компенсатора, звезда и булавка автоматической ширины (плашка номера
слота делала их шире), компенсатор считался прикидкой по ширине блока кнопок,
а ширина шапки не была привязана к ширине содержимого списка. Колонка
«Название» звёздная, и любая разница общей ширины двух сеток уходит целиком
в неё, сдвигая все колонки значений.

### Что сделано

1. **Общий набор ведущих колонок** для шапки, строки группы и строки базы:
   один метод строит все три, компенсатор передаётся только шапке.
2. **Ведущий блок строки** (звезда, булавка, значок подключения, имя) собран
   в одну панель на все пять колонок, как в разметке.
3. **Свой шаблон строки дерева** вместо Fluent: колонка кнопки разворота по
   содержимому и колонка заголовка, список вложенных строк без отступа
   (`MainWindow.xaml:1432-1441`). Штатный шаблон Avalonia сдвигает на каждый
   уровень вложенности весь заголовок строки, и колонки значений вложенных
   строк уезжали от заголовков, как только ширина колонки «Название» задавалась
   числом. Отступ уровня теперь стоит на кнопке разворота и на ведущем блоке,
   привязками к `TreeViewItem.Level`.
4. **Арифметика компенсатора** взята из вашего `AlignHeaderToData`
   (`MainWindow.Columns.cs:265`), вместо прежней прикидки по ширине блока кнопок.
5. **Ширина шапки приравнена ширине содержимого списка** по вашему
   `SyncHeaderWidthWithList`, и пересчитывается теперь на каждое изменение
   размеров списка и после перетаскивания разделителя колонок, а не только
   при пересборке строк.
6. **Ширины колонок больше не сжимаются компактным режимом.** Раньше «Действия»
   сжимались до 136 пикселей при пяти кнопках, которым нужно около 150, и
   кнопка удаления вылезала на соседнюю колонку. В разметке ширины колонок
   заданы числами, а компактный режим меняет только отступы и шрифты.
7. **Сдвиг пустой группы** считается как у вас в `GroupOffsetConverter`
   (`Converters/GroupOffsetConverter.cs:37`): отступ уровня плюс ширина кнопки
   разворота. Было плоское значение, вложенная пустая подгруппа вставала левее.
8. **Пометка закрепления в шапке** перенесена внутрь блока кнопок сразу за
   переключатель тегов, как в разметке (`MainWindow.xaml:620`). Своей колонки
   у неё больше нет, вместе с ней ушло и правило «спрятать, когда её накрыл
   блок кнопок».
9. **Заголовки групп теперь едут за разделителем колонок** вместе со строками
   баз: раньше при перетаскивании собирались только сетки строк баз, и кнопки
   группы расходились с кнопками строк до ближайшей пересборки дерева.
10. **В порядке колонок по умолчанию появился ключ `Actions`**, как у вас
    (`MainViewModel.Display.cs:540`). Без него на свежем профиле колонку
    «Действия» нельзя было переставить: окно настроек строит список
    перестановки из этого порядка.

### Расхождение, которое стоит назвать

Имя базы теперь лежит в горизонтальной панели, как у вас, и своей ширины не
знает. Чтобы длинное имя не налезало на колонки значений, ведущий блок обрезает
содержимое по своей границе (`ClipToBounds`). Обрезка жёсткая, без многоточия;
в WPF имя не подрезается вовсе.

### Проверено

Сборка без ошибок. Прогон живьём: обычная ширина окна, узкая с горизонтальной
прокруткой, изменение размера окна туда и обратно, скрытые звезда и булавка,
обычный и компактный режим. Замер положения колонок изнутри приложения:
колонки значений строки и заголовка расходятся на 1 пиксель против прежних
пятидесяти. Три встречных аудита: внешний по фактам Avalonia 11.3.20 (отступ
Fluent, момент готовности `Level`, семантика звёздных колонок), чтение вглубь
по репозиторию и проверка перечислением всех номеров колонок.
