### PR TITLE
Linux: окно хода скачивания обновления вместо молчания на 50 МБ (issue #225)

### DIFF
--- a/Configuration Management/Configuration Management.csproj
+++ b/Configuration Management/Configuration Management.csproj
@@ -90,6 +90,7 @@
          исключаем из Windows-сборки, чтобы она не попадала в компиляцию WPF. -->
     <Compile Remove="Services\UpdateService.Avalonia.cs" />
     <Compile Remove="Services\ManualUpdateWindow.Avalonia.cs" />
+    <Compile Remove="Services\UpdateProgressWindow.Avalonia.cs" />
   </ItemGroup>
 
   <!-- WPF-ресурсы иконок (embedded, только Windows) -->

--- a/Configuration Management/Services/UpdateProgressWindow.Avalonia.cs
+++ b/Configuration Management/Services/UpdateProgressWindow.Avalonia.cs
@@ -1,0 +1,85 @@
+#if LINUX
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Configuration_Management.Localization;
+using Configuration_Management.Themes;
+
+namespace Configuration_Management.Services;
+
+/// <summary>
+/// Окно хода скачивания обновления (Linux/Avalonia). Показывается на время загрузки
+/// нового исполняемого файла, как этап прогресса единого диалога обновления в
+/// Windows-версии (<c>UpdateAvailableWindow</c>): без него между ответом «Скачать»
+/// и вопросом о перезапуске приложение молчит несколько минут, и со стороны
+/// пользователя загрузка десятков МБ неотличима от зависания (issue #225).
+/// </summary>
+internal sealed class UpdateProgressWindowAvalonia : Window
+{
+    private readonly ProgressBar _bar;
+    private readonly TextBlock _caption;
+
+    public UpdateProgressWindowAvalonia()
+    {
+        Title = LocalizationManager.T("Update.NewVersionAvailable");
+        Width = 440;
+        SizeToContent = SizeToContent.Height;
+        CanResize = false;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        SystemDecorations = SystemDecorations.Full;
+
+        ThemeBrushes.Bind(this, TemplatedControl.BackgroundProperty, "ContentBackgroundColorBrush");
+
+        _caption = new TextBlock
+        {
+            Text = LocalizationManager.T("Update.Downloading"),
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 13
+        };
+        ThemeBrushes.Bind(_caption, TextBlock.ForegroundProperty, "TextPrimaryColorBrush");
+
+        _bar = new ProgressBar
+        {
+            Minimum = 0,
+            Maximum = 100,
+            Value = 0,
+            IsIndeterminate = true,
+            Height = 8,
+            HorizontalAlignment = HorizontalAlignment.Stretch
+        };
+
+        Content = new StackPanel
+        {
+            Spacing = 16,
+            Margin = new Thickness(16),
+            Children = { _caption, _bar }
+        };
+    }
+
+    /// <summary>
+    /// Показывает долю скачанного. Отрицательное значение означает, что размер файла
+    /// сервер не сообщил: полоса остаётся бегущей, процент не выводится. Вызывается
+    /// из потока загрузки, поэтому переход в поток интерфейса выполняется здесь.
+    /// </summary>
+    public void SetProgress(double percent)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (percent < 0)
+            {
+                _bar.IsIndeterminate = true;
+                _caption.Text = LocalizationManager.T("Update.Downloading");
+                return;
+            }
+
+            _bar.IsIndeterminate = false;
+            _bar.Value = percent;
+            _caption.Text = string.Format(
+                LocalizationManager.T("Update.DownloadProgressFormat"), (int)percent);
+        });
+    }
+}
+#endif

--- a/Configuration Management/Services/UpdateProgressWindow.Avalonia.cs
+++ b/Configuration Management/Services/UpdateProgressWindow.Avalonia.cs
@@ -1,4 +1,5 @@
 #if LINUX
+using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -28,7 +29,12 @@ internal sealed class UpdateProgressWindowAvalonia : Window
         Width = 440;
         SizeToContent = SizeToContent.Height;
         CanResize = false;
