### PR TITLE
Linux/Avalonia: модальные окна не открываются и не перетаскиваются (issues #168, #177)

### DIFF
--- a/Configuration Management/Views/ModalWindowBase.cs
+++ b/Configuration Management/Views/ModalWindowBase.cs
@@ -407,7 +407,10 @@ namespace Configuration_Management
         /// </summary>
         private Control BuildTitleStrip()
         {
-            var strip = new Border();
+            // Прозрачная заливка обязательна: Border без Background не участвует
+            // в проверке попадания, нажатие уходит мимо и окно не таскается
+            // (issue #177). Внешний вид от неё не меняется.
+            var strip = new Border { Background = Brushes.Transparent };
             strip.PointerPressed += OnTitleStripPointerPressed;
 
             var grid = new Grid();

--- a/Configuration Management/Views/ModalWindowBase.cs
+++ b/Configuration Management/Views/ModalWindowBase.cs
@@ -316,8 +316,21 @@ namespace Configuration_Management
             if (change.GetNewValue<object?>() is Control inner)
             {
                 _wrappingContent = true;
-                Content = BuildChrome(inner);
-                _wrappingContent = false;
+                try
+                {
+                    // Обёртка ставит Content второй раз, пока inner уже числится
+                    // логическим ребёнком окна: при замене ContentControl снимает
+                    // у него логического родителя, а inner к этому моменту лежит
+                    // внутри нового Grid, и обход дерева обёртки падает с
+                    // AttachedToLogicalTreeCore ... has no logical parent.
+                    // Сброс в null отпускает inner заранее.
+                    Content = null;
+                    Content = BuildChrome(inner);
+                }
+                finally
+                {
+                    _wrappingContent = false;
+                }
             }
         }
 
@@ -530,10 +543,10 @@ namespace Configuration_Management
                 if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
                     BeginResizeDrag(edge, e);
             };
-            Grid.SetRow(zone, 0);
-            Grid.SetColumn(zone, 0);
-            Grid.SetRowSpan(zone, host.RowDefinitions.Count);
-            Grid.SetColumnSpan(zone, host.ColumnDefinitions.Count);
+            // host это overlay, созданный как new Grid() без строк и колонок,
+            // поэтому span из его счётчиков равен нулю, а Avalonia такой span
+            // не принимает: ArgumentException прямо в OnOpened. Зона и без
+            // привязок занимает единственную ячейку целиком.
             host.Children.Add(zone);
         }
 


### PR DESCRIPTION
## Что происходит

На Linux модальные окна не появляются на экране. Проверено на сборке
`ConfigurationManagement-linux-x64` из релиза `v0.3.6.64`: главное окно
работает, а «Настройки», «Настройка информационной базы» и «Очистка кэша 1С»
создаются и остаются неотображёнными. Через X видно, что окно есть,
но `map_state=0` и размер 1768x935 вместо своего:

```
Настройки: map_state=0 viewable=False geom=1768x935+10+10
Настройка информационной базы: map_state=0 viewable=False geom=1768x935+10+10
Очистка кэша 1С: map_state=0 viewable=False geom=1768x935+10+10
Управление конфигурациями 1С v0.3.6.64: map_state=2 viewable=True geom=1200x760+0+0
```

Похоже на issue #168: там то же действие на другой машине даёт SIGABRT.

Важно для воспроизведения: всё это относится к безрамочному режиму. При
включённом системном заголовке `UseGlassChrome` равен false, обёртка не
строится, и обе ошибки ниже не возникают, кроме четырёх окон, у которых
`SystemDecorations="None"` задано в разметке (перечислены ниже).

## Причина

Две независимые, обе в `Views/ModalWindowBase.cs`.

**1. `AddResizeZone`, строки 533-537.** Зоны изменения размера кладутся
в `overlay`, который создан строкой выше как `new Grid()`, то есть без строк
и колонок. Span берётся из его собственных счётчиков:

```csharp
Grid.SetRowSpan(zone, host.RowDefinitions.Count);      // 0
Grid.SetColumnSpan(zone, host.ColumnDefinitions.Count); // 0
```

Avalonia нулевой span не принимает, и исключение летит прямо из `OnOpened`,
то есть из `Window.ShowDialog`:

```
System.ArgumentException: 0 is not a valid value for 'RowSpan'
   at Avalonia.Controls.Grid.SetRowSpan(Control element, Int32 value)
   at Configuration_Management.ModalWindowBase.AddResizeZone(...)
   at Configuration_Management.ModalWindowBase.AddResizeZones(Grid root)
   at Configuration_Management.ModalWindowBase.OnOpened(EventArgs e)
   at Avalonia.Controls.Window.ShowCore[TResult](Window owner, Boolean modal)
   at Avalonia.Controls.Window.ShowDialog[TResult](Window owner)
   at Configuration_Management.ViewModels.MainViewModel.OpenSettings()
```

Так падает каждое изменяемое по размеру безрамочное окно. Привязки при этом
ни на что не влияют: `overlay` состоит из единственной ячейки, и зона занимает
её целиком и без них.

**2. `OnPropertyChanged`, обёртка содержимого.** `Content` ставится второй раз
поверх прежнего значения, и Avalonia присоединяет тот же `Grid` к логическому
дереву повторно:

```
System.InvalidOperationException: AttachedToLogicalTreeCore called for 'Grid' but control has no logical parent.
   at Avalonia.Controls.ContentControl.ContentChanged(AvaloniaPropertyChangedEventArgs e)
   at Configuration_Management.ModalWindowBase.OnPropertyChanged(...)
   at Avalonia.Controls.ContentControl.set_Content(Object value)
   at Configuration_Management.CacheCleanWindow..ctor(...)
```

