### PR TITLE
Linux/Avalonia: в окне выбора цвета не помещались HEX и кнопки

### DIFF
--- a/Configuration Management/Controls/ColorPickerControl.Avalonia.cs
+++ b/Configuration Management/Controls/ColorPickerControl.Avalonia.cs
@@ -100,14 +100,13 @@ namespace Configuration_Management.Controls
         /// </summary>
         public ColorPickerControl()
         {
-            // Размеры ползунка шаблон Fluent берёт из своих ресурсов: поля 15
-            // сверху и снизу и круглый бегунок 20 на 20, то есть строка выходит
-            // 50 (ключ SliderHorizontalHeight задаёт не всю высоту, а минимум
-            // сетки шаблона, 32). Четыре такие строки давали лишние сто пикселей,
-            // и ряд кнопок уходил за нижнюю границу окна, высота которого задана
-            // числом из разметки (ColorPickerWindow.xaml:11). Переопределяются
-            // именно ресурсы, а не высота самого ползунка: от голой высоты
-            // шаблон обрезает бегунок снизу и круглым он быть перестаёт.
+            // Размеры строки ползунка шаблон Fluent берёт из своих ресурсов:
+            // поля 15 сверху и снизу и бегунок 20 на 20, строка занимает около
+            // 50. Ключ SliderHorizontalHeight задаёт минимум сетки шаблона (32),
+            // а не всю высоту. В разметке строка занимает 22, и высота окна
+            // (ColorPickerWindow.xaml:11) рассчитана на такие строки, поэтому
+            // размеры задаются ресурсами шаблона. Высота, заданная самому
+            // ползунку, обрезает бегунок по вертикали.
             Resources["SliderHorizontalHeight"] = SliderHeight;
             Resources["SliderPreContentMargin"] = new GridLength((SliderHeight - SliderThumbSize) / 2);
             Resources["SliderPostContentMargin"] = new GridLength((SliderHeight - SliderThumbSize) / 2);

--- a/Configuration Management/Controls/ColorPickerControl.Avalonia.cs
+++ b/Configuration Management/Controls/ColorPickerControl.Avalonia.cs
@@ -48,6 +48,11 @@ namespace Configuration_Management.Controls
         private double _saturation = 100;
         private double _brightness = 100;
 
+        // Строка ползунка как в разметке WPF, где своей высоты у ползунка нет
+        // и строка выходит около 22 пикселей.
+        private const double SliderHeight = 22;
+        private const double SliderThumbSize = 14;
+
         private readonly Slider _redSlider = new() { Minimum = 0, Maximum = 255 };
         private readonly Slider _greenSlider = new() { Minimum = 0, Maximum = 255 };
         private readonly Slider _blueSlider = new() { Minimum = 0, Maximum = 255 };
@@ -95,6 +100,21 @@ namespace Configuration_Management.Controls
         /// </summary>
         public ColorPickerControl()
         {
+            // Размеры ползунка шаблон Fluent берёт из своих ресурсов: поля 15
+            // сверху и снизу и круглый бегунок 20 на 20, то есть строка выходит
+            // 50 (ключ SliderHorizontalHeight задаёт не всю высоту, а минимум
+            // сетки шаблона, 32). Четыре такие строки давали лишние сто пикселей,
+            // и ряд кнопок уходил за нижнюю границу окна, высота которого задана
+            // числом из разметки (ColorPickerWindow.xaml:11). Переопределяются
+            // именно ресурсы, а не высота самого ползунка: от голой высоты
+            // шаблон обрезает бегунок снизу и круглым он быть перестаёт.
+            Resources["SliderHorizontalHeight"] = SliderHeight;
+            Resources["SliderPreContentMargin"] = new GridLength((SliderHeight - SliderThumbSize) / 2);
+            Resources["SliderPostContentMargin"] = new GridLength((SliderHeight - SliderThumbSize) / 2);
+            Resources["SliderHorizontalThumbWidth"] = SliderThumbSize;
+            Resources["SliderHorizontalThumbHeight"] = SliderThumbSize;
+            Resources["SliderThumbCornerRadius"] = new CornerRadius(SliderThumbSize / 2);
+
             _hexBox = new TextBox { Width = 110, Padding = new Thickness(4, 3) };
             _hexBox.TextChanged += OnHex_TextChanged;
 
@@ -127,7 +147,7 @@ namespace Configuration_Management.Controls
             root.Children.Add(_colorPreview);
 
             // Полная палитра (оттенок × насыщенность)
-            var paletteLabel = BuildSectionLabel(LocalizationManager.T("ColorPicker.FullPalette"));
+            var paletteLabel = BuildSectionLabel(LocalizationManager.T("ColorPicker.FullPalette"), 6);
             Grid.SetRow(paletteLabel, 1);
             root.Children.Add(paletteLabel);
 
@@ -169,7 +189,7 @@ namespace Configuration_Management.Controls
             root.Children.Add(brightnessRow);
 
             // Предустановленные цвета
-            var presetsLabel = BuildSectionLabel(LocalizationManager.T("ColorPicker.Palette"));
+            var presetsLabel = BuildSectionLabel(LocalizationManager.T("ColorPicker.Palette"), 4);
             Grid.SetRow(presetsLabel, 4);
             root.Children.Add(presetsLabel);
 
@@ -202,7 +222,8 @@ namespace Configuration_Management.Controls
             var hexRow = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
-                Margin = new Thickness(0, 2, 0, 0),
+                // Поле сверху как в разметке (ColorPickerControl.xaml:120).
+                Margin = new Thickness(0, 4, 0, 0),
                 Spacing = 8
             };
             var hexLabel = new TextBlock
@@ -229,12 +250,22 @@ namespace Configuration_Management.Controls
 
         private Color CurrentColor => HsvColor.ToRgb(_hue, _saturation / 100.0, _brightness / 100.0);
 
-        private static TextBlock BuildSectionLabel(string text) => new()
+        /// <summary>
+        /// Подпись секции: второстепенный цвет и поле снизу как в разметке
+        /// (ColorPickerControl.xaml:49-50 и 80-81), где у первой подписи 6, а
+        /// у второй 4.
+        /// </summary>
+        private static TextBlock BuildSectionLabel(string text, double bottomMargin)
         {
-            Text = text,
-            FontWeight = FontWeight.SemiBold,
-            Margin = new Thickness(0, 0, 0, 4)
-        };
+            var label = new TextBlock
+            {
+                Text = text,
+                FontWeight = FontWeight.SemiBold,
+                Margin = new Thickness(0, 0, 0, bottomMargin)
+            };
+            ThemeBrushes.Bind(label, TextBlock.ForegroundProperty, "TextSecondaryColorBrush");
+            return label;
+        }
 
         private Grid BuildBrightnessRow()
         {
@@ -263,7 +294,8 @@ namespace Configuration_Management.Controls
 
         private Grid BuildRgbRow(int row, string label, string accent, Slider slider, TextBlock value)
         {
-            var grid = new Grid { Margin = new Thickness(0, 1) };
+            // Поле строки как в разметке (ColorPickerControl.xaml:85, 96, 107).
+            var grid = new Grid { Margin = new Thickness(0, 2) };
             grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(20)));
             grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
             grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(40)));


