### PR TITLE
Windows/WPF: восстановлен запуск через окно входа, ключи локализации вместо подписей (issue #189)

### DIFF
--- a/Configuration Management/App.xaml.cs
+++ b/Configuration Management/App.xaml.cs
@@ -62,6 +62,27 @@ namespace Configuration_Management
                 var profileService = AppServices.GetRequiredService<IProfileService>();
                 profileService.EnsureInitialized();
 
+                // Любое окно, закрытое до создания главного, гасит приложение: режим
+                // завершения по умолчанию OnLastWindowClose считает его последним,
+                // и главное окно уже не открывается. Поэтому до показа главного
+                // окна завершение только явное, прежний режим возвращается после.
+                var shutdownModeBeforeStartup = ShutdownMode;
+                ShutdownMode = ShutdownMode.OnExplicitShutdown;
+
+                // Локализацию поднимаем до окна входа и ранних окон ошибок: настройки
+                // выбранного профиля читаются ниже, а без словаря окно показывает
+                // ключи (Auth.Title, Auth.Login) вместо подписей. Язык берётся из
+                // профиля, активного с прошлого запуска, и уточняется после входа.
+                try
+                {
+                    var startupSettings = AppServices.GetRequiredService<IInfobaseRepository>().LoadSettings();
+                    LocalizationManager.Instance.Initialize(startupSettings.Language);
+                }
+                catch
+                {
+                    LocalizationManager.Instance.Initialize();
+                }
+
                 // Если в приложении несколько учётных записей — показываем окно авторизации
                 // по аналогии со списком пользователей 1С. При одной записи входим без запроса.
                 if (profileService.Profiles.Count > 1)
@@ -117,6 +138,10 @@ namespace Configuration_Management
                 try
                 {
                     LocalizationManager.Instance.Initialize(settings.Language);
+                    // Если словарь уже поднят ради окна входа, Initialize выходит сразу,
+                    // поэтому язык выбранного профиля применяется отдельно и по тем же
+                    // правилам: пустое значение означает язык системы.
+                    LocalizationManager.Instance.ApplyPreferredLanguage(settings.Language);
                 }
                 catch
                 {
@@ -188,6 +213,11 @@ namespace Configuration_Management
                 // окна оно ещё пустое, поэтому масштабирование не сработало бы.
 
                 mainWindow.Show();
+
+                // Прежний режим завершения возвращается: на время старта он
+                // переключался на явный, иначе закрытие окна входа гасило
+                // приложение до появления главного.
+                ShutdownMode = shutdownModeBeforeStartup;
 
                 // Фоновая проверка обновлений (Windows/WPF): запускаем после показа
                 // главного окна, чтобы не задерживать старт. Если пользователь отключил


### PR DESCRIPTION
Закрывает issue #189. Правка не новая: это восстановление уже принятого PR #128, который потерялся в WPF-ветке при переписывании `App.xaml.cs` в 0.3.5.90 (bb4aa84) и 0.4.0.0 (e1132ae). В Avalonia-ветке она жива и работает: `Configuration Management/App.axaml.cs:199`.

Дифф в один файл, 30 строк, только внутри `#if WINDOWS`.

## 1. Окно входа показывает ключи локализации (issue #189)

Словарь поднимается в `App.xaml.cs` после `LoginWindow.ShowLogin`, а `Translate` до инициализации возвращает сам ключ. Поэтому в окне выбора учётной записи видны `Auth.Title`, `Auth.SelectAccountHint`, `Auth.Login`, `Common.Cancel` вместо подписей. Видит любой, у кого больше одного профиля.

Локализация инициализируется до окна входа по языку профиля, активного с прошлого запуска. Язык выбранного профиля применяется после входа отдельным вызовом `LocalizationManager.ApplyPreferredLanguage(settings.Language)`: `Initialize` идемпотентен и после ранней инициализации молча выходит, поэтому существующего вызова `Initialize(settings.Language)` уже недостаточно.

Тонкость, важная для правильности: `ApplyPreferredLanguage` вызывается **всегда**, а не только когда язык задан. Пустой `Language` это штатное значение «выбирать автоматически», и без безусловного вызова такой профиль унаследовал бы язык чужого профиля, а `PersistSettings` при выходе записал бы его в настройки навсегда.

## 2. Закрытие окна входа гасит приложение

При штатном `ShutdownMode.OnLastWindowClose` закрытие окна входа считается закрытием последнего окна, и главное окно уже не открывается. На время старта режим переключается на `OnExplicitShutdown`, а после `mainWindow.Show()` возвращается **прежнее** значение, а не константа: если `ShutdownMode` когда-нибудь задастся в `App.xaml`, переключение его не затрёт.

## Что не трогается

Оба вспомогательных механизма из PR #128 в коде сохранились и в этом PR не меняются:

* `LocalizationManager.ApplyPreferredLanguage` (`Localization/LocalizationManager.cs:296`);
* снимок языка системы, снятый до первой смены культуры (там же, ниже по файлу). Он нужен потому, что `SetLanguage` перезаписывает `CurrentUICulture`, и после ранней инициализации автоматический выбор указывал бы на уже выбранный язык.

Защита от self-owner в `LoginWindow.xaml.cs:32-37`, тоже из PR #128, на месте и не трогается.

## Проверено

* Ветка нарезана от `origin/main` (12ec46b), правка накладывается на текущий файл чисто.
* Сборка Linux-цели на ветке: без ошибок и предупреждений. WPF-цель `net10.0-windows` на Linux не собирается в принципе, поэтому компиляцию Windows-части подтвердит CI, а поведение проверялось при исходном PR #128 на Windows-сборке 0.3.5.34 по семи сценариям: вход без пароля и по паролю доводит до главного окна, отмена завершает процесс без висящих процессов, подписи в окне входа локализованы, профиль с автоматическим языком получает русский при предыдущем профиле на английском.
* Содержимое правки идентично тому, что было в PR #128: текст сверен построчно.

Ветка независима, от других наших PR не зависит.

---
Клавдий, агент Linux-порта в форке ksv47
