### PR TITLE
Linux/Avalonia: при скрытой колонке «Действия» список уезжает вправо на узком окне (issue #191)

### DIFF
--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -4858,11 +4858,13 @@ namespace Configuration_Management
                 || _columnHeaderRow.ColumnDefinitions.Count <= NameHeaderColumn)
                 return;
 
-            // Арифметика авторская (MainWindow.Columns.cs:265): компенсатор равен
-            // разнице между началом первой колонки значений строки и началом той же
-            // колонки заголовка, посчитанным без самого компенсатора. Ведущие колонки
-            // у обеих сеток одинаковы, поэтому разницу даёт только сдвиг строки
-            // деревом, и после подгонки значения стоят ровно под заголовками.
+            // Арифметика авторская (AlignHeaderToData, MainWindow.Columns.cs), с одним
+            // отличием: там в суммы входит и колонка имени, здесь она исключена
+            // (issue #191, см. ниже). Компенсатор равен разнице между началом колонки
+            // имени строки и началом той же колонки заголовка, посчитанным без самого
+            // компенсатора. Ведущие колонки у обеих сеток одинаковы, поэтому разницу
+            // даёт только сдвиг строки деревом, и после подгонки значения стоят ровно
+            // под заголовками.
             Grid? rowGrid = null;
             double rowOrigin = 0;
             foreach (var card in _tree.GetVisualDescendants().OfType<InfobaseRowCard>())
@@ -4882,12 +4884,20 @@ namespace Configuration_Management
             double offset = 0;
             if (rowGrid is not null && rowGrid.ColumnDefinitions.Count > NameRowColumn)
             {
+                // Звёздная колонка имени в сумму не входит (issue #191). Компенсатор
+                // отнимает ширину именно у неё, поэтому при её учёте следующий расчёт
+                // получает уменьшенную ширину заголовка и увеличивает компенсатор на
+                // ту же величину: ширина списка росла до десятков тысяч точек, и все
+                // колонки, кроме «Названия», уезжали за правый край. Ведущие колонки
+                // у заголовка и строки одинаковы, а общая ширина у них общая, поэтому
+                // после совмещения ведущих колонок имя занимает одинаковое место
+                // в обеих сетках и колонки данных встают под своими заголовками.
                 double rowLead = 0;
-                for (var i = 0; i <= NameRowColumn; i++)
+                for (var i = 0; i < NameRowColumn; i++)
                     rowLead += rowGrid.ColumnDefinitions[i].ActualWidth;
 
                 double headerLead = 0;
-                for (var i = 0; i <= NameHeaderColumn; i++)
+                for (var i = 0; i < NameHeaderColumn; i++)
                 {
                     if (!ReferenceEquals(_columnHeaderRow.ColumnDefinitions[i], _headerOffsetColumn))
                         headerLead += _columnHeaderRow.ColumnDefinitions[i].ActualWidth;


### PR DESCRIPTION
Исправление issue #191.

## Симптом

При скрытой колонке «Действия» из списка баз пропадают все остальные колонки: видна только «Название». Проявляется на узком окне; на широком (у меня порог между 1700 и 1850 точками при правой панели по умолчанию) всё в порядке, поэтому дефект легко принять за исправленный.

Колонки не пропадают, а уезжают далеко вправо. Замер по снимку, полоса горизонтальной прокрутки под списком, окно 1200:

* «Действия» видимы: ползунок 520 точек при дорожке 845, содержимое около 1370 точек, как и ожидается;
* «Действия» скрыты: ползунок 16 точек при той же дорожке, то есть содержимое разрастается примерно до 40 тысяч точек.

Скрытие любой другой колонки к этому не приводит: с `ShowSizeColumn: false` и видимыми «Действиями» на 1200 ползунок 556 точек, все колонки на месте.

## Причина

Круг между двумя расчётами.

`AlignHeaderToRows` считает компенсатор как разницу ведущих колонок строки и заголовка, включая в обе суммы звёздную колонку имени (`i <= NameRowColumn` и `i <= NameHeaderColumn`). Компенсатор отнимает ширину именно у звёздной колонки: она сжимается ровно на ту величину, которую он получил. На следующем расчёте `headerLead` оказывается меньше на эту же величину, и компенсатор растёт снова.

Дальше растущий компенсатор попадает в `UpdateListMinWidth`: тот суммирует все ведущие колонки заголовка, включая компенсатор, в `_listContent.MinWidth`. Ширина содержимого растёт, звёздная колонка отыгрывает ширину назад, и круг повторяется. Пока содержимое влезает в окно, `Math.Max(0, ...)` держит компенсатор на нуле и круг не запускается, поэтому на широком окне дефекта нет.

## Правка

Звёздная колонка имени исключена из обеих сумм (`i < NameRowColumn`, `i < NameHeaderColumn`). Ведущие колонки у заголовка и строки одинаковы, общая ширина у них общая, поэтому после совмещения ведущих колонок имя занимает одинаковое место в обеих сетках, а колонки данных встают под своими заголовками. Компенсатор перестаёт зависеть от собственного прошлого значения.

## Проверка

Прогон Linux-сборки на профиле с девятью базами и двумя группами:

| Ширина окна | «Действия» | До правки | После правки |
|---|---|---|---|
| 1200 | скрыты | только «Название» | все колонки, ползунок 592 |
| 1500 | скрыты | только «Название» | все колонки, прокрутки нет |
| 1850 | скрыты | все колонки | все колонки, прокрутки нет |
| 1200 | видимы | все колонки, ползунок 520 | все колонки, ползунок 520 |
| 1850 | видимы | все колонки | все колонки |

Отдельно проверено выравнивание после разворота группы: значения строк вложенных баз стоят под своими заголовками, то есть компенсатор продолжает делать свою работу.

`dotnet build -c Release` для Linux-цели: ноль ошибок, ноль предупреждений. Цель `net10.0-windows` на Linux не собирается, WPF-ветка этой правкой не затронута.

---
Клавдий, агент Linux-порта в форке ksv47

🤖 Generated with [Claude Code](https://claude.com/claude-code)
