### PR TITLE
Linux/Avalonia: скрытие окна оставляло приложение в вечном ожидании

### DIFF
--- a/Configuration Management/Services/AvaloniaDialogService.cs
+++ b/Configuration Management/Services/AvaloniaDialogService.cs
@@ -201,12 +201,44 @@ namespace Configuration_Management.Services
         {
             var owner = CurrentOwner();
             bool result = true;
-            var frame = new DispatcherFrame();
-            window.Closed += (_, _) =>
+            // Кадр снимается и по скрытию окна, а не только по закрытию: Window.Hide()
+            // события Closed не даёт, а прячет окно вместе с дочерними. Пока диалог
+            // открыт, такое скрытие приходит со стороны: базу запускают из меню трея,
+            // и при настройке «после запуска уйти в трей» главное окно прячется вместе
+            // с диалогом. Раньше кадр в этом случае крутился бы вечно, и приложение
+            // замирало целиком.
+            DispatcherFrame frame = new();
+            var opened = false;
+            var hiddenWithoutClose = false;
+            var closed = false;
+
+            void StopFrame() => frame.Continue = false;
+            void OnOpened(object? sender, EventArgs e) => opened = true;
+            void OnClosed(object? sender, EventArgs e)
             {
+                closed = true;
                 result = window is MaterialMessageWindowAvalonia mw ? mw.Confirmed : true;
-                frame.Continue = false;
-            };
+                StopFrame();
+            }
+
+            void OnVisibilityChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+            {
+                if (e.Property != Visual.IsVisibleProperty || !Equals(e.NewValue, false) || closed)
+                    return;
+
+                // Окно спрятали со стороны, ответа пользователь не давал. Возвращаем
+                // отказ: положительный ответ здесь означал бы согласие на удаление базы
+                // или снятие сеансов, которого никто не подтверждал. Скрытое окно потом
+                // закрывается, иначе оно остаётся в списке окон приложения и держит
+                // процесс живым при ShutdownMode.OnLastWindowClose.
+                result = false;
+                hiddenWithoutClose = true;
+                StopFrame();
+            }
+
+            window.Opened += OnOpened;
+            window.Closed += OnClosed;
+            window.PropertyChanged += OnVisibilityChanged;
 
             // Владелец пригоден только видимый и с измеренной геометрией. На Linux/X11
             // модальный показ относительно неотрисованного владельца (нулевая геометрия)
@@ -241,10 +273,18 @@ namespace Configuration_Management.Services
                 frame.Continue = false;
                 try
                 {
+                    // Запасному показу нужен свой кадр: прежний уже остановлен, и
+                    // PushFrame на нём вернулся бы сразу, не дождавшись ответа.
+                    frame = new DispatcherFrame();
                     window.WindowStartupLocation = WindowStartupLocation.CenterScreen;
                     if (!window.IsVisible)
                         window.Show();
-                    Dispatcher.UIThread.PushFrame(frame);
+
+                    // Ждать имеет смысл только когда окно действительно открылось:
+                    // IsVisible выставляется до разметки содержимого, и окно, упавшее
+                    // на разметке, ожиданием уже не дождаться.
+                    if (opened)
+                        Dispatcher.UIThread.PushFrame(frame);
                 }
                 catch
                 {
@@ -258,6 +298,15 @@ namespace Configuration_Management.Services
                 // не должен оставлять висящий вложенный цикл сообщений.
                 frame.Continue = false;
                 try { if (window.IsVisible) window.Hide(); } catch { /* ignore */ }
+
+                if (hiddenWithoutClose && !closed)
+                {
+                    try { window.Close(); } catch { /* ignore */ }
+                }
+
+                window.Opened -= OnOpened;
+                window.Closed -= OnClosed;
+                window.PropertyChanged -= OnVisibilityChanged;
             }
 
             return result;

--- a/Configuration Management/Views/ModalWindowBase.cs
+++ b/Configuration Management/Views/ModalWindowBase.cs
@@ -245,8 +245,49 @@ namespace Configuration_Management
             if (IsVisible)
                 return DialogResult;
 
-            var frame = new DispatcherFrame();
-            Closed += (_, _) => frame.Continue = false;
+            // Кадр вложенного цикла снимается не только по закрытию окна, но и по
+            // его скрытию. Window.Hide() события Closed не даёт, а прячет окно вместе
+            // с дочерними, а такое скрытие приходит со стороны, пока диалог открыт:
+            // при настройке «после запуска базы уйти в трей» базу можно запустить
+            // из меню трея, и главное окно спрячется вместе с диалогом
+            // (MainWindow.Avalonia.cs, OnAfterLaunchRequested). Раньше кадр в этом
+            // случае оставался крутиться навсегда, и приложение замирало целиком,
+            // оставаясь живым процессом. Кадр пересоздаётся для запасного пути показа,
+            // поэтому обработчики читают текущий, а не захваченный при подписке.
+            // Результат прошлого сеанса не переносится в новый: окно можно показать
+            // повторно, и неотвеченный диалог обязан вернуть отказ, а не прежнее «да».
+            DialogResult = false;
+
+            DispatcherFrame frame = new();
+            var opened = false;
+            var hiddenWithoutClose = false;
+            var closed = false;
+
+            void StopFrame() => frame.Continue = false;
+            void OnOpened(object? sender, EventArgs e) => opened = true;
+            void OnClosedHandler(object? sender, EventArgs e)
+            {
+                closed = true;
+                StopFrame();
+            }
+
+            void OnVisibilityChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+            {
+                if (e.Property != IsVisibleProperty || !Equals(e.NewValue, false) || closed)
+                    return;
+
+                // Скрытое окно остаётся открытым для приложения: оно продолжает
+                // числиться в списке окон, а при ShutdownMode.OnLastWindowClose это
+                // держит процесс живым и не отпускает блокировку единственного
+                // экземпляра. Поэтому скрытие доводится до закрытия, но уже после
+                // выхода из кадра, чтобы не закрывать окно изнутри его же события.
+                hiddenWithoutClose = true;
+                StopFrame();
+            }
+
+            Opened += OnOpened;
+            Closed += OnClosedHandler;
+            PropertyChanged += OnVisibilityChanged;
 
             // Владелец пригоден только видимый и с измеренной геометрией. На Linux/X11
             // модальный показ относительно неотрисованного владельца (нулевая геометрия)
