### PR TITLE
Linux: Esc в модальных диалогах не закрывает их до первого клика внутри окна (issue #226)

### DIFF
--- a/Configuration Management/Views/MainWindow.Avalonia.cs
+++ b/Configuration Management/Views/MainWindow.Avalonia.cs
@@ -5835,6 +5835,23 @@ namespace Configuration_Management
                 }
             }
 
+            // Esc при открытом диалоге закрывает сам диалог. Пока пользователь не
+            // кликнул внутри диалога, событие приходит именно сюда: сфокусированной
+            // остаётся кнопка главного окна, которой диалог и открыли, а клавиатурное
+            // событие Avalonia ведёт вверх по дереву от сфокусированного элемента и
+            // маршрута диалога не задевает вовсе (issue #226). После клика внутри
+            // маршрут идёт через диалог, и Esc обрабатывает его собственный OnKeyDown.
+            // Фокус в диалог не переносим: первым элементом обхода в безрамочном окне
+            // оказывается кнопка «Свернуть» собственной полосы заголовка, и рамка
+            // фокуса вставала бы на неё.
+            if (e.Key == Key.Escape && e.KeyModifiers == KeyModifiers.None
+                && TopmostModalDialog() is { } dialog)
+            {
+                dialog.CloseAsCancel();
+                e.Handled = true;
+                return;
+            }
+
             // Esc уводит окно в трей, если так задано настройкой. В поле ввода
             // клавиша остаётся своей: там ей отменяют правку.
             if (e.Key == Key.Escape && e.KeyModifiers == KeyModifiers.None
@@ -5867,6 +5884,35 @@ namespace Configuration_Management
             if (_vm.DeleteInfobaseCommand.CanExecute(null))
                 _vm.DeleteInfobaseCommand.Execute(null);
             e.Handled = true;
+        }
+
+        /// <summary>
+        /// Верхнее по Z-порядку открытое окно, если это диалог, унаследованный от
+        /// <see cref="ModalWindowBase"/>, иначе <c>null</c>. Порядок берём у платформы
+        /// (<see cref="Window.SortWindowsByZOrder"/>), а не порядок открытия: у окон
+        /// без отношения владения он последнему открытому не равен. Если сверху лежит
+        /// окно другого рода (сообщение, ход обновления), метод возвращает <c>null</c>:
+        /// закрывать вместо него диалог под ним нельзя.
+        /// </summary>
+        private ModalWindowBase? TopmostModalDialog()
+        {
+            if (Avalonia.Application.Current?.ApplicationLifetime
+                    is not Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop)
+                return null;
+
+            var visible = new List<Window>();
+            foreach (var window in desktop.Windows)
+            {
+                if (!ReferenceEquals(window, this) && window.IsVisible)
+                    visible.Add(window);
+            }
+
+            if (visible.Count == 0)
+                return null;
+
+            var ordered = visible.ToArray();
+            Window.SortWindowsByZOrder(ordered);
+            return ordered[ordered.Length - 1] as ModalWindowBase;
         }
 
         /// <summary>

--- a/Configuration Management/Views/ModalWindowBase.cs
+++ b/Configuration Management/Views/ModalWindowBase.cs
@@ -639,12 +639,22 @@ namespace Configuration_Management
         {
             if (e.Key == Key.Escape && e.KeyModifiers == KeyModifiers.None && !e.Handled)
             {
-                DialogResult = false;
-                Close();
+                CloseAsCancel();
                 e.Handled = true;
                 return;
             }
             base.OnKeyDown(e);
+        }
+
+        /// <summary>
+        /// Закрывает диалог так же, как кнопка «Отмена»: без положительного
+        /// результата. Вызывается и из <see cref="OnKeyDown"/>, и из главного окна,
+        /// когда Esc пришёл туда (см. MainWindow.Avalonia.cs, OnWindowKeyDown).
+        /// </summary>
+        internal void CloseAsCancel()
+        {
+            DialogResult = false;
+            Close();
         }
 
         /// <summary>


### PR DESCRIPTION
Esc в модальных диалогах Linux не закрывает их, пока пользователь не кликнет по чему-нибудь внутри окна. То есть issue #226 после 0.3.7.17 закрыт наполовину: главное окно по Esc в трей больше не уходит, а сам диалог не закрывается.

## Что видно при прогоне 0.3.7.19

Сборка из релиза апстрима, KDE/X11, профиль с девятью базами.

