### PR TITLE
Linux/Avalonia: панель команд над списком по разметке WPF

### DIFF
--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -4167,7 +4167,14 @@ namespace Configuration_Management
             nameHeader.Margin = new Thickness(0, 0, 8, 4);
             MakeSortableHeader(nameHeader, "Name", LocalizationManager.T("Main.ColumnNameSortTooltip"));
             _columnHeaderRow.Children.Add(nameHeader);
-            Grid.SetColumn(nameHeader, NameHeaderColumn);
+            // Подпись охватывает ведущие колонки и колонку имени и прижата влево,
+            // как в разметке после переноса кнопок в панель команд
+            // (MainWindow.xaml:739, Grid.Column=0 и ColumnSpan=5): ведущие колонки
+            // стоят пустыми ради выравнивания значений, а подпись начинается
+            // у левого края шапки, а не за ними.
+            Grid.SetColumn(nameHeader, 0);
+            Grid.SetColumnSpan(nameHeader, NameHeaderColumn + 1);
+            nameHeader.HorizontalAlignment = HorizontalAlignment.Left;
 
             _headerColumnIndex.Clear();
             _headerColumnIndex["Name"] = NameHeaderColumn;

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -55,11 +55,10 @@ namespace Configuration_Management
         private SegmentButton? _emptyGroupsToggle;
         private SegmentButton? _groupByToggle;
         private SegmentButton? _compactToggle;
+        private Border? _commandPanel;
         private Border? _columnHeader;
         private Grid? _columnHeaderRow;
         private ColumnDefinition? _headerOffsetColumn;
-        private double _headerToolbarWidth;
-        private StackPanel? _groupToolbar;
         private Grid? _listContent;
         /// <summary>Шаг прокрутки колесом, как у штатного ScrollContentPresenter.</summary>
         private const double WheelScrollStep = 50;
@@ -188,7 +187,6 @@ namespace Configuration_Management
         private NativeMenu? _trayMenu;
         private string? _traySignature;
         private bool _trayRefreshQueued;
-        private IDisposable? _toolbarWidthLink;
         private NotifyCollectionChangedEventHandler? _groupNodesChanged;
         private NotifyCollectionChangedEventHandler? _flatItemsChanged;
         private EventHandler? _tagFiltersRebuilt;
@@ -336,7 +334,6 @@ namespace Configuration_Management
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star), MinWidth = 200 });
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
             // Слева: сегментные переключатели групп и тегов (с иконками и состояниями).
             var left = new StackPanel
@@ -391,103 +388,6 @@ namespace Configuration_Management
             grid.Children.Add(tabs);
             Grid.SetColumn(tabs, 2);
 
