### PR TITLE
Linux/Avalonia: клик правее текста в редактируемом списке ставит курсор, а не открывает список

### DIFF
--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -452,7 +452,7 @@
         <Setter Property="MinHeight" Value="36"/>
         <Setter Property="MinWidth" Value="120"/>
         <Setter Property="MaxDropDownHeight" Value="280"/>
-        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         <Setter Property="ItemContainerTheme" Value="{StaticResource ModernComboBoxItem}"/>
         <Setter Property="HorizontalAlignment" Value="Stretch"/>
 

--- a/Configuration Management/Themes/Controls.axaml
+++ b/Configuration Management/Themes/Controls.axaml
@@ -437,13 +437,10 @@
         </Style>
     </ControlTheme>
 
-    <!-- Шаблон комбобокса задан явно (как в WPF, LightTheme.xaml:298): штатная тема Fluent
-         на части дистрибутивов рисует стрелку не у правого края и не открывает список.
-         Полупрозрачная кнопка занимает всю площадь (Grid.ColumnSpan=2) и двухсторонне
-         связана с IsDropDownOpen, поэтому список надёжно открывается кликом в любом месте;
-         стрелка живёт ВНУТРИ шаблона кнопки и всегда прижата к правому краю. У редактируемых
-         списков поверх кнопки лежит PART_EditableText: в колонке контента он ловит клик для
-         ввода текста, а правая часть (стрелка) остаётся кнопке и открывает список. -->
+    <!-- Шаблон комбобокса НЕ переопределяем: штатная тема Fluent открывает список
+         кликом в любом месте (ComboBox.OnPointerReleased переключает IsDropDownOpen),
+         а у редактируемых списков клик по PART_EditableTextBox ставит курсор для ввода.
+         Это тот же вывод, что записан в CHANGELOG для 0.3.5.32-0.3.5.34. -->
     <ControlTheme x:Key="ModernComboBox" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
         <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
@@ -458,97 +455,6 @@
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="ItemContainerTheme" Value="{StaticResource ModernComboBoxItem}"/>
         <Setter Property="HorizontalAlignment" Value="Stretch"/>
-
-        <Setter Property="Template">
-            <ControlTemplate TargetType="ComboBox">
-                <Grid x:Name="Root">
-                    <Border x:Name="Background"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{TemplateBinding CornerRadius}">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="32"/>
-                            </Grid.ColumnDefinitions>
-
-                            <!-- Hit-цель: кнопка на всю площадь, стрелка внутри неё справа.
-                                 Клик по любой точке нередактируемого списка и по правому краю
-                                 редактируемого переключает IsDropDownOpen. -->
-                            <ToggleButton Grid.ColumnSpan="2"
-                                          Focusable="False"
-                                          IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                          Background="Transparent"
-                                          BorderThickness="0">
-                                <ToggleButton.Template>
-                                    <ControlTemplate TargetType="ToggleButton">
-                                        <Grid Background="Transparent" Cursor="Hand">
-                                            <Path Data="M0,0 L4,4 L8,0"
-                                                  Stroke="{DynamicResource TextSecondaryBrush}"
-                                                  StrokeThickness="1.5"
-                                                  HorizontalAlignment="Right"
-                                                  VerticalAlignment="Center"
-                                                  Width="10" Height="5"
-                                                  Margin="0,0,11,0"
-                                                  Stretch="Uniform"/>
-                                        </Grid>
-                                    </ControlTemplate>
-                                </ToggleButton.Template>
-                            </ToggleButton>
-
-                            <!-- Режим выбора (нередактируемый) -->
-                            <ContentPresenter x:Name="PART_ContentPresenter"
-                                              Grid.Column="0"
-                                              Margin="{TemplateBinding Padding}"
-                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalAlignment="Center"
-                                              IsHitTestVisible="False"
-                                              Content="{TemplateBinding SelectionBoxItem}"
-                                              ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"/>
-
-                            <!-- Редактируемый режим (сервер / порт / размер шрифта):
-                                 отступ задаём полем (Margin = Padding), чтобы текст начинался
-                                 там же, где у обычного списка. Видимость переключает сам контрол
-                                 по IsEditable. -->
-                            <TextBox x:Name="PART_EditableText"
-                                     Grid.Column="0"
-                                     Margin="{TemplateBinding Padding}"
-                                     Padding="0"
-                                     VerticalContentAlignment="Center"
-                                     HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                     Background="Transparent"
-                                     BorderThickness="0"
-                                     Foreground="{TemplateBinding Foreground}"
-                                     FontSize="{TemplateBinding FontSize}"
-                                     CaretBrush="{DynamicResource TextPrimaryBrush}"
-                                     IsVisible="False"/>
-                        </Grid>
-                    </Border>
-
-                    <Popup x:Name="PART_Popup"
-                           Placement="Bottom"
-                           PlacementTarget="{Binding #Root}"
-                           AllowsTransparency="True"
-                           Focusable="False"
-                           StaysOpen="False"
-                           IsOpen="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
-                        <Border Background="{DynamicResource ComboBoxDropDownBackground}"
-                                BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
-                                BorderThickness="1"
-                                CornerRadius="8"
-                                Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
-                                MinWidth="{Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}"
-                                MaxHeight="{TemplateBinding MaxDropDownHeight}">
-                            <ScrollViewer HorizontalScrollBarVisibility="Disabled"
-                                          VerticalScrollBarVisibility="Auto">
-                                <ItemsPresenter/>
-                            </ScrollViewer>
-                        </Border>
-                    </Popup>
-                </Grid>
-            </ControlTemplate>
-        </Setter>
 
         <Style Selector="^ /template/ Border#Background">
             <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>


