### PR TITLE
Linux: остатки кэша от удалённых баз не находились (issue #178)

### DIFF
--- a/Configuration Management/Services/OneCCacheCleaner.cs
+++ b/Configuration Management/Services/OneCCacheCleaner.cs
@@ -400,6 +400,25 @@ public static class OneCCacheCleaner
     }
 
     /// <summary>
+    /// Определяет, является ли имя каталога именем кеша информационной базы. Платформа
+    /// называет такой каталог собственным GUID, а для клиент-серверной базы использует
+    /// имя вида Srvr__<сервер>__Ref__<база>__. Служебные каталоги платформы (conf, logs,
+    /// ExtCompT, STT, standalone-server) под эти правила не подходят и остатками
+    /// не считаются.
+    /// </summary>
+    private static bool IsBaseCacheDirName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return false;
+
+        if (Guid.TryParseExact(name, "D", out _))
+            return true;
+
+        return name.StartsWith("Srvr__", StringComparison.OrdinalIgnoreCase)
+            && name.Contains("__Ref__", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Определяет, является ли имя каталога временным именем удаления (<c><имя>.deleting_<guid></c>).
     /// Такие каталоги — остатки прерванного удаления; их не нужно ни считать остатками
     /// от удалённых баз, ни переименовывать повторно (иначе имя растёт на 41 символ за раз).
@@ -410,7 +429,8 @@ public static class OneCCacheCleaner
     /// <summary>
     /// Перечисляет каталоги кеша, не принадлежащие ни одной текущей информационной базе.
     /// Это «остатки» от удалённых из списка или созданных вне приложения баз: каталоги,
-    /// имя которых не совпадает ни с одним «защищённым» именем (см. <see cref="BuildProtectedNames"/>).
+    /// имя которых узнаётся как имя кеша базы (см. <see cref="IsBaseCacheDirName"/>)
+    /// и не совпадает ни с одним «защищённым» именем (см. <see cref="BuildProtectedNames"/>).
     /// Каталоги версий платформы (например, «8.3.24.1234») не удаляются — они анализируются,
     /// и удаляются только их вложенные каталоги-кеши. Временные каталоги *.deleting_*
     /// не учитываются.
@@ -445,12 +465,12 @@ public static class OneCCacheCleaner
                     foreach (var cd in cacheDirs)
                     {
                         var n = Path.GetFileName(cd);
-                        if (IsDeletingName(n) || protectedNames.Contains(n))
+                        if (IsDeletingName(n) || protectedNames.Contains(n) || !IsBaseCacheDirName(n))
                             continue;
                         yield return cd;
                     }
                 }
-                else if (!protectedNames.Contains(versionName))
+                else if (!protectedNames.Contains(versionName) && IsBaseCacheDirName(versionName))
                 {
                     // Прямой каталог кеша в корне (без версии).
                     yield return versionDir;
@@ -657,13 +677,11 @@ public static class OneCCacheCleaner
             if (!string.IsNullOrEmpty(home))
             {
                 // В ~/.1cv8/1C/1cv8 рядом с кешем баз платформа держит свои служебные
-                // каталоги (conf, logs, ExtCompT, STT, standalone-server), а каталоги
-                // кеша серверных баз называются Srvr__<сервер>__Ref__<база>__,
-                // то есть не совпадают с именами из BuildProtectedNames. Поиск
-                // осиротевшего кеша принял бы всё это за остатки удалённых баз, поэтому
-                // корень отдаётся только для точечной очистки по конкретной базе.
-                if (!forOrphanScan)
-                    roots.Add(Path.Combine(home, ".1cv8", "1C", "1cv8"));
+                // каталоги (conf, logs, ExtCompT, STT, standalone-server). Остатками
+                // считаются только каталоги, узнаваемые как кеш базы (см.
+                // IsBaseCacheDirName), поэтому служебные под очистку не попадают
+                // и корень отдаётся в обоих режимах.
+                roots.Add(Path.Combine(home, ".1cv8", "1C", "1cv8"));
                 roots.Add(Path.Combine(home, ".1cv8", "1cv8"));
             }
         }