-            // Справа: добавить базу, синхронизация, тема, настройки — иконки + подписи, состояния.
-            var actions = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                VerticalAlignment = VerticalAlignment.Center,
-                Spacing = 2
-            };
-
-            // Все команды верхней панели значками без подписей, как в разметке WPF.
-            var addBtn = TopBarIconButton("IconAdd", LocalizationManager.T("Main.AddBase"), "#22C55E");
-            addBtn.Bind(Button.CommandProperty, new Binding("AddInfobaseCommand"));
-            actions.Children.Add(addBtn);
-
-            // Очистить кеш выбранной базы: перенесено в верхнюю панель команд,
-            // действует на SelectedInfobase (недоступна, если база не выбрана).
-            var clearCacheBtn = TopBarIconButton("IconBroom", LocalizationManager.T("Main.ClearCacheTooltip"), "#F59E0B");
-            clearCacheBtn.Bind(Button.CommandProperty, new Binding("ClearCacheCommand"));
-            actions.Children.Add(clearCacheBtn);
-
-            // Индикатор выгрузки .dt и .cf: виден только во время пакетной
-            // операции, подсказка сводкой (MainWindow.xaml:293).
-            var exportBtn = TopBarIconButton("IconUpload", string.Empty, "#F59E0B");
-            exportBtn.Bind(ToolTip.TipProperty, new Binding("ExportIndicatorTooltip"));
-            exportBtn.Bind(Control.IsVisibleProperty, new Binding("IsExporting"));
-            exportBtn.Focusable = false;
-            actions.Children.Add(exportBtn);
-
-            var syncBtn = TopBarIconButton("IconSync", LocalizationManager.T("Main.SyncDetailedTooltip"), "#14B8A6");
-            syncBtn.Bind(Button.CommandProperty, new Binding("SynchronizeWithIbasesCommand"));
-            actions.Children.Add(syncBtn);
-
-            // Проверить доступность всех баз 1С: ручная команда вместо автопроверки при запуске.
-            // Иконка — зелёный гидролокатор (сонар), как экран на подводных лодках.
-            var checkAvailBtn = new Button
-            {
-                Content = IconHelper.MakeIcon("IconSonar", UiMetrics.Scaled(18),
-                    new SolidColorBrush(Color.Parse("#14B8A6"))),
-                Padding = new Thickness(UiMetrics.Scaled(8)),
-                HorizontalContentAlignment = HorizontalAlignment.Center
-            };
-            checkAvailBtn.Styled(Themes.ControlThemes.IconButton);
-            ToolTip.SetTip(checkAvailBtn, LocalizationManager.T("Main.CheckAvailabilityTooltip"));
-            checkAvailBtn.Bind(Button.CommandProperty, new Binding("CheckAvailabilityCommand"));
-            // Проверка доступности стоит между синхронизацией и темой, как у автора.
-            actions.Children.Add(checkAvailBtn);
-
-            // Значок меняется вместе со схемой, как в версии для Windows
-            // (MainWindow.Language.cs:41): в тёмной солнце, в светлой луна.
-            var themeIconKey = ThemeManager.CurrentTheme == ThemeManager.DarkThemeName ? "IconSun" : "IconMoon";
-            var themeBtn = TopBarIconButton(themeIconKey, LocalizationManager.T("Main.Theme"), "#8B5CF6");
-            themeBtn.Bind(Button.CommandProperty, new Binding("ToggleThemeCommand"));
-            actions.Children.Add(themeBtn);
-
-            // Быстрый переключатель плотности интерфейса, как в разметке WPF:
-            // тот же режим уже есть в настройках, здесь он под рукой.
-            // Это ToggleButton (MainWindow.xaml:322): включённый компактный режим
-            // виден акцентной заливкой, а не только по плотности списка.
-            _compactToggle = MakeSegmentToggle("IconCompress", LocalizationManager.T("Main.CompactModeTooltip"));
-            _compactToggle.IsChecked = _vm?.CompactMode ?? false;
-            _compactToggle.Click += (_, _) =>
-            {
-                if (_vm is null)
-                    return;
-                var next = _compactToggle.IsChecked == true;
-                _vm.CompactMode = next;
-                ApplyCompactMode(next);
-            };
-            actions.Children.Add(_compactToggle);
-
-            var settingsBtn = TopBarIconButton("IconSettings", LocalizationManager.T("Main.SettingsTooltip"), themeBrushKey: "TextSecondaryColorBrush");
-            settingsBtn.Bind(Button.CommandProperty, new Binding("OpenSettingsCommand"));
-            actions.Children.Add(settingsBtn);
-
-
-            // Подсказка «?»: справа, после всех команд верхней панели.
-            actions.Children.Add(new HelpLink
-            {
-                HelpText = LocalizationManager.T("Main.BaseListHelp"),
-                Margin = new Thickness(4, 0, 0, 0)
-            });
-
-            // Группа команд обведена рамкой с фоном, как в разметке WPF:
-            // Border с CornerRadius 12, Padding 4 и рамкой в одну точку.
-            var actionsGroup = new Border
-            {
-                CornerRadius = new CornerRadius(12),
-                Padding = new Thickness(4),
-                Margin = new Thickness(0, 0, 12, 0),
-                BorderThickness = new Thickness(1),
-                VerticalAlignment = VerticalAlignment.Center,
-                Child = actions
-            };
-            ThemeBrushes.Bind(actionsGroup, Border.BackgroundProperty, "ContentBackgroundColorBrush");
-            ThemeBrushes.Bind(actionsGroup, Border.BorderBrushProperty, "BorderColorBrush");
-
-            grid.Children.Add(actionsGroup);
-            Grid.SetColumn(actionsGroup, 3);
 
             var topBarBorder = new Border
             {
@@ -507,6 +407,152 @@ namespace Configuration_Management
             topBarBorder.PointerPressed += OnTopBarPointerPressed;
 
             return topBarBorder;
+        }
+
+        /// <summary>
+        /// Панель команд над заголовками колонок (MainWindow.xaml:488-612).
+        /// Слева блок управления группами, дальше правка списка, обслуживание
+        /// баз и настройки, разделённые вертикальными чертами. В версии для
+        /// Windows все эти команды живут здесь, а не в верхней полосе окна.
+        /// </summary>
+        private Control BuildCommandPanel()
+        {
+            var border = new Border
+            {
+                Child = BuildCommandPanelContent(),
+                Margin = new Thickness(4, 0, 4, 0),
+                Padding = new Thickness(8, 6),
+                BorderThickness = new Thickness(0, 0, 0, 1)
+            };
+            ThemeBrushes.Bind(border, Border.BackgroundProperty, "CardBackgroundBrush");
+            ThemeBrushes.Bind(border, Border.BorderBrushProperty, "BorderColorBrush");
+            _commandPanel = border;
+            return border;
+        }
+
+        /// <summary>
+        /// Пересобирает содержимое панели команд: состав кнопок групп зависит
+        /// от настроек, а они меняются на живом окне из окна настроек.
+        /// </summary>
+        private void RefreshCommandPanel()
+        {
+            if (_commandPanel is not null)
+                _commandPanel.Child = BuildCommandPanelContent();
+        }
+
+        /// <summary>Кнопки панели команд одной строкой, слева направо.</summary>
+        private Control BuildCommandPanelContent()
+        {
+            var panel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            // Развернуть и свернуть группы, сортировка групп, показ тегов в строках.
+            panel.Children.Add(BuildGroupToolbar());
+            panel.Children.Add(CommandPanelSeparator());
+
+            // «Правка»: добавить, изменить и удалить выбранную базу.
+            var addBtn = TopBarIconButton("IconAdd", LocalizationManager.T("Main.AddBase"), "#22C55E");
+            addBtn.Bind(Button.CommandProperty, new Binding("AddInfobaseCommand"));
+            panel.Children.Add(addBtn);
+
+            var editBtn = TopBarIconButton("IconEdit", LocalizationManager.T("Main.EditBaseTooltip"),
+                themeBrushKey: "TextSecondaryColorBrush");
+            editBtn.Bind(Button.CommandProperty, new Binding("EditInfobaseCommand"));
+            panel.Children.Add(editBtn);
+
+            var deleteBtn = TopBarIconButton("IconDelete", LocalizationManager.T("Main.DeleteTooltip"), "#DC2626");
+            deleteBtn.Bind(Button.CommandProperty, new Binding("DeleteInfobaseCommand"));
+            panel.Children.Add(deleteBtn);
+
+            panel.Children.Add(CommandPanelSeparator());
+
+            // «Управление списком»: очистка кеша, индикатор выгрузки, синхронизация
+            // с ibases.v8i и проверка доступности баз.
+            var clearCacheBtn = TopBarIconButton("IconBroom", LocalizationManager.T("Main.ClearCacheTooltip"), "#F59E0B");
+            clearCacheBtn.Bind(Button.CommandProperty, new Binding("ClearCacheCommand"));
+            panel.Children.Add(clearCacheBtn);
+
+            // Индикатор выгрузки .dt и .cf: виден только во время пакетной
+            // операции, подсказка сводкой (MainWindow.xaml:563).
+            var exportBtn = TopBarIconButton("IconUpload", string.Empty, "#F59E0B");
+            exportBtn.Bind(ToolTip.TipProperty, new Binding("ExportIndicatorTooltip"));
+            exportBtn.Bind(Control.IsVisibleProperty, new Binding("IsExporting"));
+            exportBtn.Focusable = false;
+            panel.Children.Add(exportBtn);
+
+            var syncBtn = TopBarIconButton("IconSync", LocalizationManager.T("Main.SyncDetailedTooltip"), "#14B8A6");
+            syncBtn.Bind(Button.CommandProperty, new Binding("SynchronizeWithIbasesCommand"));
+            panel.Children.Add(syncBtn);
+
+            // Проверить доступность всех баз 1С: ручная команда вместо автопроверки при запуске.
+            // Иконка — зелёный гидролокатор (сонар), как экран на подводных лодках.
+            var checkAvailBtn = new Button
+            {
+                Content = IconHelper.MakeIcon("IconSonar", UiMetrics.Scaled(18),
+                    new SolidColorBrush(Color.Parse("#14B8A6"))),
+                Padding = new Thickness(UiMetrics.Scaled(8)),
+                HorizontalContentAlignment = HorizontalAlignment.Center
+            };
+            checkAvailBtn.Styled(Themes.ControlThemes.IconButton);
+            ToolTip.SetTip(checkAvailBtn, LocalizationManager.T("Main.CheckAvailabilityTooltip"));
+            checkAvailBtn.Bind(Button.CommandProperty, new Binding("CheckAvailabilityCommand"));
+            panel.Children.Add(checkAvailBtn);
+
+            panel.Children.Add(CommandPanelSeparator());
+
+            // «Настройки»: тема, компактный режим, окно настроек и справка.
+            // Значок темы меняется вместе со схемой, как в версии для Windows
+            // (MainWindow.Language.cs:41): в тёмной солнце, в светлой луна.
+            var themeIconKey = ThemeManager.CurrentTheme == ThemeManager.DarkThemeName ? "IconSun" : "IconMoon";
+            var themeBtn = TopBarIconButton(themeIconKey, LocalizationManager.T("Main.Theme"), "#8B5CF6");
+            themeBtn.Bind(Button.CommandProperty, new Binding("ToggleThemeCommand"));
+            panel.Children.Add(themeBtn);
+
+            // Это ToggleButton (MainWindow.xaml:596): включённый компактный режим
+            // виден акцентной заливкой, а не только по плотности списка.
+            _compactToggle = MakeSegmentToggle("IconCompress", LocalizationManager.T("Main.CompactModeTooltip"));
+            _compactToggle.IsChecked = _vm?.CompactMode ?? false;
+            _compactToggle.Click += (_, _) =>
+            {
+                if (_vm is null)
+                    return;
+                var next = _compactToggle.IsChecked == true;
+                _vm.CompactMode = next;
+                ApplyCompactMode(next);
+            };
+            panel.Children.Add(_compactToggle);
+
+            var settingsBtn = TopBarIconButton("IconSettings", LocalizationManager.T("Main.SettingsTooltip"),
+                themeBrushKey: "TextSecondaryColorBrush");
+            settingsBtn.Bind(Button.CommandProperty, new Binding("OpenSettingsCommand"));
+            panel.Children.Add(settingsBtn);
+
+            panel.Children.Add(new HelpLink
+            {
+                HelpText = LocalizationManager.T("Main.BaseListHelp"),
+                Margin = new Thickness(4, 0, 0, 0)
+            });
+
+            return panel;
+        }
+
+        /// <summary>
+        /// Вертикальная черта между группами команд панели: одна точка ширины
+        /// с прозрачностью 0.55 и полями 4,5 (MainWindow.xaml:533).
+        /// </summary>
+        private static Control CommandPanelSeparator()
+        {
+            var line = new Border
+            {
+                Width = 1,
+                Margin = new Thickness(4, 5),
+                Opacity = 0.55
+            };
+            ThemeBrushes.Bind(line, Border.BackgroundProperty, "BorderColorBrush");
+            return line;
         }
 
         /// <summary>
