### PR TITLE
Linux/Avalonia: диалоги и главное окно с чёрным фоном в светлой теме

### DIFF
--- a/Configuration Management/Themes/ThemeBrushes.Avalonia.cs
+++ b/Configuration Management/Themes/ThemeBrushes.Avalonia.cs
@@ -28,7 +28,12 @@ namespace Configuration_Management.Themes
         /// в содержимое окна, останется неокрашенным молча. Ловушки такого рода:
         /// ToolTip.Tip и MenuItem.Icon у неоткрытого меню.
         /// </remarks>
-        public static void Bind(StyledElement target, AvaloniaProperty property, string brushKey)
+        /// <returns>
+        /// Подписка на ресурс. Освобождать её нужно только там, где то же свойство
+        /// потом задаётся обычным присваиванием: живая привязка переживает такую
+        /// запись и вернёт своё значение при следующей смене темы или схемы.
+        /// </returns>
+        public static System.IDisposable Bind(StyledElement target, AvaloniaProperty property, string brushKey)
             => target.Bind(property, new Avalonia.Markup.Xaml.MarkupExtensions.DynamicResourceExtension(brushKey));
 
         /// <summary>

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -5251,6 +5251,8 @@ namespace Configuration_Management
         /// если окно работает в непрозрачном режиме (<see cref="_opaqueWindow"/>), чтобы не
         /// провоцировать непрерывную перерисовку фона на X11 с программным рендером.
         /// </summary>
+        private IDisposable? _backgroundBinding;
+
         private void ApplySystemDecorations()
         {
             SystemDecorations = _useSystemTitleBar ? SystemDecorations.Full : SystemDecorations.None;
@@ -5274,11 +5276,11 @@ namespace Configuration_Management
                 // явно, чтобы нативное окно гарантированно было непрозрачным.
                 TransparencyLevelHint = Array.Empty<WindowTransparencyLevel>();
 
-                // Фон берётся из темы, а не фиксированным тёмным цветом: со включённым
-                // системным заголовком подложка окна не рисуется вовсе, а в безрамочном
-                // режиме фон окна виден в углах за скруглением подложки и давал там
-                // тёмные клинья в светлой теме. Кисть та же, что у подложки.
-                ThemeBrushes.Bind(this, TemplatedControl.BackgroundProperty,
+                // Фон берётся из темы, а не фиксированным тёмным цветом: он виден
+                // в углах за скруглением подложки и давал там тёмные клинья в светлой
+                // теме. Кисть та же, что у подложки.
+                _backgroundBinding?.Dispose();
+                _backgroundBinding = ThemeBrushes.Bind(this, TemplatedControl.BackgroundProperty,
                     "ContentBackgroundColorBrush");
             }
             else
@@ -5288,6 +5290,11 @@ namespace Configuration_Management
                 TransparencyLevelHint = new[] { WindowTransparencyLevel.Transparent };
                 // Без прозрачного фона самого окна прозрачность не активируется:
                 // содержимое рисуется поверх, а «стекло» даёт полупрозрачный фон корня.
+                // Привязку фона к теме снимаем: иначе следующая смена темы или схемы
+                // перезапишет прозрачный фон непрозрачной кистью, потому что простое
+                // присваивание живущую привязку не отменяет.
+                _backgroundBinding?.Dispose();
+                _backgroundBinding = null;
                 Background = Brushes.Transparent;
             }
         }

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -5273,7 +5273,13 @@ namespace Configuration_Management
                 // по поведению Avalonia, но не провоцирует CS8625. Сплошной фон задаём
                 // явно, чтобы нативное окно гарантированно было непрозрачным.
                 TransparencyLevelHint = Array.Empty<WindowTransparencyLevel>();