--- a/Configuration Management/Services/OneCCacheCleaner.cs
+++ b/Configuration Management/Services/OneCCacheCleaner.cs
@@ -263,6 +263,33 @@ public static class OneCCacheCleaner
     }
 
     /// <summary>
+    /// Проверяет, принадлежит ли запись карты какой-либо из текущих баз. Кроме точного
+    /// <see cref="MatchesBase"/> клиент-серверная база засчитывается и при совпадении
+    /// одного имени базы: одна и та же база попадает в карту столько раз, сколькими
+    /// написаниями хоста к ней подключались (localhost, короткое имя, FQDN, имя с портом),
+    /// и её кеш не должен становиться «остатком» из-за написания, которого нет в списке.
+    /// </summary>
+    private static bool BelongsToAnyBase(IdConnStrEntry entry, IReadOnlyList<Infobase> bases)
+    {
+        foreach (var ib in bases)
+        {
+            if (MatchesBase(entry, ib))
+                return true;
+
+            if (entry.Settings.Type == ConnectionType.ClientServer
+                && ib.Connection.Type == ConnectionType.ClientServer
+                && !string.IsNullOrWhiteSpace(entry.Settings.DatabaseName)
+                && string.Equals(
+                    entry.Settings.DatabaseName.Trim(),
+                    (ib.Connection.DatabaseName ?? string.Empty).Trim(),
+                    StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Приводит путь к единому виду для сравнения: прямой слэш, без завершающего слэша.
     /// </summary>
     private static string NormalizePathForCompare(string path)
@@ -400,23 +427,15 @@ public static class OneCCacheCleaner
     }
 
     /// <summary>
-    /// Определяет, является ли имя каталога именем кеша информационной базы. Платформа
-    /// называет такой каталог собственным GUID, а для клиент-серверной базы использует
-    /// имя вида Srvr__<сервер>__Ref__<база>__. Служебные каталоги платформы (conf, logs,
-    /// ExtCompT, STT, standalone-server) под эти правила не подходят и остатками
-    /// не считаются.
+    /// Определяет, является ли имя каталога именем кеша информационной базы: платформа
+    /// называет такой каталог собственным GUID. Служебные каталоги платформы (conf, logs,
+    /// ExtCompT, STT, tmplts, distr) названы словами, под правило не подходят и остатками
+    /// не считаются. Имена вида Srvr__<сервер>__Ref__<база>__ здесь намеренно не
+    /// распознаются: как имя каталога, создаваемого платформой, они не подтверждены,
+    /// а такой каталог может принадлежать стороннему инструменту.
     /// </summary>
     private static bool IsBaseCacheDirName(string name)
-    {
-        if (string.IsNullOrWhiteSpace(name))
-            return false;
-
-        if (Guid.TryParseExact(name, "D", out _))
-            return true;
-
-        return name.StartsWith("Srvr__", StringComparison.OrdinalIgnoreCase)
-            && name.Contains("__Ref__", StringComparison.OrdinalIgnoreCase);
-    }
+        => !string.IsNullOrWhiteSpace(name) && Guid.TryParseExact(name, "D", out _);
 
     /// <summary>
     /// Определяет, является ли имя каталога временным именем удаления (<c><имя>.deleting_<guid></c>).
@@ -438,6 +457,23 @@ public static class OneCCacheCleaner
     private static IEnumerable<string> EnumerateOrphanDirectories(OneCCacheKind kind, IEnumerable<Infobase> allBases)
     {
         var protectedNames = BuildProtectedNames(allBases);
+
+        // Без карты IdConnStrMap защита баз неполна: каталог кеша живой базы называется
+        // GUID, который взять больше неоткуда, и остатками стали бы каталоги всех баз
+        // сразу. В этом случае остатки не ищутся вовсе.
+        var map = LoadIdConnStrMap();
+        if (map is null)
+            yield break;
+
+        // Каталоги, которые карта сопоставила базам из списка: они не остатки, даже если
+        // написание хоста в карте и в списке разное.
+        var bases = (allBases ?? Enumerable.Empty<Infobase>()).Where(b => b is not null).ToList();
+        var mappedToBase = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in map)
+        {
+            if (BelongsToAnyBase(entry, bases))
+                mappedToBase.Add(entry.CacheGuid);
+        }
 
         foreach (var root in GetCacheRoots(kind, forOrphanScan: true))
         {
@@ -465,12 +501,15 @@ public static class OneCCacheCleaner
                     foreach (var cd in cacheDirs)
                     {
                         var n = Path.GetFileName(cd);
-                        if (IsDeletingName(n) || protectedNames.Contains(n) || !IsBaseCacheDirName(n))
+                        if (IsDeletingName(n) || protectedNames.Contains(n)
+                            || mappedToBase.Contains(n) || !IsBaseCacheDirName(n))
                             continue;
                         yield return cd;
                     }
                 }
-                else if (!protectedNames.Contains(versionName) && IsBaseCacheDirName(versionName))
+                else if (!protectedNames.Contains(versionName)
+                    && !mappedToBase.Contains(versionName)
+                    && IsBaseCacheDirName(versionName))
                 {
                     // Прямой каталог кеша в корне (без версии).
                     yield return versionDir;
@@ -677,10 +716,11 @@ public static class OneCCacheCleaner
             if (!string.IsNullOrEmpty(home))
             {
                 // В ~/.1cv8/1C/1cv8 рядом с кешем баз платформа держит свои служебные
-                // каталоги (conf, logs, ExtCompT, STT, standalone-server). Остатками
-                // считаются только каталоги, узнаваемые как кеш базы (см.
-                // IsBaseCacheDirName), поэтому служебные под очистку не попадают
-                // и корень отдаётся в обоих режимах.
+                // каталоги (conf, logs, ExtCompT, STT, tmplts, distr). Остатками считаются
+                // только каталоги, названные GUID (см. IsBaseCacheDirName), поэтому
+                // служебные под очистку не попадают и корень отдаётся в обоих режимах.
+                // Каталог автономного сервера здесь не лежит: он уровнем выше,
+                // в ~/.1cv8/standalone-server, а с 8.3.27 в ~/.1cv8/ss-data.
                 roots.Add(Path.Combine(home, ".1cv8", "1C", "1cv8"));
                 roots.Add(Path.Combine(home, ".1cv8", "1cv8"));
             }


### PR DESCRIPTION
Продолжение issue #178. Размеры по базам и очистка выбранной базы после `dab242c` работают, проверено на Linux и на Windows. Не работает третий пункт: «Остатки от удалённых баз».

## Что не так

На Linux размер остатков всегда 0 Б, и очистка остатков ничего не находит.

`OneCCacheCleaner.GetCacheRoots(kind, forOrphanScan: true)` не отдаёт корень `~/.1cv8/1C/1cv8`, то есть тот единственный каталог, где на Linux лежит кеш баз. Остальные корни там пусты по существу: `~/.cache/1cv8` пуст, `~/.local/share/1cv8` содержит только `hsts-storage.sqlite` от встроенного браузера, `~/.1cv8/1cv8` не существует. `EnumerateOrphanDirectories` обходит пустоту.

Причина исключения понятна из комментария в коде: рядом с кешем баз лежат служебные каталоги платформы, и поиск остатков принял бы их за кеш удалённых баз.

## Что сделано

`Services/OneCCacheCleaner.cs`:

* корень `~/.1cv8/1C/1cv8` отдаётся и в режиме поиска остатков;
* остатком считается только каталог, имя которого является GUID (`IsBaseCacheDirName`). Служебные каталоги платформы (`conf`, `logs`, `STT`, `ExtCompT`, `tmplts`, `distr`) названы словами и под правило не подходят, поэтому список исключений вести не нужно;
* каталог защищён не только точным `MatchesBase`, но и по имени базы: одна база попадает в `IdConnStrMap` столько раз, сколькими написаниями хоста к ней подключались (`localhost`, короткое имя, FQDN, имя с портом), и её кеш не должен становиться остатком из-за написания, которого нет в списке баз;
* если карта `IdConnStrMap` не прочиталась, остатки не ищутся вовсе: имя каталога кеша живой базы взять больше неоткуда, и без карты остатками стали бы каталоги всех баз сразу.

Имена вида `Srvr__<сервер>__Ref__<база>__` намеренно не распознаются: как имя каталога, создаваемого платформой, они не подтверждаются документацией, а такой каталог может принадлежать стороннему инструменту. Каталоги баз, названные так, теперь просто не рассматриваются в поиске остатков.

Заодно исправлен комментарий про автономный сервер: на Linux его каталог лежит не в `~/.1cv8/1C/1cv8`, а уровнем выше (`~/.1cv8/standalone-server`, с 8.3.27 `~/.1cv8/ss-data`).

## Проверено прогоном

Стенд: Linux, 9 баз, кеш `~/.1cv8/1C/1cv8` 3,6 МБ, 27 подкаталогов, карта из 20 пар. Перед очисткой снималась копия каталога, после проверки состояние возвращалось.

| Проверка | Результат |
|---|---|
| Размер остатков до правки | 0 Б |
| Размер остатков после правки | 336,6 КБ |
| Независимый счёт по диску тем же критерием | 344720 байт, 16 каталогов |
| Перечисление через `EnumerateOrphanDirectories` (вызов по месту) | 16 каталогов, 344720 байт, тот же список |
| Очистка остатков через интерфейс | «Удалено каталогов-остатков от удалённых баз», на диске исчезли ровно они |
| Каталоги баз из списка | уцелели, включая базу, чей кеш записан в карте дважды под разными именами хоста |
| Служебные каталоги и `*.pfl`, `helpsynt.dat` | не тронуты |
| Тот же прогон с удалённым `1cv8u.pfl` | 0 каталогов, ничего не удаляется |
| Повторное открытие окна после очистки | остатки 0 Б |

## Что изменяется для Windows

Файл общий, поэтому поведение меняется и там, в сторону сужения: раньше остатком считался любой каталог без защищённого имени, теперь только каталог с именем-GUID и только при прочитанной карте. Сценарий, на котором Windows-сторона проверяла `dab242c` (каталог с чужим GUID, записи о котором в карте нет), сохраняется: такой каталог остаётся остатком.

## Замечено рядом, в этот PR не входит

1. Каталоги `*.deleting_*` не подбираются ни в одном режиме: не считаются размером, не принадлежат базе, не удаляются. Каталог от прерванного удаления остаётся навсегда. На проверявшейся Windows-машине такой есть: имя-GUID с четырьмя суффиксами `.deleting_<hex>` подряд, 11 файлов, 312 КБ, то есть удаление срывалось четыре раза подряд (похоже, на атрибуте «только чтение», который `dab242c` как раз и починил).
2. Размер остатков считается по обоим типам кеша (`GetOrphanSize(OneCCacheKind.All, …)`), а удаление идёт по типу, выбранному галками. При снятой галке одного из типов показанный размер больше того, что будет удалено.
3. Каталог, имя которого состоит из одних цифр и дефисов, распознаётся как каталог версии платформы раньше, чем как каталог кеша. Для случайного GUID вероятность порядка 4e-7, дефект теоретический.
4. Подпись «Остатки от удалённых баз <размер>» при размере окна по умолчанию обрезается кнопкой «Очистить»: единица измерения не помещается. Видно и на Linux, и на Windows.

---
Писал агент, который ведёт Linux-порт в форке ksv47.
