### PR TITLE
Linux: автообновление закрывало приложение в пакетной установке (issue #153)

### DIFF
--- a/Configuration Management/Services/UpdateService.Avalonia.cs
+++ b/Configuration Management/Services/UpdateService.Avalonia.cs
@@ -325,20 +325,37 @@ namespace Configuration_Management.Services
                 return;
             }
 
-            var newBinary = await DownloadNewBinaryAsync(release.DownloadUrl!);
-            if (newBinary is null)
-            {
-                ShowOnUi(() => _dialogs.ShowError(
-                    LocalizationManager.T("Update.DownloadFailed"),
-                    LocalizationManager.T("Update.NewVersionAvailable")));
-                return;
-            }
-
             var target = ResolveTargetBinary();
             if (target is null)
             {
                 ShowOnUi(() => _dialogs.ShowError(
                     LocalizationManager.T("Update.InstallFailed"),
+                    LocalizationManager.T("Update.NewVersionAvailable")));
+                return;
+            }
+
+            // Способ установки проверяется до скачивания, как и в режиме с вопросом
+            // (issue #153). Без этой проверки автообновление в пакетной установке
+            // (deb в /usr/bin, AppImage) доходило до запуска помощника и закрывало
+            // приложение, а заменить файл помощник не мог: каталог не на запись.
+            // Со стороны пользователя это выглядело как самопроизвольный выход
+            // через несколько секунд после запуска.
+            var autoBlocker = GetSelfUpdateBlocker(target);
+            if (autoBlocker is not null)
+            {
+                var manual = autoBlocker;
+                if (!string.IsNullOrWhiteSpace(release.HtmlUrl))
+                    manual += Environment.NewLine + Environment.NewLine + release.HtmlUrl;
+                ShowOnUi(() => _dialogs.ShowInfo(
+                    manual, LocalizationManager.T("Update.NewVersionAvailable")));
+                return;
+            }
+
+            var newBinary = await DownloadNewBinaryAsync(release.DownloadUrl!);
+            if (newBinary is null)
+            {
+                ShowOnUi(() => _dialogs.ShowError(
+                    LocalizationManager.T("Update.DownloadFailed"),
                     LocalizationManager.T("Update.NewVersionAvailable")));
                 return;
             }


### PR DESCRIPTION
Исправление issue #153 в части, которая осталась после ваших правок рендеринга: самопроизвольный выход через несколько секунд после запуска, о котором сегодня написал 7OH.

## Что происходит

Это не зависание и не рендеринг. Приложение выходит само, потому что фоновая проверка обновлений при включённом автообновлении (`AutoUpdateEnabled` по умолчанию `true`) доходит до конца и закрывает процесс, а заменить файл не может.

`DownloadAndInstallAutoAsync` в Avalonia-ветке скачивает новый бинарник, зовёт `ApplyRestartNow` и сразу `ShutdownNow`. Проверка способа установки (`GetSelfUpdateBlocker`) есть только в пути с вопросом пользователю (`DownloadAndInstallAsync`), в автоматическом её нет. В пакетной установке (deb в `/usr/bin`, AppImage) каталог недоступен на запись, помощник запускается, приложение закрывается, замена не проходит. Со стороны пользователя это ровно то, что описано: окно появилось, успел подвигать и открыть настройки, через несколько секунд закрылось.

Отсюда же объяснение, почему у 7OH «не DEB сборка 0.3.7.4 работает»: там версия совпадает с последним выпуском, обновляться не на что, и путь автообновления просто не запускается.

## Воспроизведение

Собрал версию 0.3.7.0 (заведомо старше выпуска), положил в каталог с правами `r-xr-xr-x`, запустил с отдельным `XDG_CONFIG_HOME`:

* до правки: старт нормальный, лог доходит до «Запуск завершён», через 21 секунду процесс исчезает, бинарник на месте, обновление не применилось, пользователю ничего не показано;
* после правки: приложение живо и через минуту, показано сообщение «Программа установлена в системный каталог, самообновление недоступно» со ссылкой на страницу выпуска.

## Правка

В `DownloadAndInstallAutoAsync` цель определяется и проверяется `GetSelfUpdateBlocker` до скачивания, как и в режиме с вопросом. Если самообновление недоступно, показывается то же сообщение со ссылкой на выпуск, и приложение продолжает работу.

Windows не затронут: там та же ситуация решается повышением прав (`NeedsElevation` и запуск помощника через RunAs), на Linux такого пути нет.

## Что это значит для пользователя

Пакетная установка (deb) обновляется пакетом, а не сама. Сообщение теперь об этом и говорит, вместо молчаливого выхода.

---
Клавдий, агент Linux-порта в форке ksv47

🤖 Generated with [Claude Code](https://claude.com/claude-code)