-                Background = new SolidColorBrush(Color.Parse("#FF161616"));
+
+                // Фон берётся из темы, а не фиксированным тёмным цветом: со включённым
+                // системным заголовком подложка окна не рисуется вовсе, а в безрамочном
+                // режиме фон окна виден в углах за скруглением подложки и давал там
+                // тёмные клинья в светлой теме. Кисть та же, что у подложки.
+                ThemeBrushes.Bind(this, TemplatedControl.BackgroundProperty,
+                    "ContentBackgroundColorBrush");
             }
             else
             {

--- a/Configuration Management/Views/ModalWindowBase.cs
+++ b/Configuration Management/Views/ModalWindowBase.cs
@@ -74,7 +74,16 @@ namespace Configuration_Management
                     // Пустой список эквивалентен null по поведению Avalonia (системный
                     // уровень прозрачности по умолчанию), но не провоцирует CS8625.
                     TransparencyLevelHint = Array.Empty<WindowTransparencyLevel>();
-                    Background = new SolidColorBrush(Color.Parse("#FF161616"));
+
+                    // Фон берётся из темы, а не фиксированным тёмным цветом. Со включённым
+                    // системным заголовком окна (SystemDecorations.Full) «стеклянной»
+                    // подложки у диалога нет, см. UseGlassChrome, и фон окна виден
+                    // насквозь: в светлой теме диалог выглядел чёрным прямоугольником
+                    // с нечитаемым тёмным текстом. Кисть та же, что у подложки и у
+                    // MaterialMessageWindow, поэтому смена темы и цветовой схемы
+                    // подхватывается сама.
+                    ThemeBrushes.Bind(this, TemplatedControl.BackgroundProperty,
+                        "ContentBackgroundColorBrush");
                 }
                 else
                 {


### PR DESCRIPTION
## Что не так

В непрозрачном режиме отрисовки фон окна задавался константой `#FF161616`:

* `Views/ModalWindowBase.cs:77` для всех диалоговых окон;
* `Views/MainWindow.Avalonia.cs:5276` для главного окна.

Непрозрачный режим включается на любом X11 (`Services/LinuxRendering.cs`,
`NoCompositorAssumed = !IsWayland()`), в виртуализации и на программном рендере,
то есть у большинства пользователей Linux.

**У диалогов** тёмный фон не видно, пока выключена настройка «Системный заголовок
окна»: поверх фона лежит собственная подложка, покрашенная кистью темы. Но при
`SystemDecorations.Full` подложка не строится вовсе (`UseGlassChrome`,
`Views/ModalWindowBase.cs:211`), и наружу выходит голый фон окна. В светлой теме
диалог выглядит чёрным прямоугольником, а текст на нём тёмный и почти не читается.

**У главного окна** тем же цветом красятся четыре угла за скруглением подложки:
в светлой теме там тёмные клинья.

Ошибок при этом нет ни одной, в журнале пусто: окна живые и ввод принимают.

## Что сделано

Фон окна в непрозрачном режиме привязан к кисти темы `ContentBackgroundColorBrush`
через `ThemeBrushes.Bind`, ровно как это уже сделано в
`Services/MaterialMessageWindow.Avalonia.cs:33`. Именно поэтому окно сообщений
выглядит правильно, в отличие от остальных. Смена темы и цветовой схемы
подхватывается сама, непрозрачность окна сохраняется: кисть непрозрачна во всех
темах и схемах (`Models/ColorScheme.cs:235` и `:269`, `Themes/LightTheme.axaml:12`,
`Themes/DarkTheme.axaml:11`).

Запрос уровня прозрачности и расширение клиентской области не трогаются, поведение
из issue #153 не возвращается.

## Как проверялось

Стенд: VMware, X11, KDE, драйвер vmwgfx, запуск с `LIBGL_ALWAYS_SOFTWARE=1`.
Диагностика приложения: `Virtualized=True`, `SoftwareRender=True`,
`NoCompositorAssumed=True`, `OpaqueWindow=True`.

* окно настроек с включённым системным заголовком: до правки чёрное с нечитаемым
  текстом, после правки светлое в светлой теме и тёмно-синее в тёмной;
* главное окно в безрамочном режиме: до правки тёмные клинья в углах, после правки
  цвет темы;
* сборка Linux-цели на 0.3.6.79: 0 ошибок, 0 предупреждений.

Правка разбиралась по заявке в форке, где пользователь жаловался на чёрные окна
на трёх разных конфигурациях (виртуальная машина, реальная машина в X11 и в
Wayland). Настройка системного заголовка лежит в профиле, поэтому симптом
не зависел ни от типа сессии, ни от драйвера, ни от программного рендеринга,
и это сбивало с толку.

## Второй коммит

Настройка «Системный заголовок окна» переключается на живом главном окне,
и `ApplySystemDecorations` проходит обе ветки по очереди. Обычное присваивание
`Background = Brushes.Transparent` живую привязку к ресурсу темы не отменяет:
следующая смена темы или схемы вернула бы непрозрачную кисть и погасила
прозрачность. Привязка теперь освобождается явно, для этого `ThemeBrushes.Bind`
отдаёт подписку (прежние вызовы её просто игнорируют).

Путь достижим только там, где непрозрачный режим не включён принудительно,
то есть на Wayland: на X11 `OpaqueWindow` истинен всегда, поэтому прогоном
на нашем стенде он не проверяется, найден чтением кода.

---
Клавдий, агент Linux-порта в форке ksv47