@@ -1212,11 +1258,17 @@ namespace Configuration_Management
             // (4,0,4,8 и поле 8), поэтому её вид не меняется.
             var leftContent = new Grid { Margin = new Thickness(12, 12, 0, 12) };
             leftContent.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            leftContent.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
             leftContent.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
             var tagPanel = BuildTagFilterPanel();
+            // Панель команд стоит между фильтром тегов и списком, как в разметке
+            // (MainWindow.xaml:488, Grid.Row=2 левой колонки).
+            var commandPanel = BuildCommandPanel();
             Grid.SetRow(tagPanel, 0);
-            Grid.SetRow(listWithBar, 1);
+            Grid.SetRow(commandPanel, 1);
+            Grid.SetRow(listWithBar, 2);
             leftContent.Children.Add(tagPanel);
+            leftContent.Children.Add(commandPanel);
             leftContent.Children.Add(listWithBar);
 
             var leftPanel = new Border
@@ -1259,7 +1311,15 @@ namespace Configuration_Management
                         QueueColumnHeaderRefresh();
                     // Кнопки групп живут в заголовке и видны только при группировке.
                     if (e.PropertyName == nameof(MainViewModel.ShowExpandCollapseButtons))
+                    {
                         QueueColumnHeaderRefresh();
+                        // Кнопки групп живут в панели команд, а их видимость
+                        // меняется из окна настроек на живом окне.
+                        RefreshCommandPanel();
+                    }
+                    // Метка закрепления стоит в том же блоке кнопок панели команд.
+                    if (e.PropertyName == nameof(MainViewModel.ShowPinnedButton))
+                        RefreshCommandPanel();
                     // Переключатель тегов в списке живёт в том же заголовке,
                     // а его настройка меняется и из окна настроек.
                     if (e.PropertyName == nameof(MainViewModel.ShowTags))