-        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        // Владельца окну не назначают намеренно: дочернее окно уходит в трей вместе
+        // с главным (Window.Hide прячет детей и снимает владельца) и обратно уже
+        // не возвращается, то есть загрузка снова шла бы без единого признака работы.
+        WindowStartupLocation = WindowStartupLocation.CenterScreen;
+        // Отдельной кнопки в панели задач нет ни у одного окна продукта.
+        ShowInTaskbar = false;
         SystemDecorations = SystemDecorations.Full;
 
         ThemeBrushes.Bind(this, TemplatedControl.BackgroundProperty, "ContentBackgroundColorBrush");
@@ -75,10 +81,11 @@ internal sealed class UpdateProgressWindowAvalonia : Window
                 return;
             }
 
+            var shown = Math.Clamp(percent, 0, 100);
             _bar.IsIndeterminate = false;
-            _bar.Value = percent;
+            _bar.Value = shown;
             _caption.Text = string.Format(
-                LocalizationManager.T("Update.DownloadProgressFormat"), (int)percent);
+                LocalizationManager.T("Update.DownloadProgressFormat"), (int)shown);
         });
     }
 }

--- a/Configuration Management/Services/UpdateService.Avalonia.cs
+++ b/Configuration Management/Services/UpdateService.Avalonia.cs
@@ -247,7 +247,7 @@ namespace Configuration_Management.Services
             // Скачиваем новый бинарник, не блокируя поток интерфейса: диалог показан
             // из UI-потока, и синхронное ожидание здесь замораживало окно на всё время
             // загрузки (десятки МБ).
-            var newBinary = await DownloadNewBinaryAsync(release.DownloadUrl!)
+            var newBinary = await DownloadWithProgressAsync(release.DownloadUrl!)
                 .ConfigureAwait(true);
             if (newBinary is null)
             {
@@ -325,7 +325,7 @@ namespace Configuration_Management.Services
                 return;
             }
 
-            var newBinary = await DownloadNewBinaryAsync(release.DownloadUrl!)
+            var newBinary = await DownloadWithProgressAsync(release.DownloadUrl!)
                 .ConfigureAwait(true);
             if (newBinary is null)
             {
@@ -469,7 +469,7 @@ namespace Configuration_Management.Services
                 return;
             }
 
