### PR TITLE
Windows: текст редактируемого списка уезжал под нижний край (issue #216)

### DIFF
--- a/Configuration Management/Themes/DarkTheme.xaml
+++ b/Configuration Management/Themes/DarkTheme.xaml
@@ -375,14 +375,32 @@
                                      что и у обычного поля ввода / нередактируемого списка, без
                                      двойного отступа. Клик по полю ставит курсор и позволяет ввод;
                                      область вне поля (и стрелка) уходит кнопке DropDownToggle
-                                     и открывает список. -->
+                                     и открывает список.
+
+                                     Style="{x:Null}" обязателен: иначе к полю применяется
+                                     неявный стиль TextBox из ресурсов окна, а в окне настроек
+                                     это ModernTextBox с MinHeight=36. Список «Размер» шрифта
+                                     фактически 36 точек (MinHeight стиля сильнее локальной
+                                     Height=34), полю в нём остаётся 36 - 3 (рамка)
+                                     - 12 (Margin) = 21 точка, MinHeight растягивает поле
+                                     до 36 вниз, и текст уходит на 7,5 точки ниже центра,
+                                     под нижний край списка (issue #216). Замер: ActualHeight
+                                     поля 36 до правки и 21 после.
+
+                                     HorizontalScrollBarVisibility=Hidden (как в штатном
+                                     ComboBoxEditableTextBox WPF): у поля высотой 21 полоса
+                                     прокрутки съедала бы 15 точек из 21, а у списков без
+                                     заданной высоты растила бы и поле, и сам список прямо
+                                     при наборе. Текст при Hidden по-прежнему прокручивается
+                                     кареткой. -->
                                 <TextBox x:Name="PART_EditableTextBox"
+                                         Style="{x:Null}"
                                          Grid.Column="0"
                                          Margin="{TemplateBinding Padding}"
                                          Padding="0"
                                          VerticalContentAlignment="Center"
                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                         HorizontalScrollBarVisibility="Auto"
+                                         HorizontalScrollBarVisibility="Hidden"
                                          TextWrapping="NoWrap"
                                          Background="Transparent"
                                          BorderThickness="0"

--- a/Configuration Management/Themes/LightTheme.xaml
+++ b/Configuration Management/Themes/LightTheme.xaml
@@ -369,14 +369,32 @@
                                      что и у обычного поля ввода / нередактируемого списка, без
                                      двойного отступа. Клик по полю ставит курсор и позволяет ввод;
                                      область вне поля (и стрелка) уходит кнопке DropDownToggle
-                                     и открывает список. -->
+                                     и открывает список.
+
+                                     Style="{x:Null}" обязателен: иначе к полю применяется
+                                     неявный стиль TextBox из ресурсов окна, а в окне настроек
+                                     это ModernTextBox с MinHeight=36. Список «Размер» шрифта
+                                     фактически 36 точек (MinHeight стиля сильнее локальной
+                                     Height=34), полю в нём остаётся 36 - 3 (рамка)
+                                     - 12 (Margin) = 21 точка, MinHeight растягивает поле
+                                     до 36 вниз, и текст уходит на 7,5 точки ниже центра,
+                                     под нижний край списка (issue #216). Замер: ActualHeight
+                                     поля 36 до правки и 21 после.
+
+                                     HorizontalScrollBarVisibility=Hidden (как в штатном
+                                     ComboBoxEditableTextBox WPF): у поля высотой 21 полоса
+                                     прокрутки съедала бы 15 точек из 21, а у списков без
+                                     заданной высоты растила бы и поле, и сам список прямо
+                                     при наборе. Текст при Hidden по-прежнему прокручивается
+                                     кареткой. -->
                                 <TextBox x:Name="PART_EditableTextBox"
+                                         Style="{x:Null}"
                                          Grid.Column="0"
                                          Margin="{TemplateBinding Padding}"
                                          Padding="0"
                                          VerticalContentAlignment="Center"
                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                         HorizontalScrollBarVisibility="Auto"
+                                         HorizontalScrollBarVisibility="Hidden"
                                          TextWrapping="NoWrap"
                                          Background="Transparent"
                                          BorderThickness="0"


### PR DESCRIPTION
Правка в темах WPF: `Configuration Management/Themes/LightTheme.xaml` и
`Configuration Management/Themes/DarkTheme.xaml`, шаблон стиля `ModernComboBox`.
Avalonia-код не затронут.

## Как воспроизводится

Проверено на Windows 11, сборка Debug из `main` (0.3.7.13):

1. «Настройки» → «Отображение» → вкладка «Шрифт».
2. Поле «Размер»: текст стоит не по центру, а у нижней границы поля
   и обрезается. Снимок повторяет приложенный к issue #216.

В Linux/Avalonia поле стоит ровно, поэтому правки в Avalonia-коде на этот
симптом повлиять не могли.

## Причина

`PART_EditableTextBox` в шаблоне не задавал собственного стиля, поэтому к нему
применялся неявный стиль `TextBox` из ресурсов окна. В `Views/SettingsWindow.xaml`
объявлен `<Style TargetType="TextBox" BasedOn="{StaticResource ModernTextBox}"/>`,
а `ModernTextBox` задаёт `MinHeight="36"`.

Расчёт для списка «Размер»:

| Величина | Точек |
|---|---|
| фактическая высота списка (`Height="34"` перебивается `MinHeight="36"` стиля `ModernComboBox`) | 36 |
| минус рамка `Chrome` (1,5 сверху и снизу) | 33 |
| минус `Margin` поля (`Margin` = `Padding` 10,6) | 21 |
| `MinHeight` из неявного стиля `TextBox` | 36 |

Поле растягивается до 36 точек вниз от своей позиции, текст центрируется
внутри 36 и оказывается на 7,5 точки ниже центра списка — у нижнего края,
с обрезкой. Замер: `ActualHeight` поля 36 до правки и 21 после, смещение
центра 7,5 → 0.

## Что изменено

1. `PART_EditableTextBox` получает `Style="{x:Null}"` — тем же приёмом, каким
   в этом шаблоне уже отключён неявный стиль у `ToggleButton`. Все нужные
   свойства (фон, рамка, отступы, выравнивание, цвет, размер шрифта, каретка)
   шаблон задаёт локально.
2. `HorizontalScrollBarVisibility` переведён с `Auto` на `Hidden` — значение
   по умолчанию `TextBoxBase` и то, что стоит в штатном шаблоне
   `ComboBoxEditableTextBox` WPF. Без этого у поля высотой 21 точка полоса
   прокрутки съедала бы 15 точек из 21, а у списков без заданной высоты росли
   бы и поле, и сам список прямо при наборе длинного значения. Текст при
   `Hidden` по-прежнему прокручивается кареткой.

## Что происходит с остальными редактируемыми списками

Перекоса текста у них не было — у них не задана высота, поэтому под поле
раздувался сам список:

| Список | Было | Стало |
|---|---|---|
| сервер, порт, сервер хранилища (`Views/ConnectionSettingsWindow.xaml`) | 51 | 36 |
| шаблон даты и времени (`Views/SettingsWindow.xaml`, `ExportTimestampFormatComboBox`) | 49 | 38 |

Соседние обычные поля ввода в этих окнах — 36, так что списки встают с ними
вровень. Обходной путь у шаблона даты (`MinHeight="38"`, `Padding="10,5"`)
правка не ломает, но его комментарий после неё описывает уже не ту причину —
оставлен как есть, чтобы не смешивать с исправлением.

У списка «СУБД» (`Views/CreateInfobaseWindow.xaml`) дефекта не было вовсе:
в этом окне нет своего неявного стиля `TextBox`, а стиль MaterialDesign
`MinHeight` не задаёт. Для него меняется только оформление: вместо
контекстного меню MaterialDesign — встроенное меню `TextBox` WPF, и системный
цвет выделения вместо янтарного.

## Проверка

Сборка Debug, Windows 11, тёмная и светлая темы:

* поле «Размер» — текст по центру, обрезки нет;
* ввод с клавиатуры, выделение, каретка и раскрытие списка работают;
* длинное значение в поле «Сервер» — полоса прокрутки не появляется, высота
  списка не меняется, текст прокручивается кареткой;
* «Сервер», «Имя базы» и «Порт сервера» в свойствах базы — одной высоты;
* `dotnet build` — 0 предупреждений, 0 ошибок.

Правка прошла три независимых круга аудита; замечания по числам в разборе,
по формулировке про остальные списки и по полосе прокрутки учтены в этом
виде правки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
