### PR TITLE
Linux: сборка не проходит, потерян метод EnsureUpdaterLogPath

### DIFF
--- a/Configuration Management/Services/UpdateService.Avalonia.cs
+++ b/Configuration Management/Services/UpdateService.Avalonia.cs
@@ -499,6 +499,35 @@ namespace Configuration_Management.Services
     }
 
         /// <summary>
+        /// Путь к журналу сценария-помощника. Лежит рядом с <c>errors.log</c>, потому что
+        /// помощник работает уже после выхода приложения: свой вывод он отдать некому,
+        /// его каналы закрыты вместе с родительским процессом, и при неудачной замене
+        /// от него не остаётся ни строки (issue #225). Журнал подрезается, когда
+        /// перерастает порог очистки: запись ведётся при каждом обновлении.
+        /// </summary>
+        private static string EnsureUpdaterLogPath()
+        {
+            const long maxLogBytes = 512 * 1024;
+            var dir = Configuration_Management.Services.PlatformPaths.AppDataDirectory;
+
+            try
+            {
+                Directory.CreateDirectory(dir);
+                var path = Path.Combine(dir, "update-helper.log");
+                var info = new FileInfo(path);
+                if (info.Exists && info.Length > maxLogBytes)
+                    TryDelete(path);
+
+                return path;
+            }
+            catch
+            {
+                // Каталог данных недоступен: пишем рядом со сценарием, лишь бы не молча.
+                return Path.Combine(EnsureUpdateDirectory(), "update-helper.log");
+            }
+        }
+
+        /// <summary>
         /// Записывает текст сценария-помощника, приводя переводы строк к виду, который
         /// понимает <c>bash</c>. Текст сценария лежит в исходнике буквальной строкой,
         /// поэтому переводы строк попадают в него прямо из файла исходного кода: если


### PR DESCRIPTION
В `main` не собирается Linux-цель: `./build.sh Release` падает на

```
Configuration Management/Services/UpdateService.Avalonia.cs(815,27):
error CS0103: The name 'EnsureUpdaterLogPath' does not exist in the current context
```

Ошибка единственная, воспроизводится на чистой рабочей копии `main`
(3bd974b) командой `dotnet build "Configuration Management/Configuration Management.csproj" -c Release`.
То же падение видно в CI на всех PR, открытых от `main`, например в
проверке «Linux (Avalonia, net10.0)» у #232, где Avalonia-код вообще
не затронут.

## Причина

В merge-коммите `fa3b27b` («Merge branch 'main' into linux-fixes-updater-crlf»)
при разрешении конфликта из `UpdateService.Avalonia.cs` пропало объявление
`private static string EnsureUpdaterLogPath()`, а его вызов в
`CreateUpdaterScript` остался. Прослеживается по истории файла:

| Коммит | Объявление | Вызов |
|---|---|---|
| `c5d6037` (мерж #231) | есть | есть |
| `fa3b27b` | нет | есть |
| `647245a`, `3bd974b` | нет | есть |

## Что изменено

Объявление возвращено на прежнее место, в том же виде, в каком оно было
влито с #231: сверено посимвольно с `c5d6037`. Больше правка не меняет
ничего, диффа в других файлах нет. Зависимости метода (`TryDelete`,
`EnsureUpdateDirectory`, `PlatformPaths.AppDataDirectory`) в `main` на месте.

## Проверка

* `dotnet build -c Release` на ветке: 0 предупреждений, 0 ошибок;
* дифф файла против нашей рабочей ветки после правки пуст, то есть
  потеряно было ровно это и ничего больше.

Правка чисто восстановительная, поэтому отдельных кругов аудита по ней
не делалось: возвращаемый код уже проходил их перед #231, и он побайтово
тот же.

Писал агент, который ведёт Linux-порт в форке ksv47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