-            var newBinary = await DownloadNewBinaryAsync(release.DownloadUrl!);
+            var newBinary = await DownloadWithProgressAsync(release.DownloadUrl!);
             if (newBinary is null)
             {
                 ShowOnUi(() => _dialogs.ShowError(
@@ -507,10 +507,71 @@ namespace Configuration_Management.Services
         }
 
         /// <summary>
+        /// Скачивает новый бинарник, показывая на это время окно хода загрузки. Размер
+        /// файла — десятки МБ, и без индикатора отрезок между согласием на обновление и
+        /// вопросом о перезапуске выглядит как зависание приложения (issue #225).
+        /// В Windows-версии тот же этап показан полосой прогресса в едином диалоге
+        /// обновления (<c>UpdateAvailableWindow</c>).
+        /// </summary>
+        private async Task<string?> DownloadWithProgressAsync(string url)
+        {
+            UpdateProgressWindowAvalonia? window = null;
+            try
+            {
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    window = new UpdateProgressWindowAvalonia();
+                    ShowProgressWindow(window);
+                });
+            }
+            catch
+            {
+                // Окно индикатора не должно мешать самому обновлению.
+                window = null;
+            }
+
+            try
+            {
+                return await DownloadNewBinaryAsync(url, window).ConfigureAwait(true);
+            }
+            finally
+            {
+                if (window is not null)
+                {
+                    try
+                    {
+                        await Dispatcher.UIThread.InvokeAsync(() => window.Close());
+                    }
+                    catch { /* окно могли закрыть вместе с приложением */ }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Показывает окно хода загрузки поверх главного окна, не блокируя вызывающий код:
+        /// модальный показ остановил бы цепочку обновления до закрытия окна пользователем.
+        /// </summary>
+        private static void ShowProgressWindow(Avalonia.Controls.Window window)
+        {
+            var owner = Avalonia.Application.Current?.ApplicationLifetime
+                is IClassicDesktopStyleApplicationLifetime desktop
+                && desktop.MainWindow is { IsVisible: true } main
+                    ? main
+                    : null;
+
+            if (owner is not null)
+                window.Show(owner);
+            else
+                window.Show();
+        }
+
+        /// <summary>
         /// Скачивает новый бинарник по прямой ссылке во временный каталог. Возвращает путь
         /// к файлу или null при сетевой ошибке / пустом файле. Временный файл удаляется при неудаче.
+        /// О ходе загрузки сообщается окну <paramref name="progress"/>, если оно показано.
         /// </summary>
-        private async Task<string?> DownloadNewBinaryAsync(string url)
+        private async Task<string?> DownloadNewBinaryAsync(
+            string url, UpdateProgressWindowAvalonia? progress = null)
         {
             var dir = EnsureUpdateDirectory();
             var dest = Path.Combine(dir, "ConfigurationManagement.new");
@@ -530,9 +591,36 @@ namespace Configuration_Management.Services
                 await using var source = await response.Content
                     .ReadAsStreamAsync(cancellation.Token)
                     .ConfigureAwait(false);
+                // Общий размер сервер сообщает не всегда: без него доля неизвестна,
+                // и окно показывает бегущую полосу вместо процентов.
+                var totalBytes = response.Content.Headers.ContentLength ?? -1;
                 await using (var target = new FileStream(dest, FileMode.Create, FileAccess.Write, FileShare.None))
                 {
-                    await source.CopyToAsync(target, cancellation.Token).ConfigureAwait(false);
+                    var buffer = new byte[81920];
+                    long readTotal = 0;
+                    var lastPercent = -1;
+                    progress?.SetProgress(totalBytes > 0 ? 0 : -1);
+
+                    int read;
+                    while ((read = await source.ReadAsync(buffer, cancellation.Token).ConfigureAwait(false)) > 0)
+                    {
+                        await target.WriteAsync(buffer.AsMemory(0, read), cancellation.Token)
+                            .ConfigureAwait(false);
+                        readTotal += read;
+
+                        if (progress is null || totalBytes <= 0)
+                            continue;
+
+                        // Отчёт только на смене целого процента: иначе на каждый блок
+                        // в 80 КБ приходилась бы отправка в поток интерфейса.
+                        var percent = (int)(readTotal * 100 / totalBytes);
+                        if (percent == lastPercent)
+                            continue;
+
+                        lastPercent = percent;
+                        progress.SetProgress(percent);
+                    }
+
                     await target.FlushAsync(cancellation.Token).ConfigureAwait(false);
                 }
 

--- a/Configuration Management/Services/UpdateService.Avalonia.cs
+++ b/Configuration Management/Services/UpdateService.Avalonia.cs
@@ -508,10 +508,10 @@ namespace Configuration_Management.Services
 
         /// <summary>
         /// Скачивает новый бинарник, показывая на это время окно хода загрузки. Размер
-        /// файла — десятки МБ, и без индикатора отрезок между согласием на обновление и
-        /// вопросом о перезапуске выглядит как зависание приложения (issue #225).
-        /// В Windows-версии тот же этап показан полосой прогресса в едином диалоге
-        /// обновления (<c>UpdateAvailableWindow</c>).
+        /// файла составляет десятки МБ, и без индикатора отрезок между согласием на
+        /// обновление и вопросом о перезапуске выглядит как зависание приложения
+        /// (issue #225). В Windows-версии тот же этап показан полосой прогресса
+        /// в едином диалоге обновления (<c>UpdateAvailableWindow</c>).
         /// </summary>
         private async Task<string?> DownloadWithProgressAsync(string url)
         {
@@ -521,13 +521,14 @@ namespace Configuration_Management.Services
                 await Dispatcher.UIThread.InvokeAsync(() =>
                 {
                     window = new UpdateProgressWindowAvalonia();
-                    ShowProgressWindow(window);
+                    window.Show();
                 });
             }
             catch
             {
-                // Окно индикатора не должно мешать самому обновлению.
-                window = null;
+                // Окно индикатора не должно мешать самому обновлению, но закрыть его
+                // всё равно нужно: платформенное окно создаётся конструктором, и сбой
+                // мог прийти уже из показа.
             }
 
             try
@@ -536,33 +537,22 @@ namespace Configuration_Management.Services
             }
             finally
             {
-                if (window is not null)
+                var closing = window;
+                if (closing is not null)
                 {
-                    try
-                    {
-                        await Dispatcher.UIThread.InvokeAsync(() => window.Close());
-                    }
-                    catch { /* окно могли закрыть вместе с приложением */ }
+                    // С потока интерфейса окно закрывается сразу, а не отложенно: иначе
+                    // следующий за загрузкой вопрос успевает открыться поверх ещё живого
+                    // окна прогресса, становится его дочерним, и закрытие прогресса гасит
+                    // вопрос вместо пользователя (ответ читается как отказ). Проверено
+                    // прогоном: вопрос о перезапуске снимался сам.
+                    if (Dispatcher.UIThread.CheckAccess())
+                        closing.Close();
+                    else
+                        // С фонового потока ждать нельзя: при закрытии приложения во время
+                        // загрузки цикл сообщений уже остановлен, и ожидание не завершится.
+                        Dispatcher.UIThread.Post(() => closing.Close());
                 }
             }
-        }
-
-        /// <summary>
-        /// Показывает окно хода загрузки поверх главного окна, не блокируя вызывающий код:
-        /// модальный показ остановил бы цепочку обновления до закрытия окна пользователем.
-        /// </summary>
-        private static void ShowProgressWindow(Avalonia.Controls.Window window)
-        {
-            var owner = Avalonia.Application.Current?.ApplicationLifetime
-                is IClassicDesktopStyleApplicationLifetime desktop
-                && desktop.MainWindow is { IsVisible: true } main
-                    ? main
-                    : null;
-
-            if (owner is not null)
-                window.Show(owner);
-            else
-                window.Show();
         }
 
         /// <summary>
@@ -613,7 +603,7 @@ namespace Configuration_Management.Services
 
                         // Отчёт только на смене целого процента: иначе на каждый блок
                         // в 80 КБ приходилась бы отправка в поток интерфейса.
-                        var percent = (int)(readTotal * 100 / totalBytes);
+                        var percent = (int)Math.Min(100, readTotal * 100 / totalBytes);
                         if (percent == lastPercent)
                             continue;
 
@@ -624,7 +614,17 @@ namespace Configuration_Management.Services
                     await target.FlushAsync(cancellation.Token).ConfigureAwait(false);
                 }
 
-                return new FileInfo(dest).Length > 0 ? dest : null;
+                // Размер теперь известен, поэтому обрыв, не бросивший исключение, ловится
+                // здесь: недокачанный бинарник не должен подставляться вместо рабочего.
+                // Так же принимает файл Windows-версия (size >= totalBytes).
+                var size = new FileInfo(dest).Length;
+                if (size <= 0 || (totalBytes > 0 && size < totalBytes))
+                {
+                    TryDelete(dest);
+                    return null;
+                }
+
+                return dest;
             }
             catch
             {


### PR DESCRIPTION
## Что не так сейчас

Заявка #225, последнее сообщение заявителя: он соглашается на обновление,
окно закрывается, дальше несколько минут ничего не происходит, потом вопрос
о перезапуске. Он же прямо просит: «хотелось бы конечно видеть окно прогресса,
как в винде».

Это не догадка о его машине, а свойство кода: в Linux-ветке загрузка идёт
через `CopyToAsync`, между `_dialogs.Confirm` о скачивании и `_dialogs.Confirm`
о перезапуске приложение не показывает ничего. Файл self-contained single-file
весит около 50 МБ, то есть на обычном канале это минуты молчания.

В Windows-ветке этот этап показан: `UpdateAvailableWindow` переключается на
`ProgressPanel`, полосу двигает событие `DownloadProgressChanged`
из `UpdateService.ReportDownloadProgress`.

## Что в правке

`Configuration Management/Services/UpdateService.Avalonia.cs`

* `DownloadNewBinaryAsync` получил необязательный параметр окна прогресса,
  а копирование потока переведено с `CopyToAsync` на цикл чтения с отчётом
  о доле скачанного. Отчёт отправляется только на смене целого процента,
  чтобы на каждый блок в 80 КБ не приходилось обращение к потоку интерфейса.
  Если сервер не сообщил `Content-Length`, доля неизвестна и полоса остаётся
  бегущей.
* Добавлена обёртка `DownloadWithProgressAsync`: показывает окно, ждёт
  загрузку, закрывает окно в любом исходе. На неё переведены все три места,
  откуда шла загрузка: ветка самообновления, ветка обновления с повышением
  прав и автоматическое обновление.
* Процент считается по `Content-Length` и ограничен диапазоном 0..100;
  скачанный файл принимается по заявленному размеру, а не только по признаку
  «размер больше нуля».

`Configuration Management/Services/UpdateProgressWindow.Avalonia.cs` (новый файл)

Окно с полосой и подписью, стиль взят с соседнего
`ManualUpdateWindow.Avalonia.cs`. Кнопок нет, как и в Windows-ветке, где
на время загрузки обе кнопки диалога выключены. Существующие ключи
локализации `Update.Downloading` и `Update.DownloadProgressFormat`
использованы как есть, новых ключей не добавлено.

Владелец окну не назначается намеренно. `Window.Hide()` в Avalonia прячет
дочерние окна вместе с родителем и снимает у них владельца, обратной операции
нет, поэтому уход главного окна в трей (Esc или закрытие в трей) во время
загрузки уносил бы индикатор навсегда, то есть возвращал бы ровно то молчание,
против которого правка и сделана. `ShowInTaskbar` снят, как у остальных окон
продукта (`ModalWindowBase`, разметка WPF).

`Configuration Management/Configuration Management.csproj`

Одна строка: новый файл исключён из Windows-сборки рядом с
`ManualUpdateWindow.Avalonia.cs`.

Windows/WPF правка не затрагивает.

## Как проверялось

Стенд: публикация single-file с версией 0.3.7.12 в отдельный каталог,
изолированный `XDG_CONFIG_HOME`, реальный релиз 0.3.7.13 как более свежая
версия.

* Путь самообновления: оба диалога совпали со снимками заявителя, на время
  загрузки показано окно с процентами (в снимках прогонов 40%, 52%, 74%),
  окно закрылось само, дальше вопрос о перезапуске, замена бинарника
  и перезапуск на 0.3.7.13. Полный цикл около 35 секунд.
* Автоматическое обновление (сборка с временно снятой проверкой
  виртуализации, иначе на виртуальной машине этот путь выключен):
  окно прогресса показано, замена и перезапуск прошли.
* Путь «обновить после закрытия»: файл заменён помощником после выхода,
  временных остатков в каталоге загрузки не осталось.
* `dotnet build -c Release`: 0 ошибок, 0 предупреждений.

Правка прошла три встречных аудита. По их вердиктам добавлено ограничение
процента диапазоном 0..100 (как `Math.Min` в `ReportDownloadProgress`
Windows-версии) и приём скачанного файла по заявленному размеру, а не только
по «размер больше нуля»: `Content-Length` теперь читается, и обрыв, не бросивший
исключение, иначе положил бы на диск урезанный бинарник, который подставляется
вместо исполняемого файла приложения. Так же принимает файл Windows-версия.

Отдельно найдено прогоном и исправлено: окно прогресса должно закрываться
синхронно с потока интерфейса. При отложенном закрытии следующий вопрос
(«Перезапустить приложение сейчас?») успевал открыться поверх ещё живого окна
прогресса, становился его дочерним и гасился вместе с ним, что читалось как
ответ «Нет», и обновление молча уходило в режим «после закрытия».

Отдельно: воспроизвести саму жалобу заявителя на 0.3.7.12 не удалось,
обновление на стенде проходит до конца. Об этом написано в заявке.

## Чего в правке намеренно нет

* Докачки через HTTP Range, как в Windows-ветке (`DownloadChunkAsync`). На Linux
  её не было и раньше, правка устойчивость загрузки не трогает.
* Кнопки отмены: на Windows её тоже нет, там на время загрузки обе кнопки
  диалога выключаются.
* Полосы в строке состояния главного окна (`UpdateProgressPanel`,
  `MainWindow.xaml:2601-2614`). На Windows ход загрузки показан в двух местах,
  и это второе на Linux не портировано: ключ `Update.DownloadProgress` лежит
  в обоих словарях и Linux-кодом не используется. Если вы предпочитаете именно
  этот вариант вместо отдельного окна, скажите, перенесём.

## Смежное, замеченное при разборе, но в этот PR не вошло

`DownloadAndInstallAutoAsync` не накрыт защёлкой `_updateInProgress`, которая
стоит в `ShowUpdateDialogAsync`. При включённом автообновлении кнопка «Проверить
обновления» во время идущей фоновой загрузки запускает вторую загрузку в тот же
файл, и обе кончаются ошибкой. Дефект существовал и до правки, но с индикатором
он стал видимым: на экране ненадолго появляются два окна прогресса.

---

Клавдий, агент Linux-порта в форке ksv47
