### PR TITLE
Linux: в окне очистки кэша не показывались размеры (issue 178)

### DIFF
--- a/Configuration Management/Views/CacheCleanWindow.Avalonia.cs
+++ b/Configuration Management/Views/CacheCleanWindow.Avalonia.cs
@@ -208,9 +208,14 @@ namespace Configuration_Management
             foreach (var t in _programSizeTexts.Values) t.Text = "…";
             foreach (var t in _userSizeTexts.Values) t.Text = "…";
 
+            // Тип кеша читается до Task.Run: CurrentKind обращается к IsChecked
+            // переключателей, а свойства элементов Avalonia доступны только из
+            // потока интерфейса, иначе вызов падает с «Call from invalid thread»
+            // и размеры остаются незаполненными. Так же сделано в RefreshOrphanSize.
+            var kind = CurrentKind();
             var program = await Task.Run(() => OneCCacheCleaner.GetSize(OneCCacheKind.Program, _infobases));
             var user = await Task.Run(() => OneCCacheCleaner.GetSize(OneCCacheKind.User, _infobases));
-            var orphans = await Task.Run(() => OneCCacheCleaner.GetOrphanSize(CurrentKind(), _infobases));
+            var orphans = await Task.Run(() => OneCCacheCleaner.GetOrphanSize(kind, _infobases));
 
             _programCacheSizeText.Text = FormatSize(program);
             _userCacheSizeText.Text = FormatSize(user);


### PR DESCRIPTION
Правка в одну строку по вашей просьбе проверить #178 на 0.3.6.75.

## Что не работало

На Linux окно «Очистка кэша 1С» не показывало ни одного размера: многоточия во
всех ячейках, и они не сменялись числами ни со временем, ни при переключении
галок типа кэша.

`Views/CacheCleanWindow.Avalonia.cs:213`:

```csharp
var orphans = await Task.Run(() => OneCCacheCleaner.GetOrphanSize(CurrentKind(), _infobases));
```

`CurrentKind()` читает `IsChecked` у переключателей типа кэша, а свойства
элементов Avalonia доступны только из потока интерфейса. Внутри `Task.Run` это
даёт `InvalidOperationException: Call from invalid thread`. Метод
`RefreshCacheSizes` объявлен `async void`, его исключение никто не наблюдает,
поэтому он обрывается молча на третьем из трёх замеров. Первые два успевают
посчитаться, но присваивание текста стоит после третьего, и до интерфейса не
доходит ничего; цикл по базам тоже не выполняется.

Из `errors.log`:

```
System.InvalidOperationException: Call from invalid thread
   at Avalonia.Threading.Dispatcher.<VerifyAccess>g__ThrowVerifyAccess|16_0()
   at Avalonia.AvaloniaObject.GetValue[T](StyledProperty`1 property)
   at Avalonia.Controls.Primitives.ToggleButton.get_IsChecked()
   at Configuration_Management.CacheCleanWindow.CurrentKind() ... line 232
   at Configuration_Management.CacheCleanWindow.<RefreshCacheSizes>b__46_2() ... line 213
```

## Что изменено

Тип кэша читается до `Task.Run`, ровно как это уже сделано в соседнем
`RefreshOrphanSize`. Шесть строк, из них пять комментарий.

## Проверено запуском

Список из восьми баз (одна файловая, семь клиент-серверных), сборка с этой
ветки:

* до правки: все размеры многоточия, три записи `Call from invalid thread`
  в `errors.log`;
* после правки: программный кэш 0 Б, пользовательский 106,7 МБ, по базам от
  0 Б до 106,7 МБ, остатки 0 Б, в `errors.log` новых записей нет.

Остальное из #178 на Linux подтверждаю закрытым: размеры считаются по обоим
типам кэша, подпись «Остатки от удалённых баз» не обрезается. Сам сценарий с
остатками проверить не на чем, на этой машине их нет: все каталоги кэша
принадлежат базам из списка.

PR отправлен отдельно от #184 и с ним не пересекается: разные файлы.

Клавдий, агент Linux-порта в форке ksv47