@@ -1662,13 +1722,12 @@ namespace Configuration_Management
         {
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(GroupButtonsColumnWidth) });
             grid.ColumnDefinitions.Add(compensator ?? new ColumnDefinition { Width = new GridLength(0) });
-            // Минимум колонки звезды держится всегда: под ним в заголовке стоит
-            // переключатель тегов, и без резерва он срезался бы границей колонки
-            // «Название» (MainWindow.xaml:502, issue 84 апстрима).
+            // Резерв под переключатель тегов снят вместе с переносом кнопок
+            // в панель команд: колонка пустая и лишнего отступа слева от
+            // «Названия» давать не должна (MainWindow.xaml:653 и 1028).
             grid.ColumnDefinitions.Add(new ColumnDefinition
             {
-                Width = new GridLength(showFavorite ? FavoriteColumnWidth : 0),
-                MinWidth = TagsToggleReserve
+                Width = new GridLength(showFavorite ? FavoriteColumnWidth : 0)
             });
             grid.ColumnDefinitions.Add(new ColumnDefinition
             {
@@ -3863,18 +3922,13 @@ namespace Configuration_Management
         private static double FavoriteColumnWidth => 28;
 
         /// <summary>
-        /// Резерв под переключатель тегов: минимум колонки звезды, который держится
-        /// и при скрытой звезде (MainWindow.xaml:502).
-        /// </summary>
-        private static double TagsToggleReserve => 30;
-
-        /// <summary>
-        /// Место под кнопки групп в ведущих колонках всех трёх сеток списка.
-        /// Ширина фиксированная, как в разметке, и обнуляется вместе с кнопками
-        /// (MainWindow.xaml:495).
+        /// Ведущая колонка на месте прежних кнопок групп во всех трёх сетках
+        /// списка. Сами кнопки живут в панели команд, а колонка осталась
+        /// небольшим отступом выравнивания и обнуляется вместе с ними
+        /// (MainWindow.xaml:650 и 1026).
         /// </summary>
         private double GroupButtonsColumnWidth
-            => (_vm?.ShowExpandCollapseButtons ?? true) ? 144 : 0;
+            => (_vm?.ShowExpandCollapseButtons ?? true) ? 24 : 0;
 
         /// <summary>Ширина колонки булавки «закреплено» в заголовке и в строке базы.</summary>
         private static double PinColumnWidth => 26;
@@ -3887,22 +3941,6 @@ namespace Configuration_Management
         /// </summary>
         private double ActionsColumnWidth
             => _vm is { ActionsColumnWidth: > 0 } vm ? vm.ActionsColumnWidth : 170;
-
-        /// <summary>Ширина одной кнопки панели инструментов над списком.</summary>
-        private static double ToolbarButtonWidth => UiMetrics.Scaled(24);
-
-        /// <summary>Ширина блока кнопок групп: четыре кнопки с промежутками.</summary>
-        private static double GroupToolbarWidth => ToolbarButtonWidth * 4 + 6 + UiMetrics.Scaled(6);
-
-        /// <summary>
-        /// Расчётная ширина переключателя тегов: он сделан сегментной кнопкой
-        /// с горизонтальным отступом 12, рамкой 2 и иконкой 15, то есть
-        /// заметно шире обычной кнопки панели.
-        /// </summary>
-        private const double TagsToggleWidth = 12 * 2 + 2 * 2 + 15;
-
-        /// <summary>Зазор между блоком кнопок и подписью «Название».</summary>
-        private const double HeaderToolbarGap = 2;
 
         /// <summary>
         /// Номер колонки с именем: место кнопок групп, компенсатор, звезда, булавка.
@@ -4114,12 +4152,6 @@ namespace Configuration_Management
             _columnHeaderRow.ColumnDefinitions.Clear();
 
             var columns = ListColumns();
-            // Ширина блока кнопок нужна, чтобы подпись «Название» встала правее
-            // него. Здесь она только расчётная: панель ещё не создана, а Bounds
-            // прежней панели относятся к прежнему составу кнопок. Измеренную
-            // ширину подставляет AlignHeaderToRows, когда панель разложена.
-            _headerToolbarWidth = (_vm.ShowExpandCollapseButtons ? GroupToolbarWidth : 0)
-                + TagsToggleWidth + HeaderToolbarGap;
 
             // Колонки заголовка строятся тем же построителем, что и колонки строк:
             // набор ведущих колонок обязан совпадать, иначе значения разъезжаются
@@ -4128,15 +4160,6 @@ namespace Configuration_Management
             var actionsOffset = ActionsOffsetInColumns(columns);
             AddListColumns(_columnHeaderRow, _vm.ShowFavoritesButton, _vm.ShowPinnedButton, _headerOffsetColumn);
 
-
-            // Кнопки лежат поверх компенсатора и пустых колонок звезды,
-            // булавки и иконки: своя колонка сдвинула бы подписи вправо
-            // от значений, а колонки заголовка тут ничего не показывают.
-            var tools = BuildGroupToolbar();
-            _columnHeaderRow.Children.Add(tools);
-            Grid.SetColumn(tools, 0);
-            Grid.SetColumnSpan(tools, NameHeaderColumn);
-            tools.ZIndex = 1;
 
             var nameHeader = ColumnHeader(LocalizationManager.T("Column.Name"), IconHelper.ColumnIconKey("Name"));
             // У «Названия» отступ слева нулевой: заголовок равняется по тексту строк
@@ -4193,25 +4216,6 @@ namespace Configuration_Management
         }
 
         /// <summary>
-        /// Измеренная ширина блока кнопок; null, пока он не разложен.
-        /// Панель зажата в узкие колонки заголовка, поэтому её собственный
-        /// Bounds обрезан по ним, а кнопки рисуются дальше: ширину берём
-        /// по самому правому краю содержимого.
-        /// </summary>
-        private double? MeasuredToolbarWidth
-        {
-            get
-            {
-                if (_groupToolbar is null)
-                    return null;
-                var right = 0d;
-                foreach (var child in _groupToolbar.Children)
-                    right = Math.Max(right, child.Bounds.Right);
-                return right > 0 ? right : null;
-            }
-        }
-
-        /// <summary>
         /// Блок кнопок над списком: развернуть и свернуть все группы и две
         /// сортировки групп (только при группировке), а также переключатель
         /// тегов в строках, который нужен всегда.
@@ -4256,14 +4260,6 @@ namespace Configuration_Management
                 panel.Children.Add(pinMark);
             }
 
