### PR TITLE
Linux/Avalonia: колонка «Действия» сужалась до недоступности кнопок, в строке пять действий вместо трёх

### DIFF
--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -3996,6 +3996,15 @@ namespace Configuration_Management
         /// <summary>Минимальная ширина колонки при перетаскивании разделителя.</summary>
         private const double MinColumnWidth = 40;
 
+        /// <summary>
+        /// Минимальная ширина колонки «Действия» при перетаскивании разделителя: под общий
+        /// предел в 40 точек в неё не помещаются три кнопки-иконки (запуск, конфигуратор,
+        /// очистка кеша), и часть действий становится недоступна. В WPF тот же предел
+        /// держит обработчик перетаскивания, а не разметка: MinWidth у колонки не задан
+        /// намеренно, чтобы скрытая колонка схлопывалась в ноль.
+        /// </summary>
+        private const double ActionsColumnMinWidth = 120;
+
         /// <summary>Ширина зоны захвата разделителя колонок.</summary>
         private const double ResizeGripWidth = 8;
 
@@ -4663,7 +4672,8 @@ namespace Configuration_Management
             if (sender is not Border grip || !ReferenceEquals(e.Pointer.Captured, grip))
                 return;
 
-            var width = Math.Max(MinColumnWidth, _resizeStartWidth + e.GetPosition(this).X - _resizeStartX);
+            var minWidth = _resizeKey == "Actions" ? ActionsColumnMinWidth : MinColumnWidth;
+            var width = Math.Max(minWidth, _resizeStartWidth + e.GetPosition(this).X - _resizeStartX);
             ApplyColumnWidth(_resizeKey, width);
             _vm?.UpdateColumnWidth(_resizeKey, width, save: false);
         }

--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -1928,12 +1928,13 @@ namespace Configuration_Management
             ActionsPanel? actions = null;
             if (_vm?.ShowActionsColumn != false)
             {
+                // Три действия, как в разметке WPF (MainWindow.xaml:1497-1517):
+                // запуск, конфигуратор, очистка кеша. Правка настроек и удаление
+                // в строке не показываются, они остаются в контекстном меню.
                 actions = new ActionsPanel { Spacing = 1 };
                 actions.Children.Add(RowActionButton(ib, "IconPlay", "LaunchEnterpriseCommand", LocalizationManager.T("Main.LaunchEnterpriseTooltip")));
                 actions.Children.Add(RowActionButton(ib, "IconWrench", "LaunchConfiguratorCommand", LocalizationManager.T("Main.LaunchConfiguratorSectionTooltip")));
-                actions.Children.Add(RowActionButton(ib, "IconEdit", "EditInfobaseCommand", LocalizationManager.T("Main.EditBaseTooltip")));
                 actions.Children.Add(RowActionButton(ib, "IconBroom", "ClearCacheCommand", LocalizationManager.T("Main.ClearCacheTooltip")));
-                actions.Children.Add(RowActionButton(ib, "IconDelete", "DeleteInfobaseCommand", LocalizationManager.T("Main.DeleteTooltip"), "#DC2626"));
                 // Кнопки живут внутри панели, обрезанной по своей колонке: в узкой
                 // колонке «Действия» лишние значки у автора пропадают, а у нас
                 // рисовались поверх колонки «Сервер/База».


### PR DESCRIPTION
## Что не так

**1. Колонку «Действия» можно сузить так, что кнопки становятся недоступны.**
Перетаскивание разделителя ограничено общим для всех колонок пределом в 40
точек (`Views/MainWindow.Avalonia.cs`, `MinColumnWidth`). В WPF предел для этой
колонки равен 120 и держится обработчиком перетаскивания
(`Views/MainWindow.Columns.cs`, `ActionsColumnMinWidth`), а не разметкой:
`MinWidth` у колонки не задан намеренно, чтобы скрытая колонка схлопывалась
в ноль (комментарий у `ActionsColumn` в `MainWindow.xaml:682-686`).

**2. В строке базы пять кнопок вместо трёх.** Avalonia показывает запуск,
конфигуратор, изменить, очистку кеша и удаление; в разметке WPF
(`MainWindow.xaml:1497-1517`) кнопки три: запуск, конфигуратор, очистка кеша,
а правка настроек и удаление живут в контекстном меню.

Пункты связаны. Кнопка занимает 33 точки, пять кнопок это 169, отсюда штатная
ширина 170. Перенести из WPF один только предел 120 было бы неверно: при такой
ширине обрезалась бы как раз очистка кеша.

## Что сделано

* предел 120 при перетаскивании только для колонки «Действия», у остальных
  колонок прежние 40, скрытие колонки в ноль не затронуто;
* состав кнопок строки приведён к разметке WPF.

## Как проверялось

Прогон на собранной ветке, ширина читалась из профиля, а не с экрана:

* до правки перетаскивание разделителя до упора давало ширину 52;
* после правки останавливается ровно на 120;
* соседняя колонка «Режим запуска» по-прежнему сужается до 52, то есть общий
  предел не тронут;
* при ширине 120 в строке базы видны все три кнопки: запуск, конфигуратор,
  очистка кеша.

Сборка Linux-цели на 0.3.6.79: 0 ошибок, 0 предупреждений.

## Что осталось за рамками правки

Пользователь, у которого в профиле уже сохранена ширина меньше 120, после
обновления получит её обратно: правка ограничивает перетаскивание, а не
загрузку настроек. В WPF ровно так же, поэтому поведение оставлено общим.
Если хотите, добавим подъём сохранённого значения до предела при загрузке,
но тогда это надо делать на обеих платформах.

---
Клавдий, агент Linux-порта в форке ksv47
