### PR TITLE
Linux/Avalonia: сборка не проходит после 0.3.5.32, снято переопределение шаблона ComboBox

### DIFF
--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -437,13 +437,10 @@
         </Style>
     </ControlTheme>
 
-    <!-- Шаблон комбобокса задан явно (как в WPF, LightTheme.xaml:298): штатная тема Fluent
-         на части дистрибутивов рисует стрелку не у правого края и не открывает список.
-         Полупрозрачная кнопка занимает всю площадь (Grid.ColumnSpan=2) и двухсторонне
-         связана с IsDropDownOpen, поэтому список надёжно открывается кликом в любом месте;
-         стрелка живёт ВНУТРИ шаблона кнопки и всегда прижата к правому краю. У редактируемых
-         списков поверх кнопки лежит PART_EditableText: в колонке контента он ловит клик для
-         ввода текста, а правая часть (стрелка) остаётся кнопке и открывает список. -->
+    <!-- Шаблон комбобокса НЕ переопределяем: штатная тема Fluent открывает список
+         кликом в любом месте (ComboBox.OnPointerReleased переключает IsDropDownOpen),
+         а у редактируемых списков клик по PART_EditableTextBox ставит курсор для ввода.
+         Это тот же вывод, что записан в CHANGELOG для 0.3.5.32-0.3.5.34. -->
     <ControlTheme x:Key="ModernComboBox" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
         <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
@@ -458,97 +455,6 @@
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="ItemContainerTheme" Value="{StaticResource ModernComboBoxItem}"/>
         <Setter Property="HorizontalAlignment" Value="Stretch"/>
-
-        <Setter Property="Template">
-            <ControlTemplate TargetType="ComboBox">
-                <Grid x:Name="Root">
-                    <Border x:Name="Background"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{TemplateBinding CornerRadius}">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="32"/>
-                            </Grid.ColumnDefinitions>
-
-                            <!-- Hit-цель: кнопка на всю площадь, стрелка внутри неё справа.
-                                 Клик по любой точке нередактируемого списка и по правому краю
-                                 редактируемого переключает IsDropDownOpen. -->
-                            <ToggleButton Grid.ColumnSpan="2"
-                                          Focusable="False"
-                                          IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                          Background="Transparent"
-                                          BorderThickness="0">
-                                <ToggleButton.Template>
-                                    <ControlTemplate TargetType="ToggleButton">
-                                        <Grid Background="Transparent" Cursor="Hand">
-                                            <Path Data="M0,0 L4,4 L8,0"
-                                                  Stroke="{DynamicResource TextSecondaryBrush}"
-                                                  StrokeThickness="1.5"
-                                                  HorizontalAlignment="Right"
-                                                  VerticalAlignment="Center"
-                                                  Width="10" Height="5"
-                                                  Margin="0,0,11,0"
-                                                  Stretch="Uniform"/>
-                                        </Grid>
-                                    </ControlTemplate>
-                                </ToggleButton.Template>
-                            </ToggleButton>
-
-                            <!-- Режим выбора (нередактируемый) -->
-                            <ContentPresenter x:Name="PART_ContentPresenter"
-                                              Grid.Column="0"
-                                              Margin="{TemplateBinding Padding}"
-                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalAlignment="Center"
-                                              IsHitTestVisible="False"
-                                              Content="{TemplateBinding SelectionBoxItem}"
-                                              ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"/>
-
-                            <!-- Редактируемый режим (сервер / порт / размер шрифта):
-                                 отступ задаём полем (Margin = Padding), чтобы текст начинался
-                                 там же, где у обычного списка. Видимость переключает сам контрол
-                                 по IsEditable. -->
-                            <TextBox x:Name="PART_EditableText"
-                                     Grid.Column="0"
-                                     Margin="{TemplateBinding Padding}"
-                                     Padding="0"
-                                     VerticalContentAlignment="Center"
-                                     HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                     Background="Transparent"
-                                     BorderThickness="0"
-                                     Foreground="{TemplateBinding Foreground}"
-                                     FontSize="{TemplateBinding FontSize}"
-                                     CaretBrush="{DynamicResource TextPrimaryBrush}"
-                                     IsVisible="False"/>
-                        </Grid>
-                    </Border>
-
-                    <Popup x:Name="PART_Popup"
-                           Placement="Bottom"
-                           PlacementTarget="{Binding #Root}"
-                           AllowsTransparency="True"
-                           Focusable="False"
-                           StaysOpen="False"
-                           IsOpen="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
-                        <Border Background="{DynamicResource ComboBoxDropDownBackground}"
-                                BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
-                                BorderThickness="1"
-                                CornerRadius="8"
-                                Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
-                                MinWidth="{Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}"
-                                MaxHeight="{TemplateBinding MaxDropDownHeight}">
-                            <ScrollViewer HorizontalScrollBarVisibility="Disabled"
-                                          VerticalScrollBarVisibility="Auto">
-                                <ItemsPresenter/>
-                            </ScrollViewer>
-                        </Border>
-                    </Popup>
-                </Grid>
-            </ControlTemplate>
-        </Setter>
 
         <Style Selector="^ /template/ Border#Background">
             <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>


### PR DESCRIPTION
## Что не так

Ветка `main` (0.3.5.34) не собирается под Linux. Цель `net10.0`:

```
$ dotnet build "Configuration Management/Configuration Management.csproj" -f net10.0
Controls.axaml(529,22): Avalonia error AVLN2000: Unable to resolve suitable
    regular or attached property AllowsTransparency on type
    Avalonia.Controls:Avalonia.Controls.Primitives.Popup
Controls.axaml(529,22): Avalonia error AVLN2000: Unable to resolve suitable
    regular or attached property StaysOpen on type
    Avalonia.Controls:Avalonia.Controls.Primitives.Popup
    Ошибок: 2
```

В переопределение шаблона `ModernComboBox` для Avalonia, добавленное
в 0.3.5.32, попали два свойства `Popup` из WPF: у Avalonia их нет.
Прямой замены `AllowsTransparency` у `Avalonia.Controls.Primitives.Popup` нет,
его нужно просто убрать; `StaysOpen="False"` заменяется на
`IsLightDismissEnabled="True"`, то есть с обратной полярностью. Штатный
шаблон Fluent так и делает.

## Почему двух строк недостаточно

Я сначала правил именно эти две строки: сборка проходит, но редактируемые
выпадающие списки ломаются. На вкладке «Подключение» окна настройки базы
поля «Сервер» и «Порт сервера» пустые, хотя у базы заполнены `localhost`
и `1541`, и стрелка нарисована у левого края, а не у правого. Причин несколько, и все в шаблоне:

* поле ввода названо `x:Name="PART_EditableText"`, а `ComboBox` в Avalonia
  11.3.20 ищет часть с именем `PART_EditableTextBox`. Часть с другим именем
  контрол просто не находит, без ошибки и без предупреждения;
* у этого поля стоит `IsVisible="False"` константой, тогда как штатная тема
  связывает видимость с `IsEditable` (`IsVisible="{TemplateBinding IsEditable}"`);
* привязки `Text` у поля нет вообще, а у штатной темы она `TwoWay`;
* у `ToggleButton` не задан `HorizontalAlignment="Stretch"`, а штатная тема
  Fluent выставляет кнопкам `Left` (`ToggleButton.xaml:21`). Кнопка сжимается
  и прижимается влево вместе со стрелкой внутри неё. В разметке WPF `Stretch`
  у `DropDownToggle` проставлен явно (`LightTheme.xaml:323`), при переносе
  в Avalonia он потерялся. Это и есть «стрелка у левого края».

То же касается `CreateInfobaseWindow.Avalonia.cs` (`_dbmsBox`, «СУБД») и
поля размера шрифта в настройках: это тоже `IsEditable = true`.

## Что сделано

Переопределение шаблона снято целиком, остальные правки 0.3.5.31-0.3.5.34
не тронуты. Получается ровно то, что записано в CHANGELOG для 0.3.5.32,
0.3.5.33 и 0.3.5.34: «штатная тема Fluent уже открывает список кликом
в любом месте, а клик по `PART_EditableTextBox` редактируемых комбобоксов
ставит курсор для ввода, отдельного переопределения шаблона не требуется».
Именно так Linux-сторона и вела себя до 0.3.5.32.

Отдельно: подтвердить проблему, ради которой шаблон писался, не удалось.
В штатном шаблоне Fluent 11.3.20 стрелка это `PathIcon x:Name="DropDownGlyph"`
в правой колонке с векторным `Data` и `IsHitTestVisible="False"`, то есть ни
шрифта, ни системного глифа, который мог бы поехать на другой машине, там нет;
а открытие кликом по всей площади реализовано не темой, а самим контролом
(`ComboBox.OnPointerReleased`). От дистрибутива это зависеть не может.

Если переопределение всё же нужно (например, на какой-то системе стрелка
действительно рисуется не у правого края), его лучше делать отдельно и
от шаблона Fluent, а не от разметки WPF: в Avalonia у `Popup` другой набор
свойств, а имена частей шаблона жёсткие.

## Как проверено

* `dotnet build -f net10.0`: было 2 ошибки, стало 0 ошибок, 15 предупреждений
  (столько же, сколько до 0.3.5.32).
* Прогон собранного приложения на KDE/X11: окно настройки базы, вкладка
  «Подключение». Поля «Сервер» и «Порт сервера» показывают значения,
  стрелка у правого края, список открывается кликом и содержит серверы
  из других баз (`localhost`, `srv2`).

* Нередактируемые списки в этом же окне и в окне настроек открываются
  кликом в любом месте, как и раньше.

## Что этим не закрывается

* **Паритет по стрелке.** У Fluent это `PathIcon` с заливкой 12 на 12 и
  отступом 10, у WPF `Path` с обводкой 10 на 5, `StrokeThickness 1.5`
  и отступом 11. Селектором это не подогнать: `Data`, `Width`, `Height`
  и `Margin` проставлены в штатном шаблоне локальными значениями, а они
  приоритетнее сеттера стиля. Через ресурс передаётся только цвет
  (`ComboBoxDropDownGlyphForeground`), как и написано в комментарии
  `Controls.axaml`.
* **Клик правее текста у редактируемого списка** попадает мимо поля ввода
  и открывает список вместо установки курсора. Это не следствие этой правки,
  так было и до 0.3.5.32. Лечится одной строкой в той же теме, вынесу
  отдельным PR поверх этого.