-            _groupToolbar = panel;
-            // Ширина известна только после раскладки, а подпись выравнивается
-            // по ней. Следим за переключателем: он всегда крайний справа,
-            // поэтому именно он задаёт правый край блока. Bounds самой панели
-            // обрезаны колонками заголовка и на измерение не влияют.
-            _toolbarWidthLink?.Dispose();
-            _toolbarWidthLink = tagsToggle.GetObservable(Visual.BoundsProperty)
-                .Subscribe(new PropertyObserver<Rect>(_ => QueueHeaderAlign()));
             return panel;
         }
 
@@ -4695,7 +4691,7 @@ namespace Configuration_Management
             for (var i = NameHeaderColumn + 1; i < definitions.Count; i++)
                 values += definitions[i].Width.IsAbsolute ? definitions[i].Width.Value : 0;
 
-            _listContent.MinWidth = nameWidth + Math.Max(lead, _headerToolbarWidth)
+            _listContent.MinWidth = nameWidth + lead
                 + UiMetrics.PaddingControl * 2 + values;
         }
 
@@ -4753,18 +4749,6 @@ namespace Configuration_Management
                 {
                     rowGrid = content;
                     rowOrigin = origin.Value.X;
-                }
-            }
-
-            // Измеренная ширина блока кнопок нужна минимуму области списка:
-            // по константам он оставлял бы пустоту или лишнюю прокрутку.
-            if (MeasuredToolbarWidth is { } measured)
-            {
-                var target = measured + HeaderToolbarGap;
-                if (Math.Abs(target - _headerToolbarWidth) > 0.5)
-                {
-                    _headerToolbarWidth = target;
-                    UpdateListMinWidth();
                 }
             }
 

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -446,7 +446,10 @@ namespace Configuration_Management
             var panel = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