@@ -285,10 +326,20 @@ namespace Configuration_Management
                 frame.Continue = false;
                 try
                 {
+                    // Запасному показу нужен свой кадр: прежний уже остановлен, и
+                    // PushFrame на нём возвращается сразу, то есть окно закрывалось бы,
+                    // едва открывшись, а результат диалога возвращался бы неспрошенным.
+                    frame = new DispatcherFrame();
                     WindowStartupLocation = WindowStartupLocation.CenterScreen;
                     if (!IsVisible)
                         Show();
-                    Dispatcher.UIThread.PushFrame(frame);
+
+                    // Ждать имеет смысл только когда окно действительно открылось.
+                    // IsVisible этого не доказывает: показ выставляет его до разметки
+                    // содержимого, и при исключении в разметке окно остаётся «видимым»,
+                    // ни разу не появившись. Ожидание такого окна не закончится никогда.
+                    if (opened)
+                        Dispatcher.UIThread.PushFrame(frame);
                 }
                 catch (Exception fallbackEx)
                 {
@@ -304,6 +355,19 @@ namespace Configuration_Management
                 // прячем, чтобы повторное открытие не копило висящие окна.
                 frame.Continue = false;
                 try { if (IsVisible) Hide(); } catch { /* ignore */ }
+
+                // Окно, спрятанное со стороны, закрываем: иначе оно остаётся
+                // в списке окон приложения и держит процесс.
+                if (hiddenWithoutClose && !closed)
+                {
+                    try { Close(); } catch { /* ignore */ }
+                }
+
+                // Подписки этого сеанса снимаются: окно может показываться повторно,
+                // а обработчики держат кадр уже закончившегося показа.
+                Opened -= OnOpened;
+                Closed -= OnClosedHandler;
+                PropertyChanged -= OnVisibilityChanged;
             }
 
             return DialogResult;


### PR DESCRIPTION
## Что не так

Синхронный показ модального окна (`Views/ModalWindowBase.cs`, `ShowDialogSync`
и `Services/AvaloniaDialogService.cs`, `ShowModalSync`) крутит вложенный кадр
диспетчера и снимает его только по событию `Closed`.

`Window.Hide()` этого события не даёт: он останавливает рендеринг, рекурсивно
прячет дочерние окна, сбрасывает `Owner` и освобождает модальную подписку,
но `Closing` и `Closed` не поднимает. Кадр после этого крутится вечно,
и приложение замирает целиком, оставаясь живым процессом.

Пока диалог открыт, такое скрытие приходит со стороны: базу можно запустить
из меню трея, оно работает поверх модальности, и при настройке «после запуска
уйти в трей» главное окно прячется вместе с диалогом
(`Views/MainWindow.Avalonia.cs`, `OnAfterLaunchRequested`).

## Что сделано

* Кадр снимается и по потере видимости окна, а не только по его закрытию.
* Скрытое окно затем закрывается: иначе оно остаётся в списке окон приложения,
  держит процесс при `ShutdownMode.OnLastWindowClose` и не отпускает файловую
  блокировку единственного экземпляра, то есть программа перестаёт запускаться.
* Диалог, спрятанный без ответа пользователя, возвращает отказ, а не согласие.
  Это важно для `AvaloniaDialogService`: там значение по умолчанию `true`,
  и спрятанный вопрос об удалении базы или снятии сеансов считался бы
  подтверждённым. Тот же принцип уже применён в
  `Services/MaterialMessageWindow.Avalonia.cs` для закрытия окна без ответа.

Попутно в тех же методах:

* запасной путь показа гасил кадр до входа в цикл и потому не ждал ответа
  вовсе, теперь у него свой кадр;
* ожидание в запасном пути начинается только по факту открытия окна:
  `IsVisible` выставляется до разметки содержимого, поэтому окно, упавшее
  на разметке, считается видимым, ни разу не появившись, и ждать его нельзя;
* результат прошлого показа не переносится в новый сеанс;
* подписки сеанса снимаются по его окончании, иначе на окне, показанном
  повторно, копятся обработчики со ссылками на кадры прошлых показов.

## Как проверялось

Отдельный пробник на голой Avalonia 11.3.20, той же версии, что в проекте,
воспроизводящий связку `ShowDialog` плюс `PushFrame`:

* до правки скрытие владельца и скрытие самого диалога оставляют кадр
  крутиться, выход только по сторожу;
* после правки кадр выходит за единицы миллисекунд во всех сценариях,
  включая обычное закрытие;
* число окон приложения после скрытия возвращается к одному, то есть
  зомби-окно не остаётся.

На живом приложении проверено, что результаты диалогов не поехали: «Отмена»
в удалении базы оставляет базу в списке, «Удалить» удаляет.

Сборка Linux-цели на 0.3.6.79: 0 ошибок, 0 предупреждений.

---
Клавдий, агент Linux-порта в форке ksv47