* Открыть настройки, нажать Esc, не кликая ни по чему: окно остаётся. Так же ведёт себя окно добавления базы.
* Нажать Esc ещё раз, кликнуть по неактивной области и нажать снова: окно остаётся.
* Кликнуть по элементу внутри окна и нажать Esc: закрывается.

Доставка клавиш при этом исправна: тем же способом Esc сворачивает главное окно в трей, а стрелка вниз двигает выделение в списке разделов настроек.

## Причина

В `ModalWindowBase.OnKeyDown` добавлен диагностический вывод. Видно, что обработчик не вызывается вовсе: до первого клика внутри окна событие до диалога не доходит.

Сфокусированным элементом остаётся кнопка главного окна, которой диалог и открыли. Avalonia ведёт клавиатурное событие вверх по дереву от сфокусированного элемента (`KeyboardDevice.ProcessRawEvent` берёт `FocusedElement`, и только при его отсутствии `e.Root`), поэтому маршрут события состоит из элементов главного окна и окно диалога в него не попадает. `Activate()` в `OnOpened` даёт диалогу фокус ввода на уровне X11, но сфокусированного элемента внутри окна не создаёт: `WindowBase.Activate` вызывает только `PlatformImpl.Activate()`.

## Что сделано

Esc обрабатывается там, куда он фактически приходит, в `MainWindow.OnWindowKeyDown`. Если верхнее по Z-порядку открытое окно это диалог-наследник `ModalWindowBase`, закрывается он, как по кнопке «Отмена». Порядок берётся у платформы через `Window.SortWindowsByZOrder`, а не по порядку открытия. Если сверху окно другого рода (сообщение, ход обновления), правка не вмешивается.

Метод `CloseAsCancel` в `ModalWindowBase` один на оба пути: его же вызывает собственный `OnKeyDown` диалога, который работает после клика внутрь, как и прежде.

## Почему не переносом фокуса в диалог

Это был первый вариант правки, и он отвергнут по итогам проверки.

* `Focusable = true` на окне остаётся навсегда: окно становится лишней остановкой при обходе по Tab, с которой Shift+Tab уже некуда возвращаться. Хуже, что глобальный обработчик нажатия мыши в `FocusManager` идёт вверх от места клика до первого фокусируемого элемента и с фокусируемым окном уводит фокус из поля ввода при клике по пустому месту диалога и при перетаскивании за полосу заголовка. Воспроизведено на headless-пробнике Avalonia 11.3.20: клик по пустому фону гасит каретку в `TextBox`, контрольное окно без `Focusable` фокус сохраняет.
* Фокус на первом элементе обхода (`KeyboardNavigationHandler.GetNext`) в безрамочном окне попадает на кнопку «Свернуть» собственной полосы заголовка. Видно по рамке фокуса сразу после открытия, и `Enter` сворачивал бы диалог вместо подтверждения.

Правка фокус не трогает вовсе, поэтому обоих последствий нет.

## Проверка

* Esc закрывает диалог с первого нажатия и при повторном открытии того же окна. Проверено на настройках и на добавлении базы.
* У вложенного диалога («Цветовое оформление» → «Создать тему» поверх настроек) закрывается только он, настройки остаются.
* Поля с автофокусом принимают ввод без клика: в «Создать тему» текст набирается сразу.
* Рамка фокуса после открытия диалога никуда не переезжает.
* При закрытых диалогах Esc по-прежнему уводит главное окно в трей.
* `dotnet build -f net10.0 -c Release`: 0 ошибок, 0 предупреждений.

## Границы

* Правка касается только наследников `ModalWindowBase`. Окна `MaterialMessageWindowAvalonia`, `ManualUpdateWindowAvalonia` и `UpdateProgressWindowAvalonia` наследуют `Window` напрямую и показываются через отдельную копию модального цикла в `AvaloniaDialogService`, Esc в них не обрабатывается ни до правки, ни после. Через них идут подтверждения удаления базы и снятия сеансов, так что это остаётся отдельным куском.
* Пока видимо окно сообщения или хода обновления, Esc из главного окна диалог не закрывает.
* Только Linux/Avalonia: оба изменённых файла целиком под `#if LINUX`, WPF-ветка Esc в `MainWindow.Hotkeys.cs` не тронута.

---

Правку готовил Клавдий, агент, который ведёт Linux-порт в форке ksv47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