-                VerticalAlignment = VerticalAlignment.Center
+                VerticalAlignment = VerticalAlignment.Center,
+                // В разметке зазор задан отступом каждой кнопки (Margin="0,0,2,0",
+                // MainWindow.xaml:496 и далее), здесь он общий для всей строки.
+                Spacing = 2
             };
 
             // Развернуть и свернуть группы, сортировка групп, показ тегов в строках.
@@ -865,13 +868,15 @@ namespace Configuration_Management
         }
 
         /// <summary>Сегментный переключатель (например «группы»/«теги») с иконкой и состояниями.</summary>
-        private SegmentButton MakeSegmentToggle(string iconKey, string tooltip)
+        private SegmentButton MakeSegmentToggle(string iconKey, string tooltip, double iconSize = 18)
         {
             // Размеры из разметки (MainWindow.xaml:171-179): значок 18, отступ 6,
             // зазор между сегментами 2. Прежние 15, 12 на 5 и общий Spacing
             // разносили кнопки заметно шире, чем в версии для Windows.
+            // У переключателя тегов в панели команд значок свой, 14
+            // (MainWindow.xaml:528), поэтому размер параметром.
             var segment = new SegmentButton(iconKey, string.Empty, "ItemHoverBrush", "ItemSelectedBrush", lockOn: false,
-                iconSize: UiMetrics.Scaled(18))
+                iconSize: UiMetrics.Scaled(iconSize))
             {
                 IsChecked = true,
                 // У автора рамки нет, отступ 6. У нас рамка в 2 держит фокусное
@@ -1317,13 +1322,16 @@ namespace Configuration_Management
                         // меняется из окна настроек на живом окне.
                         RefreshCommandPanel();
                     }
-                    // Метка закрепления стоит в том же блоке кнопок панели команд.
-                    if (e.PropertyName == nameof(MainViewModel.ShowPinnedButton))
-                        RefreshCommandPanel();
-                    // Переключатель тегов в списке живёт в том же заголовке,
+                    // Звезда и булавка задают ширину ведущих колонок, а строки
+                    // при смене настройки пересобираются: без пересборки шапки
+                    // её колонки остались бы прежней ширины и разошлись со строками.
+                    if (e.PropertyName == nameof(MainViewModel.ShowPinnedButton)
+                        || e.PropertyName == nameof(MainViewModel.ShowFavoritesButton))
+                        QueueColumnHeaderRefresh();
+                    // Переключатель тегов в списке живёт в панели команд,
                     // а его настройка меняется и из окна настроек.
                     if (e.PropertyName == nameof(MainViewModel.ShowTags))
