### PR TITLE
Linux/Avalonia: стеклянная рамка диалогов не собиралась

### DIFF
--- a/Configuration Management/Views/ModalWindowBase.cs
+++ b/Configuration Management/Views/ModalWindowBase.cs
@@ -3,9 +3,11 @@ using System;
 using System.Threading;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
+using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
@@ -146,16 +148,19 @@ namespace Configuration_Management
         /// первый установленный Control становится телом «стеклянного» контейнера
         /// с полосой заголовка (перетаскивание + свернуть/закрыть) поверх.
         /// </summary>
-        protected override void OnContentChanged(object? oldValue, object? newValue)
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
-            if (!_wrappingContent && newValue is Control inner)
+            base.OnPropertyChanged(change);
+            if (change.Property != ContentProperty || _wrappingContent)
+            {
+                return;
+            }
+            if (change.GetNewValue<object?>() is Control inner)
             {
                 _wrappingContent = true;
                 Content = BuildChrome(inner);
                 _wrappingContent = false;
-                return;
             }
-            base.OnContentChanged(oldValue, newValue);
         }
 
         /// <summary>


### PR DESCRIPTION
## Что сломано

Linux-цель версии 0.3.5.70 не компилируется. Файл `Configuration Management/Views/ModalWindowBase.cs` целиком лежит под `#if LINUX`, и добавленный в нём код «стеклянной» обёртки содержимого написан по модели WPF, а не Avalonia.

Воспроизведение на чистом `main` (0.3.5.70), Linux, .NET SDK 10.0.111:

```
cd "Configuration Management" && dotnet build "Configuration Management.csproj" -c Release
```

```
Views/ModalWindowBase.cs(149,33): error CS0115: "ModalWindowBase.OnContentChanged(object?, object?)":
не найден метод, пригодный для переопределения.
```

## Причина

1. **CS0115.** `OnContentChanged(object? oldValue, object? newValue)` это метод WPF `ContentControl`. В Avalonia такого виртуального метода у `Window` нет: изменения любых свойств приходят одним каналом `OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)`.

2. **CS0246 и CS0103** в `DialogWindowControlButton` (`ModalWindowBase.cs:740-745`): не хватает двух `using`. `ContentPresenter` живёт в `Avalonia.Controls.Presenters`, `TemplateBinding` в `Avalonia.Data`. В файле есть `Avalonia.Controls` и `Avalonia.Controls.Primitives`, но ни одного из этих двух.

Эти восемь ошибок видны не сразу: пока не разобрано объявление метода, Roslyn не доходит до тел, поэтому первый прогон показывает только одну ошибку CS0115. На счётчик ошибок как на меру оставшейся работы здесь ориентироваться нельзя.

## Что сделано

* Обёртка содержимого перевешена с `OnContentChanged` на `OnPropertyChanged` с проверкой `change.Property == ContentProperty`. Поведение прежнее: первый установленный `Control` заворачивается в `BuildChrome`, повторный вход отсекается флагом `_wrappingContent`.
* Добавлены `using Avalonia.Controls.Presenters;` и `using Avalonia.Data;`.

Правка минимальная, три места в одном файле. Windows-ветка не затронута: файл целиком под `#if LINUX`.

## Проверено

* До правки `dotnet build -c Release` на `main` падает, после правки собирается без ошибок и предупреждений уровня error.
* Приложение запускается, главное окно и список баз отрисовываются, диалоги открываются со своей полосой заголовка.

## Зависимости

Отдельный PR, ни от чего не зависит и ничего не блокирует, кроме сборки Linux целиком.
