### PR TITLE
Фатальные сообщения: запасной текст вместо ключей локализации в обеих ветках (issue #213)

### DIFF
--- a/Configuration Management/App.axaml.cs
+++ b/Configuration Management/App.axaml.cs
@@ -66,10 +66,13 @@ namespace Configuration_Management
         public override void OnFrameworkInitializationCompleted()
         {
             // Показываем любые необработанные ошибки — иначе окно просто не появляется.
+            // Заголовки берутся через TOr: обработчики регистрируются до инициализации
+            // локализации и срабатывают в том числе на самом раннем сбое, когда словари
+            // ещё пусты и T вернул бы сам ключ (issue #213).
             AppDomain.CurrentDomain.UnhandledException += (_, args) =>
             {
                 if (args.ExceptionObject is Exception ex)
-                    ShowFatalError(LocalizationManager.T("App.Fatal.Critical"), ex);
+                    ShowFatalError(TOr("App.Fatal.Critical", "Критическая ошибка"), ex);
             };
 
             // Необработанные исключения на UI-потоке (команды, построение и показ модальных
@@ -80,13 +83,13 @@ namespace Configuration_Management
             // которое строится в момент сбоя, не откроется, но приложение продолжит работу.
             Avalonia.Threading.Dispatcher.UIThread.UnhandledException += (_, args) =>
             {
-                ShowFatalError(LocalizationManager.T("App.Fatal.Interface"), args.Exception);
+                ShowFatalError(TOr("App.Fatal.Interface", "Ошибка интерфейса"), args.Exception);
                 args.Handled = true;
             };
 
             TaskScheduler.UnobservedTaskException += (_, args) =>
             {
-                ShowFatalError(LocalizationManager.T("App.Fatal.BackgroundTask"), args.Exception);
+                ShowFatalError(TOr("App.Fatal.BackgroundTask", "Ошибка фоновой задачи"), args.Exception);
                 args.SetObserved();
             };
 

--- a/Configuration Management/App.xaml.cs
+++ b/Configuration Management/App.xaml.cs
@@ -31,23 +31,28 @@ namespace Configuration_Management
             // ни WPF, ни ресурсные словари тем. См. ComReadHost.
 
             // Показываем любые необработанные ошибки — иначе окно просто не появляется.
+            // Заголовки берутся через TOr: обработчики регистрируются до инициализации
+            // локализации и срабатывают в том числе на самом раннем сбое, когда словари
+            // ещё пусты и T вернул бы сам ключ (issue #213).
             DispatcherUnhandledException += (_, args) =>
             {
-                LogFatal(LocalizationManager.T("App.Fatal.Interface"), args.Exception);
-                ShowFatalError(LocalizationManager.T("App.Fatal.Interface"), args.Exception);
+                var title = TOr("App.Fatal.Interface", "Ошибка интерфейса");
+                LogFatal(title, args.Exception);
+                ShowFatalError(title, args.Exception);
                 args.Handled = true;
             };
             AppDomain.CurrentDomain.UnhandledException += (_, args) =>
             {
                 if (args.ExceptionObject is Exception ex)
                 {
-                    LogFatal(LocalizationManager.T("App.Fatal.Critical"), ex);
-                    ShowFatalError(LocalizationManager.T("App.Fatal.Critical"), ex);
+                    var title = TOr("App.Fatal.Critical", "Критическая ошибка");
+                    LogFatal(title, ex);
+                    ShowFatalError(title, ex);
                 }
             };
             TaskScheduler.UnobservedTaskException += (_, args) =>
             {
-                ShowFatalError(LocalizationManager.T("App.Fatal.BackgroundTask"), args.Exception);
+                ShowFatalError(TOr("App.Fatal.BackgroundTask", "Ошибка фоновой задачи"), args.Exception);
                 args.SetObserved();
             };
 
@@ -326,7 +331,7 @@ namespace Configuration_Management
                 if (ex.InnerException != null)
                 {
                     sb.AppendLine();
-                    sb.AppendLine(LocalizationManager.T("App.Fatal.InternalError"));
+                    sb.AppendLine(TOr("App.Fatal.InternalError", "Внутренняя ошибка:"));
                     sb.AppendLine(ex.InnerException.Message);
                 }
                 sb.AppendLine();
@@ -337,7 +342,7 @@ namespace Configuration_Management
                     stack = stack[..1200] + "…";
                 sb.AppendLine(stack);
 
-                MessageBox.Show(sb.ToString(), LocalizationManager.T("App.Fatal.Title"),
+                MessageBox.Show(sb.ToString(), TOr("App.Fatal.Title", "Управление конфигурациями 1С — ошибка"),
                     MessageBoxButton.OK, MessageBoxImage.Error);
             }
             catch


### PR DESCRIPTION
Исправление остатка по issue #213.

В 0.3.6.94 запасной текст получил только заголовок фатального сообщения на пути запуска (`App.Fatal.StartupFailed` через `TOr`). Остальные заголовки того же окна по-прежнему выводятся голым `LocalizationManager.T`, и при сбое до инициализации локализации пользователь видит ключ вместо текста.

Переведены на `TOr` с встроенным запасным текстом:

* три глобальных обработчика: `App.Fatal.Interface`, `App.Fatal.Critical`, `App.Fatal.BackgroundTask`. Они регистрируются до защищённого блока и срабатывают в том числе на самом раннем сбое, когда словари ещё пусты;
* `App.Fatal.Title` — заголовок самого окна сообщения. До правки текст в теле окна был читаемым, а в шапке стоял ключ;
* `App.Fatal.InternalError` — подпись перед сообщением внутреннего исключения.

Запасные тексты дословно совпадают с русскими значениями из `Localization/Languages/ru.json`, так что при живой локализации поведение не меняется вообще: `TOr` возвращает перевод и подставляет запасной текст только тогда, когда `T` вернул сам ключ.

Порядок инициализации не трогал: с запасными текстами он перестаёт быть критичным, а перенос `LocalizationManager.Instance.Initialize` выше `AppServices.Configure()` невозможен, язык читается из настроек профиля.

Те же три обработчика переведены и в Avalonia-ветке (`App.axaml.cs:75,86,92`): код там был такой же, а `TOr` в этом файле уже есть и уже применён на пути запуска.

Второй пункт заявки, перенос инициализации локализации выше всего, что может упасть, я не делал: язык читается из настроек профиля, то есть после `AppServices.Configure()`, и запасные тексты закрывают симптом на любом порядке. Если хотите, чтобы порядок тоже поменялся, скажите, сделаю отдельно. Цель `net10.0-windows` на Linux не собирается, компиляцию подтвердит ваш CI; Linux-цель собирается без ошибок и предупреждений.

---
Клавдий, агент Linux-порта в форке ksv47

🤖 Generated with [Claude Code](https://claude.com/claude-code)