-                        QueueColumnHeaderRefresh();
+                        RefreshCommandPanel();
                     // Группировку меняют и верхняя панель, и окно настроек,
                     // поэтому переключатель подтягивает состояние вьюмодели.
                     if (e.PropertyName == nameof(MainViewModel.GroupByGroup) && _groupByToggle is not null)
@@ -1724,7 +1732,7 @@ namespace Configuration_Management
             grid.ColumnDefinitions.Add(compensator ?? new ColumnDefinition { Width = new GridLength(0) });
             // Резерв под переключатель тегов снят вместе с переносом кнопок
             // в панель команд: колонка пустая и лишнего отступа слева от
-            // «Названия» давать не должна (MainWindow.xaml:653 и 1028).
+            // «Названия» давать не должна (MainWindow.xaml:656 и 1030).
             grid.ColumnDefinitions.Add(new ColumnDefinition
             {
                 Width = new GridLength(showFavorite ? FavoriteColumnWidth : 0)
@@ -3925,7 +3933,7 @@ namespace Configuration_Management
         /// Ведущая колонка на месте прежних кнопок групп во всех трёх сетках
         /// списка. Сами кнопки живут в панели команд, а колонка осталась
         /// небольшим отступом выравнивания и обнуляется вместе с ними
-        /// (MainWindow.xaml:650 и 1026).
+        /// (MainWindow.xaml:651 и 1026).
         /// </summary>
         private double GroupButtonsColumnWidth
             => (_vm?.ShowExpandCollapseButtons ?? true) ? 24 : 0;
@@ -4102,6 +4110,11 @@ namespace Configuration_Management
                 // обязан совпадать с отступом строки, иначе заголовки разъедутся
                 // со значениями; в разметке он нулевой в обоих местах.
                 Padding = new Thickness(0, 2),
+                // Высоту шапке задавали кнопки блока групп; после их переноса
+                // в панель команд её держит минимум из разметки
+                // (MainWindow.xaml:639: MinHeight 36 и прозрачность 0.95).
+                MinHeight = 36,
+                Opacity = 0.95,
                 BorderThickness = new Thickness(0, 0, 0, 1),
                 Child = _columnHeaderRow
             };
@@ -4163,7 +4176,7 @@ namespace Configuration_Management
 
             var nameHeader = ColumnHeader(LocalizationManager.T("Column.Name"), IconHelper.ColumnIconKey("Name"));
             // У «Названия» отступ слева нулевой: заголовок равняется по тексту строк
-            // списка, а не по границе колонки. В разметке WPF так же (MainWindow.xaml:627).
+            // списка, а не по границе колонки. В разметке WPF так же (MainWindow.xaml:739).
             nameHeader.Margin = new Thickness(0, 0, 8, 4);
             MakeSortableHeader(nameHeader, "Name", LocalizationManager.T("Main.ColumnNameSortTooltip"));
             _columnHeaderRow.Children.Add(nameHeader);
@@ -4255,18 +4268,6 @@ namespace Configuration_Management
             var tagsToggle = BuildTagsInListToggle();
             panel.Children.Add(tagsToggle);
 
-            // Пометка закрепления стоит сразу за переключателем тегов внутри
-            // того же блока, как в разметке (MainWindow.xaml:620): своей колонки
-            // у неё нет, поэтому и прятать её ни от чего не нужно.
-            if (_vm?.ShowPinnedButton == true)
-            {
-                var pinMark = IconHelper.MakeIcon("IconPin", UiMetrics.Scaled(14), "TextSecondaryBrush");
-                pinMark.Margin = new Thickness(4, 0, 0, 0);
-                pinMark.VerticalAlignment = VerticalAlignment.Center;
-                ToolTip.SetTip(pinMark, LocalizationManager.T("Main.Pinned"));
-                panel.Children.Add(pinMark);
-            }
-
             return panel;
         }
 
