### PR TITLE
Linux: обновление не срабатывало из сборок, собранных на Windows (issue #225)

### DIFF
--- a/Configuration Management/Services/UpdateService.Avalonia.cs
+++ b/Configuration Management/Services/UpdateService.Avalonia.cs
@@ -498,6 +498,22 @@ namespace Configuration_Management.Services
         }
     }
 
+        /// <summary>
+        /// Записывает текст сценария-помощника, приводя переводы строк к виду, который
+        /// понимает <c>bash</c>. Текст сценария лежит в исходнике буквальной строкой,
+        /// поэтому переводы строк попадают в него прямо из файла исходного кода: если
+        /// рабочая копия выгружена на Windows (autocrlf), сценарий получает CRLF, и
+        /// каждая строка кончается лишним символом. Bash принимает его за часть команды:
+        /// <c>set -u</c> отвергается с подсказкой по использованию, следующая команда
+        /// не находится, сценарий выходит с кодом 2 и не заменяет исполняемый файл.
+        /// Со стороны пользователя это выглядит так, что приложение закрылось и ничего
+        /// не произошло (issue #225).
+        /// </summary>
+        private static void WriteShellScript(string scriptPath, string script)
+        {
+            File.WriteAllText(scriptPath, script.Replace("\r\n", "\n"));
+        }
+
         /// <summary>Возвращает путь к текущему исполняемому файлу приложения или null.</summary>
         internal string? ResolveTargetBinary()
         {
@@ -768,7 +784,7 @@ rmdir ""$WORK_DIR"" 2>/dev/null || true
 ";
 
             Directory.CreateDirectory(Path.GetDirectoryName(scriptPath)!);
-            File.WriteAllText(scriptPath, script);
+            WriteShellScript(scriptPath, script);
             return scriptPath;
         }
 
@@ -919,7 +935,7 @@ rmdir ""$WORK_DIR"" 2>/dev/null || true
 ";
 
             Directory.CreateDirectory(Path.GetDirectoryName(scriptPath)!);
-            File.WriteAllText(scriptPath, script);
+            WriteShellScript(scriptPath, script);
             return scriptPath;
         }
 


### PR DESCRIPTION
## Причина заявки #225 найдена, и она в сборке, а не в логике

Заявитель обновляется, приложение закрывается, новая версия не появляется. Журналы приложения при этом чистые: помощник запущен, процесс завершился с кодом 0. В каталоге загрузки остаются оба временных файла.

Прогон вашей же сборки **0.3.7.12** из выпуска на Linux повторяет это один в один. Под `strace` видно, чем всё кончается:

```
execve("/usr/bin/bash", ["bash", "/tmp/cm-update-ZG3Cdt/apply-update-...sh"]) = 0
write(2, "/tmp/cm-update-ZG3Cdt/apply-update-...: set: использование: ...")
483719 exit_group(127)
483718 exit_group(2)
```

То есть помощник живёт двенадцать миллисекунд. Причина видна сразу:

```
$ file /tmp/cm-update-ZG3Cdt/apply-update-....sh
Bourne-Again shell script, UTF-8 text executable, with CRLF line terminators
```

Текст сценария лежит в `UpdateService.Avalonia.cs` буквальной строкой (`$@"..."`), поэтому переводы строк попадают в сценарий прямо из файла исходного кода. Рабочая копия, выгруженная на Windows с `autocrlf`, даёт CRLF, и bash принимает лишний символ за часть команды: `set -u` отвергается подсказкой по использованию, следующая команда не находится (код 127), сценарий выходит с кодом 2 и не заменяет ничего.

В репозитории файл хранится с LF, поэтому в исходниках это не видно. Сборки, сделанные на Linux, дефекта не имеют: наши тестовые сборки обновляются нормально, и именно поэтому заявку долго не удавалось воспроизвести. Дефект достаётся только пользователям ваших выпусков.

## Правка

Запись сценария вынесена в `WriteShellScript`, которая приводит переводы строк к виду, понятному bash. Обе ветки замены идут через неё: обычная (`CreateUpdaterScript`) и с повышением прав (`CreatePrivilegedUpdaterScript`, там сценарий исполняется от root, и цена отказа выше).

Два изменённых вызова и один новый метод, 18 строк.

## Как проверялось

* Сборка из исходника, переведённого в CRLF (то есть в точности состояние вашей рабочей копии): до правки сценарий получается с CRLF и обновление не срабатывает, после правки сценарий с LF, обновление проходит до конца, файл заменён, приложение перезапущено, временные файлы убраны.
* Ваш выпуск 0.3.7.12, запущенный на Linux: воспроизводит отказ, сценарий на диске с CRLF.
* Наши сборки из того же исходного кода, сделанные на Linux: обновляются нормально.
* `dotnet build -c Release`: 0 ошибок, 0 предупреждений.

## Заодно про проверку на будущее

Тот же механизм коснётся любого будущего shell-сценария, который вы соберёте таким же способом из буквальной строки. Если захотите застраховаться на уровне репозитория, помогает `.gitattributes` с `* text=auto eol=lf` для исходников: тогда рабочая копия на Windows не будет отличаться переводами строк от того, что уходит в сборку.

---

Клавдий, агент Linux-порта в форке ksv47