### PR DESCRIPTION
## Что не так

В Linux-сборке диалог «Выбор цвета» не вмещает своё содержимое: поле `HEX`
видно верхушкой, а ряд кнопок «ОК»/«Отмена» уходит за нижнюю границу окна
целиком. Окно создаётся размером 470 на 560 (`Views/ColorPickerWindow.Avalonia.cs:30,32`,
числа взяты из разметки `Views/ColorPickerWindow.xaml:11`), `CanResize = false`,
прокрутки у диалога нет. Значит выбранный цвет подтвердить нечем: диалог
закрывается только крестиком. Воспроизводится на 0.3.6.74: «Настройки» →
«Цветовое оформление» → щелчок по любому цвету списка.

## Почему так выходит

Высоту строки ползунка шаблон Fluent берёт из своих ресурсов: поля 15 сверху
и снизу плюс круглый бегунок 20 на 20, то есть строка занимает около 50
пикселей. Ключ `SliderHorizontalHeight` задаёт не всю высоту, а минимум сетки
шаблона (32), поэтому сам по себе он ничего не ограничивает. В диалоге таких
строк четыре («Яркость», R, G, B), и они набирают около сотни лишних пикселей
против разметки WPF, где своей высоты у ползунка нет и строка выходит около 22.

## Что сделано

`Controls/ColorPickerControl.Avalonia.cs`:

* переопределены ресурсы шаблона ползунка (`SliderHorizontalHeight`,
  `SliderPreContentMargin`, `SliderPostContentMargin`,
  `SliderHorizontalThumbWidth`, `SliderHorizontalThumbHeight`,
  `SliderThumbCornerRadius`): строка 22, бегунок 14. Переопределяются именно
  ресурсы, а не высота самого ползунка: от голой высоты шаблон обрезает бегунок
  снизу и круглым он быть перестаёт;
* поля подписей и строк приведены к разметке `Controls/ColorPickerControl.xaml`
  (подписи секций 6 и 4 из строк 49-50 и 80-81, строки RGB 2 из строк 85, 96,
  107, поле над `HEX` 4 из строки 120);
* подписи секций получили второстепенный цвет темы, как в разметке.

Правка только в Avalonia-части, WPF не затронут.

## Проверено прогоном

Сборка ветки под Linux (`build.sh Release publish`, .NET 10, Avalonia 11.3.20):
ошибок 0. Диалог открыт из раздела «Цветовое оформление», окно 470 на 560,
геометрия снята из X, снимок сверен со снимком Windows-версии того же диалога
(456 на 553 в клиентской части).

| Ориентир | Windows | Linux после правки |
|---|---|---|
| Блок предпросмотра цвета | y 48..85 | y 47..84 |
| Ползунок «Яркость» | y 155..160 | y 156..161 |
| Дорожка R | y 233..235 | y 235..236 |
| Дорожка G | y 378..380 | y 383..384 |
| Дорожка B | y 402..404 | y 409..410 |
| Ряд кнопок «ОК»/«Отмена» | y 484..520 | y 501..537 |

До строки B раскладка совпадает с точностью до 1-3 пикселей. Нижний блок
(`HEX` и кнопки) идёт ниже эталона примерно на 10 пикселей, но помещается
с запасом 23 пикселя до нижней границы окна, и кнопки доступны.

---
Писал агент, который ведёт Linux-порт в форке ksv47.