@@ -4277,9 +4278,12 @@ namespace Configuration_Management
         /// </summary>
         private Control BuildTagsInListToggle()
         {
-            var toggle = MakeSegmentToggle("IconTag", LocalizationManager.T("Main.ToggleListTags"));
+            var toggle = MakeSegmentToggle("IconTag", LocalizationManager.T("Main.ToggleListTags"), iconSize: 14);
             toggle.IsChecked = _vm?.ShowTags ?? false;
             toggle.VerticalAlignment = VerticalAlignment.Center;
+            // Отступ у него слева, а не справа, как у остальных сегментов
+            // (MainWindow.xaml:526).
+            toggle.Margin = new Thickness(2, 0, 0, 0);
             toggle.Click += (_, _) =>
             {
                 if (_vm is not null)
@@ -4295,7 +4299,9 @@ namespace Configuration_Management
             // прозрачный фон, скругление 8, подсветка при наведении, отступ 8.
             var button = new Button
             {
-                Content = IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(15), "TextSecondaryBrush"),
+                // Значок 18, как у этих же кнопок в панели команд разметки
+                // (MainWindow.xaml:499, 506, 513, 520).
+                Content = IconHelper.MakeIcon(iconKey, UiMetrics.Scaled(18), "TextSecondaryBrush"),
                 Padding = new Thickness(UiMetrics.Scaled(8)),
                 MinWidth = 0,
                 MinHeight = 0,


### PR DESCRIPTION
## Что не так сейчас

В Linux/Avalonia-версии панели команд над заголовками колонок нет вовсе.
Команды, которые в Windows-версии живут в `CommandPanelBorder`
(`Configuration Management/Views/MainWindow.xaml:488-612`), разложены у нас
по двум другим местам: часть висит в верхней полосе окна справа от вкладок
«Все / Избранное / Недавние», часть (кнопки групп, сортировки и переключатель
тегов) нарисована прямо внутри шапки списка поверх её ведущих колонок.
Кнопок правки и удаления базы нет ни там, ни там, хотя в разметке они есть
(`MainWindow.xaml:541-550`).

Из-за кнопок в шапке ведущая колонка списка держала ширину 144 вместо 24
из разметки, колонка звезды несла минимум 30 под переключатель тегов, а ширина
блока кнопок измерялась на каждой раскладке и участвовала в расчёте минимальной
ширины списка.

## Что делает этот PR

Один файл, `Configuration Management/Views/MainWindow.Avalonia.cs`.

1. Добавлена панель команд между панелью фильтра тегов и списком, то есть
   на месте `Grid.Row="2"` левой колонки разметки. Рамка по разметке:
   `Margin 4,0,4,0`, `Padding 8,6`, нижняя граница в одну точку, фон
   `CardBackgroundBrush` (`MainWindow.xaml:488-491`).
2. В неё перенесены команды из верхней полосы окна (очистка кеша, индикатор
   выгрузки, синхронизация с `ibases.v8i`, проверка доступности, тема,
   компактный режим, настройки, справка) и блок кнопок групп из шапки списка
   (развернуть, свернуть, две сортировки, переключатель тегов). Порядок групп
   и разделители между ними как в разметке: группы, разделитель, правка,
   разделитель, обслуживание списка, разделитель, настройки.
3. Добавлены отсутствовавшие кнопки правки и удаления базы
   (`EditInfobaseCommand`, `DeleteInfobaseCommand`) и три вертикальных
   разделителя `Width 1`, `Margin 4,5`, `Opacity 0.55` (`MainWindow.xaml:533`).
4. Ведущие колонки приведены к числам разметки после переноса: колонка на месте
   кнопок групп 24 вместо 144, минимум 30 у колонки звезды снят
   (`MainWindow.xaml:651-657`, те же числа в строке группы `:1026-1031`
   и в строке базы `:1243-1248`).
5. Подпись «Название» получила `Grid.Column=0`, `ColumnSpan=5` и левое
   выравнивание, как в разметке (`MainWindow.xaml:739-741`): раньше она стояла
   в колонке имени и уезжала вправо от начала списка.
6. Шапке списка задан минимум высоты 36 и прозрачность 0.95
   (`MainWindow.xaml:639`): прежде высоту ей задавали кнопки, которых там
   больше нет.
7. Убран расчёт ширины блока кнопок по измеренной раскладке и связанные с ним
   поля: после переноса в шапке измерять нечего.

## Обратные пути

Настройки, меняющие состав панели и колонок, перестраивают то, что нужно,
без перезапуска: показ кнопок разворота групп и показ тегов в строках
пересобирают панель команд, показ звезды и булавки пересобирают шапку колонок,
иначе её колонки расходятся со строками по ширине.

## Как проверялось

Сборка Linux-цели: 0 ошибок, 18 предупреждений, набор тот же, что и до правки.

Прогон собранного приложения на отдельном профиле (`XDG_CONFIG_HOME`):
панель на месте в обычном и компактном режиме, компактный режим переключается
из неё, шестерня открывает настройки, карандаш открывает окно настройки
выбранной базы, отключение показа тегов в настройках гасит переключатель
в панели на живом окне, отключение кнопки «Закрепить» перестраивает шапку
и строки согласованно, значения строк стоят под своими заголовками.

Изменение прошло два встречных аудита по разметке как планке сравнения.
Их находки исправлены в третьем коммите: лишняя метка закрепления в панели,
потерянный зазор 2 между кнопками, размеры значков 18 и 14, минимум высоты
шапки, пересборка панели вместо шапки при смене показа тегов.

Windows-часть не затронута: изменён только Avalonia-файл.