### PR DESCRIPTION
Продолжение #129, поверх него: без него правка не применится, обе лежат
в теме `ModernComboBox` файла `Themes/Controls.axaml`.

## Что не так

У редактируемых выпадающих списков на Linux («Сервер» и «Порт сервера»
в окне настройки базы, «СУБД» в окне создания базы, размер шрифта
в настройках) клик по полю правее текста не ставит курсор, а открывает
выпадающий список.

Причина в том, что штатный шаблон Fluent расходует
`HorizontalContentAlignment` иначе, чем разметка WPF. У Fluent это значение
уходит в `HorizontalAlignment` самого поля ввода:

```xml
<!-- Avalonia 11.3.20, Themes/Fluent/Controls/ComboBox.xaml:121-124 -->
<TextBox Name="PART_EditableTextBox"
         Grid.Column="0"
         Padding="{TemplateBinding Padding}"
         HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
```

Со значением `Left` поле сжимается до желаемой ширины, не меньше минимума
темы (`TextControlThemeMinWidth`, 64), и остаток колонки занимает подложка
`Border#Background`, клик по которой контрол трактует как открытие списка.

В разметке WPF то же значение уходит в `HorizontalContentAlignment` поля
(`Themes/LightTheme.xaml:377`), а само поле растянуто по колонке, поэтому
там клик правее текста ставит курсор.

## Что сделано

`HorizontalContentAlignment` у темы `ModernComboBox` в
[`Themes/Controls.axaml`](Configuration%20Management/Themes/Controls.axaml)
изменён с `Left` на `Stretch`. Одна строка.

У нередактируемых списков это безопасно: там то же значение идёт
в `HorizontalContentAlignment` элемента `ContentPresenter`
(`ComboBox.xaml:111-118`), и текст остаётся прижат влево.

## Как проверено

Прогон собранного приложения на KDE/X11, окно настройки базы, вкладка
«Подключение», поле «Сервер» со значением `localhost`:

* до правки клик правее текста, но левее стрелки открывал список;
* после правки тот же клик ставит курсор в поле, список не открывается;
* клик по стрелке по-прежнему открывает список;
* нередактируемые списки (язык интерфейса, тип подключения, схема
  оформления) открываются кликом в любом месте, текст остаётся слева.

`dotnet build -f net10.0`: 0 ошибок, 15 предупреждений.