Лечится сбросом в `null` перед пересборкой. Снятие флага `_wrappingContent` заодно перенесено
в `finally`: если `BuildChrome` бросит исключение, флаг иначе останется
поднятым и окно больше не переобернёт содержимое.

## Проверка

Собрано и прогнано на трёх вариантах файла, профиль отдельный
(`XDG_CONFIG_HOME`), окружение X11 с KWin в виртуальной машине:

| вариант | результат |
| --- | --- |
| без правки | `AttachedToLogicalTreeCore` на окне очистки кеша, поверх окно «Ошибка интерфейса» |
| только сброс `Content` | `ArgumentException: 0 is not a valid value for 'RowSpan'` при открытии настроек, окно остаётся неотображённым |
| эта правка | 12 открытий четырёх окон подряд (добавление, настройка базы, настройки, очистка кеша), ни одной ошибки, все окна видимы |

Отдельно прогнан зонд по всем 18 наследникам `ModalWindowBase`: каждое окно
конструируется и показывается тем же путём, что и в приложении, состояние
снимается через `xwininfo` и рефлексию. Счёт по вариантам, 21 проверка
(18 классов, `CreateInfobaseWindow` в двух режимах, окно настроек и окно входа
вторым путём показа):

| вариант | конструктор прошёл | показано на экране |
| --- | --- | --- |
| без правки | 0 из 21 | 0 |
| только снятие span | 0 из 21 | 0 |
| только сброс `Content` | 21 из 21 | 11 |
| эта правка | 21 из 21 | 21 |

У варианта «только сброс `Content`» теряются ровно десять растягиваемых окон:
`ShowDialogSync` ловит `ArgumentException` в `finally` и прячет окно, поэтому
окно не появляется и в журнале не остаётся ничего.

С `UseSystemTitleBar=true` без правки не открываются четыре окна:
`DeleteInfobaseWindow`, `LinkInputWindow`, `NameInputWindow`, `TagInputWindow`.
У них в `.axaml` задано `SystemDecorations="None"`, поэтому обёртка строится
и в этом режиме.

После правки в каждом из десяти растягиваемых окон overlay получает восемь зон,
четыре рёберные совпадают с overlay по ширине или высоте, ресайз мышью работает:
тяга за правый край дала 880 на 1083, за нижний 680 на 803.

Windows-ветка не затронута: файл целиком под `#if LINUX`.

## Добавлено вторым коммитом: окна не перетаскиваются (issue #177)

После первой правки окна открываются, но не двигаются. Это отдельный дефект
того же файла, и он виден только теперь, когда «стеклянная» обёртка вообще
строится. О нём сообщил 7OH в issue #177, там же он видит окна полупрозрачными
целиком: на сборке без первой правки обёртка не строится, окно остаётся
`SystemDecorations.None` с прозрачным фоном и без полосы заголовка, поэтому оба
симптома идут вместе.

**Причина.** `BuildTitleStrip` создаёт полосу как `new Border()`, без кисти
фона. Border с пустым `Background` в Avalonia не участвует в проверке
попадания, поэтому `PointerPressed` до полосы не доходит и `BeginMoveDrag`
не вызывается. Соседний `AddResizeZone` в этом же файле ставит зонам
`Brushes.Transparent` с комментарием «прозрачная, но не null кисть: по ней
всё равно идёт hit-test» — полосе заголовка этого не сделали.

**Правка.** Полосе задан `Background = Brushes.Transparent`. Внешний вид
не меняется.

**Проверено прогоном** на publish-сборке, положение окна снималось через X
до и после перетаскивания за пустое место полосы:

| окно | без правки | с правкой |
| --- | --- | --- |
| Настройки | 160,328 → 160,328 | 160,328 → 360,516 |
| Настройка информационной базы | 220,278 → 220,278 | 220,278 → 420,416 |

Смещение совпадает с заданным жестом. Прогон повторён в обоих режимах
отрисовки, непрозрачном и «стеклянном». Изменение размера за угол не
сломалось: ширина 880 → 980.

## Замечено рядом, в правку не входит

Пока окна не открывались, до этих мест дело не доходило, а на проверке они
попались. Всё в том же файле и к самой правке отношения не имеет, поэтому
сюда не включаю. Оставляю списком на ваше усмотрение:

* `_resizeZonesAdded` ставится один раз в `OnOpened`, а `BuildChrome` при
  пересборке создаёт новый корень. `SettingsWindow` переустанавливает `Content`
  при смене языка, и после переключения окно остаётся без зон изменения размера.
  В главном окне это решено иначе: `AddResizeZones` вызывается внутри
  `BuildRoot`, то есть при каждой пересборке.
* `_glassStateSub` и `_titleSub` перезаписываются в `BuildChrome` без
  `Dispose`, поэтому каждая пересборка оставляет живую подписку, которая держит
  прежнее дерево обёртки до закрытия окна. В `MainWindow.Avalonia.cs` такая же
  подписка освобождается перед новой, здесь этого шага нет.
* Исключение из `OnOpened` перехватывается в `ShowDialogSync` и в журнал не
  попадает, поэтому по `errors.log` симптом «окно не открылось» не виден. Если
  добавить туда запись, похожие обращения будет легче разбирать.

Если что-то из этого пригодится, пришлю отдельными PR.

---
Правку готовил и проверял Claude Code, агент, который ведёт Linux-порт в форке ksv47.

